### PR TITLE
Add support for separate cashflow/valuation discount rate bases from …

### DIFF
--- a/docs/alabama_arkansas_data_collection_plan.md
+++ b/docs/alabama_arkansas_data_collection_plan.md
@@ -1,0 +1,440 @@
+# Alabama ERS And Arkansas APERS Data Collection Plan
+
+This document is the data-source and input-preparation plan for Alabama ERS
+and Arkansas APERS. It is paired with
+[Plan-Rule Resolver Framework Implementation Plan](plan_rule_resolver_framework_plan.md),
+which covers Python resolver architecture only.
+
+The source context for this work is
+[Alabama and Arkansas Pension Extension Context](alabama_arkansas_pension_extension_context.md).
+
+Before extraction, recheck the official plan websites for newer documents. The
+links below are starting points and should be treated as source-control notes,
+not permanent assumptions about the latest available valuation or handbook.
+
+## Existing Repo Data Layout To Populate
+
+Each new plan should eventually have a directory under `plans/{plan}/` matching
+the current stage-3 layout.
+
+Recommended plan ids:
+
+- `al_ers`
+- `ar_apers`
+
+Required config files:
+
+- `plans/{plan}/config/plan_config.json`
+- `plans/{plan}/config/calibration.json`
+
+Required demographic files:
+
+- `plans/{plan}/data/demographics/{class}_headcount.csv`
+- `plans/{plan}/data/demographics/{class}_salary.csv`
+- `plans/{plan}/data/demographics/{class}_salary_growth.csv`
+- or shared `plans/{plan}/data/demographics/salary_growth.csv`
+- `plans/{plan}/data/demographics/retiree_distribution.csv`
+- optional `plans/{plan}/data/demographics/entrant_profile.csv`
+
+Required decrement files:
+
+- `plans/{plan}/data/decrements/{class}_termination_rates.csv`
+- `plans/{plan}/data/decrements/{class}_retirement_rates.csv`
+- or shared `plans/{plan}/data/decrements/termination_rates.csv`
+- or shared `plans/{plan}/data/decrements/retirement_rates.csv`
+- early retirement reduction tables where the plan uses table-based reductions
+- DROP entry tables if DROP is modeled explicitly in a later phase
+
+Required mortality files:
+
+- `plans/{plan}/data/mortality/base_rates.csv`
+- `plans/{plan}/data/mortality/improvement_scale.csv`
+
+Required funding files:
+
+- `plans/{plan}/data/funding/init_funding.csv`
+- `plans/{plan}/data/funding/return_scenarios.csv`
+- optional `plans/{plan}/data/funding/amort_layers.csv`
+
+The current model can ingest aggregate public-report data, but the Alabama and
+APERS implementations will be more credible if age-service-salary census
+summaries or member-level anonymized census extracts can be obtained.
+
+## Alabama ERS Documents To Collect
+
+Collect the latest official versions of these materials before building
+`plans/al_ers`.
+
+1. ERS member handbook.
+   - Purpose: plan provisions, Tier 1/Tier 2 rules, vesting, member
+     contributions, benefit formula, FAC, compensation caps, retirement
+     eligibility, local employer treatment, and legacy DROP.
+   - Official source page: https://www.rsa-al.gov/ers/publications/
+   - Current handbook URL identified during planning:
+     https://www.rsa-al.gov/uploads/files/ERS_Member_Handbook_2023.pdf
+
+2. ERS actuarial valuation reports.
+   - Purpose: valuation assets, liabilities, normal cost, contribution rates,
+     member counts, payroll, assumptions, methods, amortization bases, and
+     plan provisions interpreted for valuation.
+   - Official source page:
+     https://www.rsa-al.gov/employers/financial-reports/
+   - Current FY24 valuation URL identified during planning:
+     https://www.rsa-al.gov/uploads/files/ERS-Val-2024-9-30_1.pdf
+
+3. RSA Annual Comprehensive Financial Report.
+   - Purpose: financial statements, investment return, benefit payments,
+     refunds, contribution totals, actuarial schedules, and historical trend
+     data.
+   - Official source page:
+     https://www.rsa-al.gov/about-rsa/publications/annual-comprehensive-financial-report/
+
+4. Act 2022-348 employer election material.
+   - Purpose: local employer option data for providing Tier 1 benefits to
+     Tier 2 members, and the implementation details needed for employer-level
+     plan options.
+   - Official source page:
+     https://www.rsa-al.gov/employers/ers/act-2022-348/
+
+5. Local employer rate reports or schedules.
+   - Purpose: employer-specific local rates, local election effects, local
+     25-year retirement options, and differences between state, state police,
+     and local employers.
+   - Likely source: RSA employer financial reports, local employer notices,
+     or direct request to RSA.
+
+6. Experience study or assumption report.
+   - Purpose: termination, retirement, disability, salary scale, payroll
+     growth, mortality, and other demographic assumptions.
+   - Likely source: RSA board materials, valuation appendices, or direct
+     request to RSA if not posted as a standalone document.
+
+7. Census or tabulated valuation data.
+   - Purpose: active headcount and salary by age, service, tier, class,
+     subgroup, and employer type.
+   - Likely source: not fully public; request from RSA or reconstruct from
+     valuation report schedules if only aggregate modeling is possible.
+
+## Arkansas APERS Documents To Collect
+
+Collect the latest official versions of these materials before building
+`plans/ar_apers`.
+
+1. APERS member handbook.
+   - Purpose: actual service, credited service, FAC, COLA, multipliers,
+     contributory and non-contributory service, elected official enhanced
+     service, retirement eligibility, early reductions, PAW, refund,
+     restoration, and DROP.
+   - Current handbook URL identified during planning:
+     https://www.apers.org/wp-content/uploads/APERS-Handbook_Updated_05-01-2025.pdf
+
+2. APERS actuarial valuation reports.
+   - Purpose: employer contribution rate, assets, liabilities, normal cost,
+     assumptions, methods, membership data, gain/loss, funding policy, and
+     contribution schedules.
+   - Current June 30, 2025 valuation URL identified during planning:
+     https://apers.org/wp-content/uploads/APERS-June-30-2025-Pension-Valuation-Report.pdf
+
+3. APERS Annual Comprehensive Financial Report.
+   - Purpose: financial statements, assets, benefit payments, contribution
+     totals, membership statistics, investment returns, actuarial schedules,
+     and DROP accounting disclosures.
+   - Current FY2024 ACFR URL identified during planning:
+     https://apers.org/wp-content/uploads/APERS-ACFR-24-web.pdf
+
+4. APERS employer reporting specifications.
+   - Purpose: work-report data fields, compensation definitions, hours-to-
+     service conversion, member and employer contributions, elected official
+     enhanced-credit reporting, and import samples.
+   - Official source page:
+     https://apers.org/employers/employer-reporting/
+
+5. APERS employer contribution rate publications.
+   - Purpose: employer group rates, effective dates, member contribution rate
+     ramp, and additional elected official contribution rates.
+   - Official source page:
+     https://apers.org/employers/employer-reporting/
+
+6. APERS board packets or funding policy documents.
+   - Purpose: contribution-rate decisions, DROP interest or crediting policy,
+     amortization policy, assumption changes, and plan-policy changes not fully
+     captured in the handbook.
+   - Likely source: APERS board materials or direct request to APERS.
+
+7. Census or tabulated valuation data.
+   - Purpose: active headcount and salary by age, actual service, credited
+     service, contribution design, hire date, elected-official status, and
+     employer group.
+   - Likely source: not fully public; request from APERS or reconstruct from
+     valuation and ACFR schedules if only aggregate modeling is possible.
+
+## Required Data Elements By Category
+
+### Plan Provisions
+
+Collect for each plan:
+
+- plan id and plan description
+- membership classes and subgroups
+- employer groups
+- tier and hire-cohort definitions
+- vesting requirements
+- normal retirement eligibility
+- early retirement eligibility
+- early retirement reduction formulas or tables
+- final average compensation windows
+- benefit multipliers
+- COLA rules
+- member contribution rates
+- employer contribution rates
+- compensation caps and pensionable-pay definitions
+- DROP eligibility and account behavior
+- refund rules
+- deferred vested rules
+- restoration or repayment rules
+- disability and survivor provisions if in scope
+
+Alabama-specific provisions:
+
+- Tier 1 versus Tier 2 ERS provisions
+- state employee, state police, and local employee distinctions
+- local employer option flags
+- local employer 25-year retirement treatment
+- employer elections under Act 2022-348
+- compensation caps tied to base pay
+- Tier 1-only or closed legacy DROP treatment
+
+APERS-specific provisions:
+
+- contributory versus non-contributory service treatment
+- service-period multipliers
+- actual service versus credited service
+- hours-to-service conversion rules
+- county and municipal elected official enhanced credit
+- pre/post July 1, 2022 FAC and COLA treatment
+- active APERS DROP rules
+- PAW, refund, and repayment provisions
+
+### Demographics
+
+Collect or derive:
+
+- active headcount by age and service
+- active average salary by age and service
+- active payroll by class, tier, and employer group
+- retiree count by age
+- retiree average benefit by age
+- retiree total annual benefit by age
+- deferred vested count and estimated allowances
+- refund-eligible inactive counts if available
+- entrant age distribution
+- entrant salary distribution
+
+For Alabama, split demographics by:
+
+- state employees
+- state police
+- local employees
+- Tier 1 and Tier 2
+- employer election group where available
+- firefighter, law enforcement, corrections, or other special subgroups where
+  applicable
+
+For APERS, split demographics by:
+
+- actual service
+- credited service
+- contribution design
+- hire cohort
+- elected official status
+- employer group
+- DROP status where available
+
+### Decrements
+
+Collect or derive:
+
+- termination rates
+- retirement rates
+- early retirement rates
+- DROP entry rates if modeled explicitly
+- disability rates if modeled
+- refund election rates if modeled
+- deferred vested commencement assumptions
+- restoration or repayment assumptions if modeled
+
+For Alabama, decrement tables should distinguish local employer options when
+those options materially affect eligibility.
+
+For APERS, decrement tables should distinguish actual-service and
+credited-service thresholds where plan behavior depends on both ledgers.
+
+### Mortality
+
+Collect:
+
+- base mortality tables
+- mortality improvement scale
+- active mortality assumptions
+- retiree mortality assumptions
+- disabled mortality assumptions if modeled
+- class-specific mortality basis, such as general, safety, teacher, or other
+  published tables
+
+If the plan valuation uses a standard table such as Pub-2010 with an
+improvement scale, convert it to the repo's `base_rates.csv` and
+`improvement_scale.csv` shape.
+
+### Funding
+
+Collect:
+
+- actuarial value of assets
+- market value of assets
+- actuarial accrued liability
+- unfunded actuarial accrued liability
+- normal cost
+- employee contributions
+- employer contributions
+- benefit payments
+- refunds
+- administrative expenses if used in contribution rates
+- amortization bases
+- amortization periods
+- payroll growth assumption
+- investment return assumption
+- asset smoothing method
+- funding policy
+- employer contribution policy
+- statutory contribution schedules
+
+For Alabama, collect separate state employee, state police, and local employer
+funding results where available.
+
+For APERS, collect employer group contribution rates and any special rates for
+wildlife officers, civilian firefighters, district judges, or other groups
+called out by APERS.
+
+### Calibration Targets
+
+Collect targets for model calibration and validation:
+
+- total active members
+- total covered payroll
+- retiree population
+- total annual benefits
+- average benefit
+- deferred vested counts
+- estimated deferred allowances
+- total AAL
+- AAL by group if available
+- normal cost rate
+- employer contribution rate
+- employee contribution rate
+- funded ratio
+- AVA and MVA
+- first-year projected benefit payments
+- first-year projected refunds
+- amortization payment or UAAL contribution component
+
+Calibration targets should be recorded with:
+
+- source document name
+- source document date
+- valuation date
+- fiscal year
+- page or table reference
+- extraction notes
+- whether the value is directly published or derived
+
+## Public Report Data Versus Request-Based Data
+
+Public reports are usually enough for:
+
+- aggregate plan provisions
+- contribution rates
+- high-level assets and liabilities
+- total active counts and payroll
+- total retiree counts and benefit payments
+- aggregate deferred vested counts
+- valuation assumptions and methods
+- broad membership schedules
+- investment return and funding policy data
+
+Public reports may be insufficient for:
+
+- age-service-salary grids
+- class-specific salary distributions
+- member-level hire dates
+- employer-option flags by member
+- Alabama local employer election status by member
+- APERS actual service and credited service by member
+- APERS service segments by contribution design
+- elected official enhanced credit history
+- DROP entry cohorts and frozen benefit details
+- refund/restoration history
+
+If full census data is unavailable, build a documented aggregate model using
+published schedules and record the approximation explicitly in the plan config
+or extraction notes.
+
+## Extraction Notes To Maintain
+
+For each collected document, create or maintain extraction notes with:
+
+- source URL
+- download date
+- document title
+- valuation date or fiscal year
+- plan population covered
+- tables used
+- fields extracted
+- transformations applied
+- assumptions made
+- known gaps
+- reviewer/date
+
+Recommended location:
+
+- `plans/{plan}/source_notes/`
+
+Recommended files:
+
+- `plans/{plan}/source_notes/source_inventory.md`
+- `plans/{plan}/source_notes/extraction_notes.md`
+- `plans/{plan}/source_notes/data_gaps.md`
+
+## Minimum Collection Checklist
+
+Minimum Alabama ERS collection before implementation:
+
+- ERS member handbook
+- latest ERS actuarial valuation report
+- latest RSA ACFR
+- Act 2022-348 employer election material
+- local employer rate or option documentation
+- mortality and assumption details from valuation or experience study
+- active and retiree demographic schedules
+- funding inputs and calibration targets
+
+Minimum Arkansas APERS collection before implementation:
+
+- APERS member handbook
+- latest APERS actuarial valuation report
+- latest APERS ACFR
+- employer reporting specifications and samples
+- employer and member contribution rate publications
+- mortality and assumption details from valuation or experience study
+- active and retiree demographic schedules
+- funding inputs and calibration targets
+
+## Assumptions
+
+- Data collection is separate from resolver architecture.
+- The original context document remains unchanged.
+- Public reports are acceptable for a first aggregate model, but census or
+  detailed valuation data is preferred for production-grade plan modeling.
+- Source documents should be rechecked before extraction because plan
+  provisions, rates, and report URLs can change.
+- Any value derived from a report table must be marked as derived rather than
+  directly published.

--- a/docs/alabama_arkansas_data_processing_implementation_plan.md
+++ b/docs/alabama_arkansas_data_processing_implementation_plan.md
@@ -1,0 +1,195 @@
+# Alabama ERS And Arkansas APERS Data Processing Implementation Plan
+
+Status: created after first implementation slice
+Date: 2026-04-28
+
+The first implementation slice has archived the primary public source PDFs and
+added minimal aggregate funding, calibration, and plan config files. This
+document tracks the remaining data-collection and processing work needed before
+either plan should be treated as model-ready.
+
+## Current Baseline
+
+Implemented:
+
+- `plans/al_ers/source_docs/`
+- `plans/ar_apers/source_docs/`
+- `plans/al_ers/config/plan_config.json`
+- `plans/ar_apers/config/plan_config.json`
+- `plans/al_ers/config/calibration.json`
+- `plans/ar_apers/config/calibration.json`
+- `plans/al_ers/data/funding/init_funding.csv`
+- `plans/ar_apers/data/funding/init_funding.csv`
+- `plans/al_ers/data/funding/return_scenarios.csv`
+- `plans/ar_apers/data/funding/return_scenarios.csv`
+
+Important limitation: the current configs are aggregate public-report baselines.
+They are intended to load and preserve funding/calibration targets, not to run a
+credible full liability projection yet.
+
+## Phase 2: Digitize Public Demographics
+
+Deliverables:
+
+- `plans/al_ers/data/demographics/{class}_headcount.csv`
+- `plans/al_ers/data/demographics/{class}_salary.csv`
+- `plans/al_ers/data/demographics/retiree_distribution.csv`
+- `plans/ar_apers/data/demographics/all_headcount.csv`
+- `plans/ar_apers/data/demographics/all_salary.csv`
+- `plans/ar_apers/data/demographics/retiree_distribution.csv`
+
+Tasks:
+
+1. APERS: digitize the active member age-service/payroll grids from the June
+   30, 2025 valuation.
+2. APERS: digitize inactive deferred annuity counts and annual annuities by
+   age group.
+3. Alabama ERS: determine whether the valuation membership schedules provide
+   enough age-service detail for public-table extraction.
+4. Alabama ERS: if only class/tier totals are public, create documented
+   synthetic age-service allocations and tag them as synthetic.
+5. Build retiree distributions from public schedules if available; otherwise
+   build aggregate distributions calibrated to retiree count and annual
+   benefit totals.
+
+Acceptance:
+
+- Active headcount and payroll totals reconcile to the public valuation totals.
+- Retiree count and annual benefit totals reconcile to public report targets.
+- Any synthetic distribution has a source note and a reproducible
+  transformation note.
+
+## Phase 3: Convert Salary Growth And Decrements
+
+Deliverables:
+
+- `plans/al_ers/data/demographics/{class}_salary_growth.csv` or shared
+  `plans/al_ers/data/demographics/salary_growth.csv`
+- `plans/ar_apers/data/demographics/salary_growth.csv`
+- `plans/al_ers/data/decrements/{class}_termination_rates.csv`
+- `plans/al_ers/data/decrements/{class}_retirement_rates.csv`
+- `plans/ar_apers/data/decrements/termination_rates.csv`
+- `plans/ar_apers/data/decrements/retirement_rates.csv`
+
+Tasks:
+
+1. Digitize Alabama ERS Schedule D salary increase assumptions.
+2. Digitize Alabama ERS withdrawal and retirement assumptions by class/tier.
+3. Digitize APERS pay increase assumptions by age.
+4. Digitize APERS withdrawal, disability, retirement, and DROP entry
+   assumptions from the valuation.
+5. Decide how to represent disability rates if the current projection path
+   cannot consume them directly.
+6. Add table-level QA checks for representative cells from each source table.
+
+Acceptance:
+
+- Decrement files are rectangular and pass CSV schema checks.
+- Representative source-table values round-trip into CSV exactly or within
+  documented rounding tolerance.
+- Any simplification, such as APERS actual-service versus credited-service
+  collapse, is explicit in extraction notes.
+
+## Phase 4: Build Mortality Inputs
+
+Deliverables:
+
+- `plans/al_ers/data/mortality/base_rates.csv`
+- `plans/al_ers/data/mortality/improvement_scale.csv`
+- `plans/ar_apers/data/mortality/base_rates.csv`
+- `plans/ar_apers/data/mortality/improvement_scale.csv`
+
+Tasks:
+
+1. Source the needed SOA Pub-2010 base table data.
+2. Source MP-2020 and MP-2021 improvement scales.
+3. Apply Alabama ERS table multipliers, age adjustments, public safety/general
+   distinctions, and the valuation's MP-2020 treatment.
+4. Apply APERS PubG/PubNS table percentages and MP-2021 generational
+   improvement.
+5. Spot-check adjusted rates at several ages, sexes, and retiree statuses.
+
+Acceptance:
+
+- Mortality CSVs match the repo's existing stage-3 format.
+- A reviewer can trace every adjusted table back to source table, multiplier,
+  age setback, and improvement scale.
+
+## Phase 5: Improve Plan Provisions
+
+Deliverables:
+
+- Updated `plans/al_ers/config/plan_config.json`
+- Updated `plans/ar_apers/config/plan_config.json`
+- Provision extraction notes in each plan's `source_notes/`
+
+Tasks:
+
+1. Extract Alabama State Police Tier 1 and Tier 2 handbook provisions.
+2. Extract Alabama local 25-year retirement rules and identify the employer
+   data needed to apply them.
+3. Extract Alabama Act 2022-348 employer election mechanics.
+4. Implement APERS service-segment multipliers if service segment data becomes
+   available.
+5. Implement APERS pre/post July 1, 2022 FAC and COLA cohorts using hire-date
+   distributions when available.
+6. Decide whether DROP remains an aggregate funding assumption or gets explicit
+   participant-state modeling.
+
+Acceptance:
+
+- Config provisions reflect extracted rules, not placeholders.
+- Known rule gaps remain in `data_gaps.md`.
+- Any model limitation is visible in config notes.
+
+## Phase 6: Request Non-Public Must-Have Data
+
+Deliverables:
+
+- `plans/al_ers/source_notes/data_request.md`
+- `plans/ar_apers/source_notes/data_request.md`
+
+Tasks:
+
+1. Draft RSA request for anonymized valuation census, retiree census, deferred
+   vested data, local employer rates, Act 2022-348 elections, and 25-year
+   retirement flags.
+2. Draft APERS request for anonymized valuation census, actual service,
+   credited service, contribution design, hire date, elected-official status,
+   service segment history, and DROP account data.
+3. Request machine-readable assumption workbooks or experience-study tables
+   from both systems.
+4. Track request date, recipient, response, restrictions, and follow-up needs.
+
+Acceptance:
+
+- Requests are specific enough for plan staff to answer without a discovery
+  meeting.
+- Any denied or unavailable data is copied into `data_gaps.md` with the date
+  and reason.
+
+## Phase 7: Validate End To End
+
+Deliverables:
+
+- Plan-specific config and data loading tests.
+- Reconciliation checks against public calibration targets.
+- Updated extraction notes for any deviations.
+
+Tasks:
+
+1. Add tests that load `al_ers` and `ar_apers` configs.
+2. Add tests that funding input totals reconcile to `calibration.json` and
+   extraction-note targets.
+3. Add data-file existence checks once demographics, decrements, and mortality
+   are implemented.
+4. Run the full model only after demographics, decrements, and mortality are
+   complete enough to avoid false precision.
+
+Acceptance:
+
+- Aggregate funding/calibration files load.
+- Public valuation totals reconcile.
+- Remaining projection differences are documented as data limitations or
+  implementation work.
+

--- a/docs/plan_rule_resolver_framework_plan.md
+++ b/docs/plan_rule_resolver_framework_plan.md
@@ -1,0 +1,292 @@
+# Plan-Rule Resolver Framework Implementation Plan
+
+This document is the implementation plan for the shared plan-rule resolver
+framework. It is paired with
+[Alabama/Arkansas Data Collection Plan](alabama_arkansas_data_collection_plan.md),
+which covers source documents and data inputs only.
+
+The source context for this work is
+[Alabama and Arkansas Pension Extension Context](alabama_arkansas_pension_extension_context.md).
+
+## Purpose And Scope
+
+The first implementation step for extending the model to Alabama ERS and
+Arkansas APERS is a behavior-preserving rule framework. The goal is to move
+current FRS and TXTRS rule resolution behind an explicit `PlanRules`
+abstraction before adding new plan content.
+
+This phase must not add Alabama ERS or Arkansas APERS plan configs. It must
+not redesign data loading, segmented service, DROP accounting, or funding. It
+should create a clean internal rule boundary while keeping all current public
+imports and FRS/TXTRS results stable.
+
+The framework should initially cover:
+
+- tier assignment
+- retirement status and eligibility
+- FAC window selection
+- COLA resolution
+- benefit multiplier resolution
+- early retirement reduction resolution
+
+## Current Resolver Surfaces
+
+The current stable public resolver surface is exported through
+`src/pension_model/plan_config.py`:
+
+- `get_tier`
+- `get_tier_vectorized`
+- `get_ben_mult`
+- `get_reduce_factor`
+- `resolve_tiers_vec`
+- `resolve_tiers_vec_str`
+- `resolve_cola_vec`
+- `resolve_ben_mult_vec`
+- `resolve_reduce_factor_vec`
+
+The implementation is currently split across:
+
+- `src/pension_model/config_resolvers.py`
+- `src/pension_model/config_resolvers_scalar.py`
+- `src/pension_model/config_resolvers_vectorized.py`
+- `src/pension_model/config_resolver_common.py`
+
+Downstream runtime callers rely on these functions from the benefit-table and
+decrement-loading paths. In particular, benefit-table construction currently
+uses the vectorized resolver path heavily, so the framework should keep
+vectorized methods as the primary runtime contract.
+
+## Target Abstraction
+
+Add a new rules package under `src/pension_model/rules/`.
+
+Recommended module layout:
+
+- `src/pension_model/rules/__init__.py`
+- `src/pension_model/rules/base.py`
+- `src/pension_model/rules/table_driven.py`
+- `src/pension_model/rules/factory.py`
+
+`base.py` should define a `PlanRules` protocol or abstract base class. The
+initial implementation should be a `TableDrivenPlanRules` class that reproduces
+today's JSON-driven FRS/TXTRS behavior exactly.
+
+Recommended `PlanRules` method boundary:
+
+```python
+class PlanRules(Protocol):
+    def resolve_tiers(
+        self,
+        class_name,
+        entry_year,
+        age,
+        yos,
+        entry_age=None,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        ...
+
+    def resolve_tier_labels(
+        self,
+        class_name,
+        entry_year,
+        age,
+        yos,
+        entry_age=None,
+    ) -> np.ndarray:
+        ...
+
+    def resolve_cola(
+        self,
+        tier_id,
+        entry_year,
+        yos,
+    ) -> np.ndarray:
+        ...
+
+    def resolve_benefit_multiplier(
+        self,
+        class_name,
+        tier_id,
+        ret_status,
+        dist_age,
+        yos,
+        dist_year,
+    ) -> np.ndarray:
+        ...
+
+    def resolve_early_reduction(
+        self,
+        class_name,
+        tier_id,
+        ret_status,
+        dist_age,
+        yos,
+        entry_year,
+    ) -> np.ndarray:
+        ...
+
+    def resolve_fas_years(
+        self,
+        tier_id,
+        class_name=None,
+        entry_year=None,
+        yos=None,
+    ) -> np.ndarray:
+        ...
+```
+
+The method signatures should accept the current arrays directly. Do not require
+new domain objects in hot paths unless profiling shows that the overhead is
+negligible.
+
+## Implementation Sequence
+
+1. Inventory current behavior.
+   - List every public resolver and its current signature.
+   - Identify scalar-only helpers and vectorized helpers.
+   - Confirm current integer status constants: `NON_VESTED`, `VESTED`,
+     `EARLY`, and `NORM`.
+   - Confirm current tier id conventions: ids are positional indexes into
+     `PlanConfig.tier_defs`.
+
+2. Add the rules package skeleton.
+   - Create `src/pension_model/rules/__init__.py`.
+   - Create `src/pension_model/rules/base.py`.
+   - Create `src/pension_model/rules/table_driven.py`.
+   - Create `src/pension_model/rules/factory.py`.
+   - Export `PlanRules`, `TableDrivenPlanRules`, and `build_plan_rules`.
+
+3. Implement `TableDrivenPlanRules`.
+   - Move or wrap the current vectorized logic from
+     `config_resolvers_vectorized.py`.
+   - Move or wrap the current scalar logic from
+     `config_resolvers_scalar.py`.
+   - Keep shared helpers either in `config_resolver_common.py` temporarily or
+     move them into the rules package if the move is mechanical and low risk.
+   - Preserve all NaN behavior, dtype choices, and status codes.
+
+4. Add a rule factory.
+   - Implement `build_plan_rules(config: PlanConfig) -> PlanRules`.
+   - Initially always return `TableDrivenPlanRules(config)`.
+   - Keep the factory simple. Do not introduce registry behavior until a
+     second concrete rules implementation exists.
+
+5. Preserve the public resolver API.
+   - Keep `pension_model.plan_config` exports unchanged.
+   - Keep `pension_model.config_resolvers` exports unchanged.
+   - Convert public resolver functions into wrappers around
+     `build_plan_rules(config)`.
+   - Avoid changing call sites in the first pass unless necessary.
+
+6. Add a low-overhead rules cache if needed.
+   - If constructing `TableDrivenPlanRules` per resolver call is measurable,
+     add a private cache keyed by `id(config)` or another safe config identity.
+   - Do not mutate the frozen `PlanConfig` unless the design is explicitly
+     reviewed.
+   - Make the cache an implementation detail of the resolver wrapper or
+     factory.
+
+7. Introduce the FAC rule boundary.
+   - Replace direct benefit-table lookup of `constants._tier_id_to_fas_years`
+     with `rules.resolve_fas_years(...)`.
+   - For current FRS and TXTRS, return exactly the same tier-based FAC years.
+   - Keep output column names unchanged: `fas_period` and `fas`.
+
+8. Add optional future context fields without activating them.
+   - If a typed rule input object is introduced, reserve optional fields for
+     future plans: `employer_id`, `subgroup`, `hire_date`, `actual_service`,
+     `credited_service`, and `service_segments`.
+   - Current FRS/TXTRS paths should not need to populate these fields.
+   - Avoid forcing APERS or Alabama concepts into the current runtime tables in
+     this phase.
+
+9. Add direct rules tests.
+   - Add focused tests for `TableDrivenPlanRules` using the existing FRS and
+     TXTRS resolver grids.
+   - Verify direct `TableDrivenPlanRules` calls match the existing public
+     scalar wrappers.
+   - Verify public wrappers still match their prior behavior.
+
+10. Keep broad compatibility tests passing.
+    - Run current resolver tests unchanged.
+    - Run current plan config tests unchanged.
+    - Run current benefit-table contract tests unchanged.
+    - Run a broader suite after focused tests pass.
+
+11. Update documentation.
+    - Add a short section to `docs/architecture_map.md` describing the rules
+      layer after implementation.
+    - Link this plan from that section.
+    - State that current FRS/TXTRS rules use `TableDrivenPlanRules`.
+
+12. Defer plan-specific expansion.
+    - Do not add Alabama-specific employer-option rules in this phase.
+    - Do not add APERS segmented-service rules in this phase.
+    - Do not move DROP from funding into rules in this phase.
+
+## Compatibility Requirements
+
+FRS and TXTRS are the compatibility baseline for this work.
+
+The implementation must preserve:
+
+- public imports from `pension_model.plan_config`
+- public imports from `pension_model.config_resolvers`
+- integer status codes
+- tier id assignment order
+- tier label strings, including status suffixes
+- COLA proration behavior
+- FAS period behavior
+- benefit multiplier outputs
+- early retirement reduction outputs
+- NaN behavior for unresolved reduction or multiplier cases
+- downstream benefit-table column names
+
+No existing FRS or TXTRS plan config JSON should need to change.
+
+## Test Commands
+
+Run these focused checks first:
+
+```powershell
+python -m pytest tests/test_pension_model/test_vectorized_resolvers_frs.py -q
+python -m pytest tests/test_pension_model/test_vectorized_resolvers_txtrs.py -q
+python -m pytest tests/test_pension_model/test_plan_config_frs.py tests/test_pension_model/test_plan_config_txtrs.py -q
+python -m pytest tests/test_pension_model/test_benefit_table_contracts.py -q
+```
+
+Then run a broader check:
+
+```powershell
+python -m pytest tests/test_pension_model -q
+```
+
+If the full suite is too slow for the implementation loop, run the focused
+checks after every meaningful refactor and the full suite before considering
+the phase complete.
+
+## Acceptance Criteria
+
+The phase is complete when:
+
+- A `PlanRules` boundary exists and is used by the public resolver wrappers.
+- `TableDrivenPlanRules` reproduces current FRS and TXTRS behavior.
+- Existing resolver tests pass unchanged.
+- Existing plan config tests pass unchanged.
+- Benefit-table contract tests pass unchanged.
+- No Alabama or APERS plan content has been added.
+- No data collection or source-document work has been mixed into the rules
+  implementation.
+- Documentation identifies the rules package as the extension point for future
+  plan behavior.
+
+## Assumptions
+
+- This is an architecture step, not a plan implementation step.
+- FRS and TXTRS output compatibility is mandatory.
+- The first rules implementation should stay close to current code to reduce
+  regression risk.
+- Richer service accounting, employer options, and plan-specific DROP behavior
+  will be added in later phases after this boundary exists.
+- It is acceptable for some helper names to remain transitional if public
+  behavior and module boundaries become clearer.

--- a/memory-bank/high_discount_rate_plan.md
+++ b/memory-bank/high_discount_rate_plan.md
@@ -1,0 +1,221 @@
+# High Discount Discount-Rate Basis Plan
+
+Date: 2026-04-25
+Branch: `scenario_testing`
+
+## Context
+
+The FRS `high_discount` scenario currently does not match between the R workflow and the Python workflow, while `low_return` and `no_cola` match to floating-point noise.
+
+Current comparison against the existing R high-discount truth table:
+
+- `aal_boy`: max Python minus R difference about `+1.724B`
+- `mva_boy`: max difference about `+1.695B`
+- `ava_boy`: max difference about `+1.695B`
+- `benefits_fy`: max difference about `+0.178B`
+- 2023 funded-ratio difference about `-0.00643`
+
+Root cause found:
+
+- In R, current term-vested members are special-cased.
+- R builds the current term-vested benefit payment stream using the baseline discount rate `dr_current_ = 0.067`.
+- R then values that payment stream using the scenario valuation rate `dr_current = 0.075`.
+- Python currently uses `constants.economic.dr_current` for both steps, so under `high_discount` it uses `0.075` both to build the payment stream and to value it.
+
+Key R code:
+
+- `R_model/R_model_frs/Florida FRS liability model.R`
+- Current term-vested section:
+  - `retire_ben_term <- get_pmt(r = dr_current_, ...)`
+  - `aal_term_current_est = roll_pv(rate = dr_current, ...)`
+
+Key Python code:
+
+- `src/pension_model/core/pipeline_current.py`
+- `compute_current_term_vested_liability()` currently uses one `discount_rate = constants.economic.dr_current` for both `_get_pmt(...)` and `_roll_pv(...)`.
+
+An in-memory Python experiment confirmed that if Python uses `0.067` for current term-vested payment construction and `0.075` for valuation, then `high_discount` matches R to floating-point precision.
+
+Important actuarial interpretation:
+
+- The current R behavior is more defensible than the current Python behavior for the current term-vested component, because a valuation discount-rate sensitivity should generally revalue projected payments rather than changing the nominal payment stream.
+- The R workflow is still not fully ideal as a general actuarial design because discount-rate roles are not explicit everywhere. Some active/future-member valuation calculations use the scenario rate deeply through annuity factors, PVFB, PVFS, and normal cost.
+- Long term, the model should separate cash-flow projection assumptions from valuation-basis assumptions explicitly.
+
+## Goals
+
+1. First, make Python match the current R workflow for FRS `high_discount`, using the same role vocabulary that will support the later explicit-basis refactor.
+2. Add tests proving R and Python match for the FRS `high_discount` scenario, and tests documenting the intended cash-flow-vs-valuation discount-rate split.
+3. Then refactor toward an explicit discount-rate basis design that separates:
+   - rates used to project or allocate benefit cash flows
+   - rates used to present-value those cash flows for AAL/PVFB/PVFS
+   - rates used for asset-return projections
+
+Do this in that order. Do not change R semantics before Python can reproduce the current R truth table. However, Phase 1 and Phase 2 should be designed as stepping stones toward Phase 3, not as temporary term-vested-only naming that will need to be undone.
+
+Naming convention:
+
+- `cashflow_discount_rate`: the rate used to construct or allocate nominal cash flows, including synthetic current term-vested benefit payment streams.
+- `valuation_discount_rate`: the rate used to present-value cash flows for AAL/PVFB/PVFS/normal cost.
+- `"baseline_dr_current"` and `"scenario_dr_current"` are basis/source names, not role names.
+- Avoid names such as `payment_discount_rate`, `benefit_discount_rate`, and `baseline_discount_rate` in new design text. They blur whether the name describes the role of the rate or the source of the rate.
+
+## Implementation Plan
+
+### Phase 1: Match Current R Behavior In Python, Using Future-Compatible Rate Roles
+
+- Preserve baseline economic assumptions before scenario overrides are merged.
+  - In `load_plan_config(...)`, keep a copy of the original plan JSON economic block before `_deep_merge(...)`.
+  - Store it in `raw`, for example as `raw["_baseline_economic"]`.
+  - Add a small `PlanConfig` property such as `baseline_dr_current` that returns `raw["_baseline_economic"]["dr_current"]`, falling back to `dr_current` when no scenario is loaded.
+
+- Add explicit discount-rate basis resolution that separates role from source.
+  - Add a small resolver, for example `_resolve_discount_rate_basis(...)`, that maps source names to rates:
+    - `"scenario_dr_current"` resolves to the scenario-loaded `dr_current`.
+    - `"baseline_dr_current"` resolves to the pre-scenario baseline `dr_current`.
+  - Add config-backed role properties with conservative defaults:
+    - `modeling.cashflow_discount_basis = "scenario_dr_current"` by default
+    - `modeling.valuation_discount_basis = "scenario_dr_current"` by default
+  - FRS should set or resolve:
+    - `cashflow_discount_basis = "baseline_dr_current"`
+    - `valuation_discount_basis = "scenario_dr_current"`
+  - This keeps the high-discount R-match behavior narrow in Phase 1, while using names that can later apply to active, retiree, refund, PVFB/PVFS, normal cost, and annuity-factor calculations.
+
+- Update `compute_current_term_vested_liability(...)`.
+  - Split the current single `discount_rate` into:
+    - `cashflow_discount_rate`
+    - `valuation_discount_rate`
+  - For FRS R-match behavior:
+    - `cashflow_discount_rate` resolves from `"baseline_dr_current"` and is `0.067`.
+    - `valuation_discount_rate` resolves from `"scenario_dr_current"` and is `0.075`.
+  - Use `cashflow_discount_rate` in `_get_pmt(...)`.
+  - Use `valuation_discount_rate` in `_roll_pv(...)`.
+  - For the `bell_curve` method, use `valuation_discount_rate` for present-value calculations. Do not invent additional cash-flow behavior unless tests show that method needs a separate cash-flow construction basis.
+
+- Expected effect:
+  - Baseline, `low_return`, and `no_cola` remain unchanged because their discount-rate valuation basis is not changed.
+  - `high_discount` should now match R.
+
+### Phase 2: Add Regression Tests For Scenario Matching
+
+- Add a focused config-role test.
+  - Load FRS with `scenarios/high_discount.json`.
+  - Assert the baseline source is still available:
+    - `baseline_dr_current == 0.067`
+    - scenario-loaded `dr_current == 0.075`
+  - Assert the role resolution:
+    - `cashflow_discount_basis == "baseline_dr_current"`
+    - `valuation_discount_basis == "scenario_dr_current"`
+    - resolved `cashflow_discount_rate == 0.067`
+    - resolved `valuation_discount_rate == 0.075`
+  - The test should make it clear that baseline/scenario are sources, while cashflow/valuation are roles.
+
+- Add a focused FRS scenario truth-table regression test.
+  - Suggested file: `tests/test_pension_model/test_truth_table_frs_scenarios.py`
+  - Use the in-process pipeline rather than shelling out.
+  - Load config with:
+    - `plans/frs/config/plan_config.json`
+    - `plans/frs/config/calibration.json`
+    - scenario path `scenarios/high_discount.json`
+  - Run liability and funding.
+  - Build the Python truth table with `build_python_truth_table(...)`.
+  - Compare to `plans/frs/baselines/r_truth_table_high_discount.csv`.
+
+- Assertion:
+  - Compare common numeric truth-table columns.
+  - Use absolute tolerance `<= 0.001` for dollar columns.
+  - Use tighter tolerance, around `1e-12`, for funded-ratio columns if practical.
+  - If the frozen R scenario CSV uses an older truth-table layout, compare only columns whose definitions match the current Python truth-table columns.
+
+- Include at least `high_discount`.
+  - If runtime is acceptable, parameterize the same test for:
+    - `low_return`
+    - `high_discount`
+    - `no_cola`
+  - Mark as `slow`, `regression`, and `plan_frs`.
+
+- Verification commands:
+
+```powershell
+.\.venv\Scripts\python.exe -m pytest tests/test_pension_model/test_truth_table_frs_scenarios.py -q
+.\.venv\Scripts\python.exe -c "import pension_model.cli as c; c.main()" run frs --no-test --scenario scenarios/high_discount.json --truth-table
+```
+
+- Manual acceptance:
+  - `output/frs/high_discount/truth_table.csv` matches `plans/frs/baselines/r_truth_table_high_discount.csv`.
+  - Max differences should be floating-point noise only.
+  - The tests document that the current term-vested cash-flow stream is built on baseline `dr_current`, then valued using scenario `dr_current`.
+
+### Phase 3: Make Discount-Rate Roles Explicit
+
+After Phase 1 and Phase 2 pass, refactor the model design so the rate roles are clear instead of implicit.
+
+- Introduce explicit conceptual rate roles:
+  - `cashflow_projection` basis: assumptions that determine nominal projected benefits, refunds, payroll, COLA, mortality, retirement, termination, and any synthetic current term-vested payment allocation.
+  - `valuation` basis: discount rates used to present-value expected cash flows for AAL, PVFB, PVFS, normal cost, and annuity factors.
+  - `asset_return` basis: return paths or assumptions used to roll MVA/AVA and investment income.
+
+- Update scenario vocabulary over time.
+  - Keep existing scenario files working for backward compatibility.
+  - Long-term scenario files should distinguish:
+    - valuation discount rate overrides
+    - asset-return overrides
+    - cash-flow projection overrides
+  - Example intent for a valuation-only high-discount sensitivity:
+
+```json
+{
+  "name": "high_discount",
+  "overrides": {
+    "valuation": {
+      "dr_current": 0.075,
+      "dr_new": 0.075,
+      "valuation_discount_basis": "scenario_dr_current"
+    },
+    "economic": {
+      "model_return": 0.075
+    },
+    "cashflow_projection": {
+      "cashflow_discount_basis": "baseline_dr_current"
+    }
+  }
+}
+```
+
+- Refactor Python first behind compatibility properties.
+  - Add new properties while keeping `economic.dr_current`, `economic.dr_new`, and `economic.model_return` usable.
+  - Update internal naming toward `cashflow_discount_rate`, `valuation_discount_rate`, and `asset_return` roles where it reduces ambiguity.
+  - Avoid a large mechanical rename until tests protect current behavior.
+
+- Refactor the R workflow second.
+  - Because `R_model/R_model_frs/` is ignored and locally supplied, treat R edits as local reference-model work unless the user explicitly wants those files force-added.
+  - In R, update function signatures conceptually from one `dr_current` role to separate roles such as:
+    - `valuation_discount_rate`
+    - `cashflow_discount_rate`
+    - `asset_model_return`
+  - Preserve old parameter names as wrappers or defaults if practical.
+
+- Baseline management after R refactor:
+  - Preserve old current-R comparison outputs if useful, for example as `r_truth_table_high_discount_legacy_r.csv`.
+  - Regenerate `r_truth_table_high_discount.csv` only after deciding that the new explicit-basis R workflow is the new reference truth.
+  - Re-run Python against the regenerated R truth table.
+
+## Acceptance Criteria
+
+- Current R-match phase:
+  - FRS `low_return` still matches R.
+  - FRS `no_cola` still matches R.
+  - FRS `high_discount` now matches R to floating-point noise.
+  - Tests document the high-discount behavior so it cannot regress silently.
+
+- Explicit-basis phase:
+  - The code distinguishes cash-flow projection rates from valuation discount rates.
+  - Scenario files can express valuation-only discount-rate sensitivities without changing nominal benefit cash flows unless explicitly requested.
+  - R and Python still match for whichever R truth baseline is designated current.
+
+## Notes For Next Session
+
+- Do not work on `main`.
+- `memory-bank/` is ignored by Git unless files are force-added.
+- `R_model/R_model_frs/` and `R_model/R_model_txtrs/` are ignored by Git and contain local manually supplied R files/data.
+- The immediate implementation target is Phase 1 plus the high-discount regression test.

--- a/plans/al_ers/source_notes/data_gaps.md
+++ b/plans/al_ers/source_notes/data_gaps.md
@@ -1,0 +1,50 @@
+# Alabama ERS Data Gaps
+
+Collection date: 2026-04-28
+
+The public valuation and handbook support a first aggregate model, but they do
+not support a production-grade member-flow model without additional data.
+
+## Must-Have But Unavailable From Public Sources
+
+| Data need | Why it is must-have | Public substitute available | Gap severity |
+| --- | --- | --- | --- |
+| Active headcount and payroll by exact age, service, tier, FLC/non-FLC, State/State Police/local group, and local employer option | Required to build `*_headcount.csv` and `*_salary.csv` without synthetic allocation | Valuation Table 1 gives counts and payroll by group/tier/FLC only | High |
+| Local employer-specific rate schedule and local funding results | Local contribution rates and amortization periods vary by employer and benefit option | Valuation says local FY2027 rates will be submitted separately; employer page has state-only rate schedule | High |
+| Local employer Act 2022-348 election flags and effective dates by employer | Required to model local employers that provide Tier 1 benefits to Tier 2 members | Employer page links to adopted-agency material, but member-level/employer-level modeling fields were not collected | High |
+| Local 25-year agency adoption flags by employer and member | Retirement eligibility differs for 25-year agencies | Handbook describes 25-year and non-25-year treatment, but no complete employer-member crosswalk was found | High |
+| Complete decrement tables in machine-readable form | Required for `termination_rates.csv` and `retirement_rates.csv` by class | Valuation Schedule D has assumption tables and representative values; full model-shaped tables still need digitization and QA | High |
+| Base Pub-2010 mortality rates and MP-2020 improvement scale in repo CSV shape | Required for `base_rates.csv` and `improvement_scale.csv` | Valuation describes table basis, adjustments, and improvement scale | High |
+| Retiree count and annual benefit by age | Required for `retiree_distribution.csv` | Valuation provides total retirees and annual allowances by group only | High |
+| Deferred vested members by age and estimated allowance | Needed for deferred-liability and commencement calibration | Valuation provides total deferred vested count and allowance by group | Medium |
+| Entrant age and entrant salary profile | Needed for open-group projection after initial valuation | Not public in collected sources | Medium |
+| DROP participant counts, entry cohorts, account balances, and payout elections | Needed if DROP is modeled explicitly | Valuation provides post-DROP active counts and total DROP distributions only | Medium |
+| State Police handbook provisions | Required for precise State Police Tier 1/Tier 2 benefit rules | ERS publications page identifies State Police handbooks, but this pass extracted the general ERS handbook and valuation only | Medium |
+| Compensation cap detail by fiscal year | Needed for pensionable-pay projection and validation | Handbook gives 120% Tier 1 and 125% Tier 2 base-pay caps; employer page links annual earnable-compensation limits | Medium |
+| Disability and survivor election history | Needed for full benefit-state modeling | Valuation gives broad assumptions and aggregate outcomes | Low to medium |
+
+## Public But Not Yet Digitized
+
+- Alabama ERS valuation Schedule D decrement assumptions.
+- Alabama ERS valuation Schedule G amortization bases.
+- Alabama ERS GASB 67/68 schedules for 9/30/2025.
+- RSA Annual Report 2025 investment and financial statement schedules.
+- ERS State Police Tier 1 and Tier 2 handbooks from the ERS publications page.
+
+## Recommended Requests To RSA
+
+1. Anonymized valuation census extract with age, service, pay, tier, class,
+   FLC flag, State/State Police/local group, employer id, local benefit-option
+   flags, and DROP status.
+2. Retiree census or tabulation by age, benefit amount, benefit type, option,
+   DROP status, and group.
+3. Deferred vested and inactive census by age, service, contribution balance,
+   estimated benefit, and expected commencement age.
+4. Complete local employer rate report for fiscal years beginning October 1,
+   2025 and October 1, 2026.
+5. Act 2022-348 and local 25-year retirement election files by employer and
+   effective date.
+6. Experience study or full assumption workbook behind the valuation tables.
+7. Machine-readable mortality table adjustments or confirmation to use SOA
+   Pub-2010 base tables with the valuation adjustments and MP-2020 scale.
+

--- a/plans/al_ers/source_notes/extraction_notes.md
+++ b/plans/al_ers/source_notes/extraction_notes.md
@@ -1,0 +1,179 @@
+# Alabama ERS Extraction Notes
+
+Collection date: 2026-04-28
+
+## Public Data Collected
+
+### Plan Identity
+
+| Field | Value | Source |
+| --- | --- | --- |
+| Plan id | `al_ers` | Local collection plan |
+| Plan name | Employees' Retirement System of Alabama | ERS member handbook; ERS valuation |
+| Plan type | Governmental defined benefit plan qualified under IRC section 401(a) | ERS member handbook, p. 6 |
+| Plan year / valuation date | September 30 | ERS valuation, prepared as of September 30, 2024 |
+| Covered groups | State employees, State Police, local employees | ERS valuation, summary of principal results |
+
+### Tier And Membership Rules
+
+| Field | Collected value | Source |
+| --- | --- | --- |
+| Tier 1 definition | Service credit in ERS or TRS before January 1, 2013 | ERS member handbook, p. 6 |
+| Tier 2 definition | First eligible ERS or TRS employment on or after January 1, 2013 with no prior ERS/TRS eligible service | ERS member handbook, p. 6 |
+| Local Tier 1 option for Tier 2 members | Local Unit employers may elect to provide Tier 1 benefits to Tier 2 employees; member tier status does not change; split benefit calculation applies for mixed service | ERS member handbook, p. 6 |
+| Vesting | 10 years of creditable service | ERS member handbook, p. 9 |
+| Mandatory participation | Non-temporary eligible position, at least half-time, and at least federal minimum wage | ERS member handbook, p. 6 |
+
+### Contributions And Rates
+
+| Field | Collected value | Source |
+| --- | --- | --- |
+| Tier 1 member contribution, regular state employees | 7.5% of earnable compensation | ERS member handbook, p. 8 |
+| Tier 1 member contribution, full-time certified FLC/EMSP state group | 8.5% effective October 1, 2024 | ERS member handbook, p. 8 |
+| Tier 1 local option | Local Units may adopt state rates or remain at 5% regular and 6% FLC/EMSP | ERS member handbook, p. 8 |
+| Tier 2 member contribution, regular state and local | 6.0% | ERS member handbook, p. 8 |
+| Tier 2 member contribution, FLC/EMSP | 7.0% effective October 1, 2024 | ERS member handbook, p. 8 |
+| Compensation cap, Tier 1 | Earnable compensation cannot exceed 120% of base pay | ERS member handbook, p. 8 |
+| Compensation cap, Tier 2 | Earnable compensation cannot exceed 125% of base pay | ERS member handbook, p. 8 |
+| State employer rate effective October 1, 2025, Tier 1 employees | 17.34% | ERS employer page |
+| State employer rate effective October 1, 2025, Tier 2 employees | 17.08% | ERS employer page |
+| State Police employer rate effective October 1, 2025, Tier 1 | 60.35% | ERS employer page |
+| State Police employer rate effective October 1, 2025, Tier 2 | 57.94% | ERS employer page |
+| FY2027 recommended state employee employer rate, Tier I | 17.15% | ERS valuation, cover letter and summary |
+| FY2027 recommended state employee employer rate, Tier II | 16.85% | ERS valuation, cover letter and summary |
+| FY2027 recommended State Police employer rate, Tier I | 58.82% | ERS valuation, cover letter and summary |
+| FY2027 recommended State Police employer rate, Tier II | 56.41% | ERS valuation, cover letter and summary |
+
+### Retirement Provisions
+
+| Field | Collected value | Source |
+| --- | --- | --- |
+| Tier 1 service retirement | Age 60 with at least 10 years, or 25 years of service for 25-year agencies | ERS member handbook, p. 18 |
+| Tier 2 service retirement | Age 62 with at least 10 years, or age 56 for FLC; also eligible after 30 years with a 2% reduction for each year from age 62 or 56 for FLC | ERS member handbook, p. 18 |
+| Tier 1 benefit factor | 2.0125% | ERS member handbook, p. 24 |
+| Tier 1 maximum monthly benefit formula | Average final salary times service times 2.0125%, divided by 12 | ERS member handbook, p. 24 |
+| Sick leave conversion | Tier 1 only; can be used for eligibility and benefit calculation where applicable | ERS member handbook, pp. 21-23 |
+| DROP | Tier 1 only in the general handbook | ERS member handbook table of contents and DROP section |
+
+### Demographic And Valuation Counts
+
+| Population | Count | Payroll / annual allowances | Source |
+| --- | ---: | ---: | --- |
+| State employees active members | 27,838 | $1,743,400,587 annual compensation | ERS valuation, p. 6 and summary |
+| State Police active members | 765 | $64,960,890 annual compensation | ERS valuation, p. 6 and summary |
+| Local employees active members | 60,310 | $3,268,583,841 annual compensation | ERS valuation, p. 6 and summary |
+| All groups active members | 88,913 | $5,076,945,318 annual compensation | ERS valuation, p. 6 |
+| State employees retirees and beneficiaries | 25,307 | $612,478,873 annual allowances | ERS valuation, summary |
+| State Police retirees and beneficiaries | 1,006 | $51,120,154 annual allowances | ERS valuation, summary |
+| Local employees retirees and beneficiaries | 32,508 | $747,315,149 annual allowances | ERS valuation, summary |
+| All groups retirees and beneficiaries | 58,821 | $1,410,914,176 annual allowances | ERS valuation, summary |
+| State employees deferred vested | 1,248 | $19,298,169 estimated deferred allowances | ERS valuation, summary |
+| State Police deferred vested | 23 | $423,667 estimated deferred allowances | ERS valuation, summary |
+| Local employees deferred vested | 2,425 | $35,409,402 estimated deferred allowances | ERS valuation, summary |
+| All groups deferred vested | 3,696 | $55,131,238 estimated deferred allowances | ERS valuation, summary |
+| Terminated employees entitled to benefits but not receiving | 32,782 total | Not collected | ERS valuation, accounting information |
+| Non-vested inactive members, no contribution for more than 5 years | 26,771 total | Not collected | ERS valuation, accounting information |
+
+### Active Membership By Valuation Class
+
+| Group | Subgroup | Count | Compensation | Source |
+| --- | --- | ---: | ---: | --- |
+| State employees | Tier 1, FLC | 1,470 | $124,710,380 | ERS valuation, Table 1 |
+| State employees | Tier 1, Non-FLC | 11,795 | $870,016,492 | ERS valuation, Table 1 |
+| State employees | Tier 2, FLC | 948 | $65,913,794 | ERS valuation, Table 1 |
+| State employees | Tier 2, Non-FLC | 13,549 | $674,978,445 | ERS valuation, Table 1 |
+| State employees | Post-DROP active service | 76 | $7,781,476 | ERS valuation, Table 1 |
+| State Police | Tier 1, Group 1 | 507 | $46,755,706 | ERS valuation, Table 1 |
+| State Police | Tier 2, Group 1 | 258 | $18,205,184 | ERS valuation, Table 1 |
+| Local employees | Tier 1, FLC | 6,283 | $476,977,239 | ERS valuation, Table 1 |
+| Local employees | Tier 1, Non-FLC | 17,852 | $1,116,892,816 | ERS valuation, Table 1 |
+| Local employees | Tier 2, FLC | 7,230 | $407,060,306 | ERS valuation, Table 1 |
+| Local employees | Tier 2, Non-FLC | 28,914 | $1,264,279,745 | ERS valuation, Table 1 |
+| Local employees | Post-DROP active service | 31 | $3,373,735 | ERS valuation, Table 1 |
+
+### Funding Inputs
+
+| Field | State employees | State Police | Local employees | All groups | Source |
+| --- | ---: | ---: | ---: | ---: | --- |
+| Actuarial accrued liability | $9,465,504,482 | $808,488,304 | $14,002,973,803 | $24,276,966,589 | ERS valuation, summary |
+| Actuarial value of assets | $5,397,929,927 | $413,787,298 | $9,648,953,337 | $15,460,670,562 | ERS valuation, summary |
+| Market value of assets | $5,779,236,225 | $442,954,983 | $10,329,013,731 | $16,551,204,939 | ERS valuation, summary |
+| UAAL based on AVA | $4,067,574,555 | $394,701,006 | $4,354,020,466 | $8,816,296,027 | ERS valuation, summary |
+| Funded ratio based on AVA | 57.0% | 51.2% | 68.9% | 63.7% | ERS valuation, summary |
+| UAAL based on MVA | $3,686,268,257 | $365,533,321 | $3,673,960,072 | $7,725,761,650 | ERS valuation, summary |
+| Funded ratio based on MVA | 61.1% | 54.8% | 73.8% | 68.2% | ERS valuation, summary |
+
+### Receipts And Disbursements, FYE September 30, 2024
+
+| Field | State employees | State Police | Local employees | All groups | Source |
+| --- | ---: | ---: | ---: | ---: | --- |
+| Member contributions | $123,585,490 | $6,251,717 | $232,742,637 | $362,579,844 | ERS valuation, Schedule C |
+| Employer contributions | $265,236,411 | $31,791,295 | $353,180,894 | $650,208,600 | ERS valuation, Schedule C |
+| Total contributions | $389,151,901 | $38,043,012 | $585,923,531 | $1,013,118,444 | ERS valuation, Schedule C |
+| Investment income | $1,042,945,768 | $78,207,568 | $1,818,833,526 | $2,939,986,862 | ERS valuation, Schedule C |
+| Benefit payments | $608,740,092 | $51,012,631 | $739,172,699 | $1,398,925,422 | ERS valuation, Schedule C |
+| Refunds to members | $17,452,667 | $99,484 | $44,340,825 | $61,892,976 | ERS valuation, Schedule C |
+| DROP distributions | $1,848,137 | $0 | $1,074,705 | $2,922,842 | ERS valuation, Schedule C |
+
+### Assumptions And Methods
+
+| Field | Collected value | Source |
+| --- | --- | --- |
+| Actuarial cost method | Entry Age Normal | ERS valuation, letter and funding policy |
+| Asset method | Five-year market-related value | ERS valuation, letter and accounting schedule |
+| Payroll growth for amortization | 2.75% annually | ERS valuation, letter |
+| Investment return | 7.45% | ERS valuation, risk assessment and accounting schedule |
+| Price inflation | 2.50% | ERS valuation, accounting schedule |
+| Salary increases, state and local | 6.00% at service 0; 4.25% for service 1-5; 4.00% for 6-10; 3.75% for 11-15; 3.50% for 16-19; 3.25% for 20+ | ERS valuation, Schedule D |
+| Salary increases, State Police | 7.75% for service 0-3; 7.50% for 4-5; 6.25% for 6; 5.50% for 7-10; 5.25% for 11-14; 4.75% for 15-17; 4.50% for 18-19; 4.00% for 20+ | ERS valuation, Schedule D |
+| COLA assumption | None | ERS valuation, accounting schedule |
+| Experience study cadence | At least every five years | ERS valuation, funding policy |
+
+### Mortality Basis
+
+| Population | Basis | Source |
+| --- | --- | --- |
+| Non-FLC service retirees | Pub-2010 General Healthy Below-Median, male and female +2 years; male 90% under 65 and 96% 65+, female 96% all ages | ERS valuation, Schedule D |
+| FLC / State Police service retirees | Pub-2010 Public Safety Healthy Below-Median, male +1 year, female no age adjustment; no rate adjustment | ERS valuation, Schedule D |
+| Beneficiaries | Pub-2010 Contingent Survivor Below-Median, male and female +2 years; no rate adjustment | ERS valuation, Schedule D |
+| Non-FLC disabled retirees | Pub-2010 General Disability, male +7 years, female +3 years; no rate adjustment | ERS valuation, Schedule D |
+| FLC / State Police disabled retirees | Pub-2010 Public Safety Disability, male +7 years, female no adjustment; no rate adjustment | ERS valuation, Schedule D |
+| Improvement scale | MP-2020, projected generationally, adjusted by 66 2/3% beginning with year 2019 | ERS valuation, Schedule D |
+
+### Decrement Data Collected
+
+The valuation includes withdrawal, death, disability, and retirement sample rates in
+Schedule D. The public extraction captured enough to identify the basis and some
+representative rates, but not a complete machine-readable decrement table for the
+repo input shape.
+
+Useful values:
+
+- No withdrawal decrement after service-retirement eligibility.
+- State/local salary scale and State Police salary scale are service-based.
+- Active death and disability assumptions are shown in the valuation table with
+  base mortality rates before mortality improvement.
+- Death-in-active-service benefit election assumption for those eligible for
+  service retirement: 70% lump sum, 20% Option 2, 10% Option 3.
+
+### Calibration Targets For First Aggregate Model
+
+Recommended starting calibration targets:
+
+| Target | Value |
+| --- | ---: |
+| Active members | 88,913 |
+| Covered payroll | $5,076,945,318 |
+| Retirees and beneficiaries | 58,821 |
+| Annual allowances | $1,410,914,176 |
+| Deferred vested members | 3,696 |
+| Estimated deferred allowances | $55,131,238 |
+| AAL | $24,276,966,589 |
+| AVA | $15,460,670,562 |
+| MVA | $16,551,204,939 |
+| UAAL on AVA | $8,816,296,027 |
+| Funded ratio on AVA | 63.7% |
+| Benefit payments, FYE 2024 | $1,398,925,422 |
+| Refunds, FYE 2024 | $61,892,976 |
+| DROP distributions, FYE 2024 | $2,922,842 |
+

--- a/plans/al_ers/source_notes/source_inventory.md
+++ b/plans/al_ers/source_notes/source_inventory.md
@@ -1,0 +1,38 @@
+# Alabama ERS Source Inventory
+
+Collection date: 2026-04-28
+
+This inventory records the public sources found for a first Alabama ERS
+aggregate model and the local source archive files used by the first
+implementation slice.
+
+## Official Sources Found
+
+| Source | Status | URL | Notes |
+| --- | --- | --- | --- |
+| ERS member handbook | Collected | https://www.rsa-al.gov/uploads/files/ERS_Member_Handbook.pdf | Current public handbook found from the ERS publications page. It supersedes the dated 2023 URL in the collection plan. |
+| ERS publications page | Collected | https://www.rsa-al.gov/ers/publications/ | Starting page for member handbook, DROP brochure, and State Police handbooks. |
+| ERS actuarial valuation, prepared as of September 30, 2024 | Collected | https://www.rsa-al.gov/uploads/files/ERS-Val-2024-9-30.pdf | Latest ERS actuarial valuation listed on the RSA financial reports page at collection time. No FY25 ERS valuation was listed. |
+| RSA employers financial reports page | Collected | https://www.rsa-al.gov/employers/financial-reports/ | Lists ERS FY24 as the latest ERS actuarial valuation. |
+| ERS employer page | Collected | https://www.rsa-al.gov/employers/ers/ | State employer rates effective October 1, 2025 and October 1, 2024; links to local participation and Act 2022-348 material. |
+| RSA Annual Report 2025 | Identified | https://www.rsa-al.gov/uploads/files/RSA_Annual_Report_2025.pdf | Useful for annual financial and investment context. Detailed extraction not completed because the FY24 ERS valuation contains the pension model calibration data needed first. |
+| ERS GASB 68 reports page | Identified | https://www.rsa-al.gov/employers/financial-reports/gasb-68-reports/ | Lists ERS GASB 68 and GASB 67 material for 9/30/2025. Useful for employer allocation accounting, not primary funding input. |
+
+## Local Source Archive
+
+| Local file | Source URL | SHA-256 |
+| --- | --- | --- |
+| `plans/al_ers/source_docs/ERS_Member_Handbook.pdf` | https://www.rsa-al.gov/uploads/files/ERS_Member_Handbook.pdf | `EAE4C3A2FAFA58D7C260AE63B3B1906CCC32894635D2CB15C2E345ED9C18AAE0` |
+| `plans/al_ers/source_docs/ERS-Val-2024-9-30.pdf` | https://www.rsa-al.gov/uploads/files/ERS-Val-2024-9-30.pdf | `995247C06284712556A6A0BDB5CE60A65C86EBC25F081B962874FE1143EEB6B9` |
+| `plans/al_ers/source_docs/RSA_Annual_Report_2025.pdf` | https://www.rsa-al.gov/uploads/files/RSA_Annual_Report_2025.pdf | `A30080CBC6EB730C7C4D4E7EC78ADDA89EF719AE6E15D800D285AD1F7CB67B90` |
+
+## Latest-Document Check
+
+- The collection plan's Alabama handbook URL used `ERS_Member_Handbook_2023.pdf`.
+  The current public URL found in this pass is
+  `https://www.rsa-al.gov/uploads/files/ERS_Member_Handbook.pdf`.
+- The RSA financial reports page listed ERS FY24 as the latest actuarial
+  valuation. The report is prepared as of September 30, 2024 and dated
+  May 21, 2025.
+- FY25 ERS GASB material is available, but the FY25 funding valuation was not
+  found on the official financial reports page at collection time.

--- a/plans/ar_apers/source_notes/data_gaps.md
+++ b/plans/ar_apers/source_notes/data_gaps.md
@@ -1,0 +1,56 @@
+# Arkansas APERS Data Gaps
+
+Collection date: 2026-04-28
+
+The public valuation and handbook support a first aggregate model, and APERS
+publishes more usable demographic schedules than Alabama ERS. A production-grade
+projection still needs data that is not public in the collected sources.
+
+## Must-Have But Unavailable From Public Sources
+
+| Data need | Why it is must-have | Public substitute available | Gap severity |
+| --- | --- | --- | --- |
+| Active census split by actual service, credited service, contribution design, hire date, elected-official status, employer group, and DROP status | APERS eligibility and benefits depend on actual service, credited service, contributory status, hire cohort, and enhanced elected-official credit | Valuation includes aggregate active counts/payroll by attained age and service and total active payroll | High |
+| Service-segment history by member or group | Multipliers differ by non-contributory vs contributory and pre/post July 1, 2007 service | Handbook gives segment multipliers; public reports do not provide segment balances | High |
+| Hire cohort split around July 1, 2022 | FAC and COLA rules depend on first employment before/on-after July 1, 2022 | Handbook gives rules; valuation does not publish a cohort cross-tab | High |
+| Full age-service-salary grid by contribution design and employer group | Required to build separate model classes without synthetic allocation | Valuation has an active age-service count/payroll grid for State and Local Division, but not by all modeling dimensions | High |
+| Complete retirement, withdrawal, disability, and death rates in machine-readable format | Required for decrement input CSVs | Valuation has public assumption tables and actual-vs-expected schedules; full digitization and QA still needed | High |
+| Base Pub-2010 mortality rates and MP-2021 improvement scale in repo CSV shape | Required for `base_rates.csv` and `improvement_scale.csv` | Valuation describes table basis and percentages | High |
+| DROP account balances, entry cohorts, expected duration distribution, and payout elections | Needed if DROP is modeled explicitly beyond aggregate payroll and liability loads | Handbook and valuation give eligibility, crediting rate, duration cap, and reported DROP/returned-retiree payroll | Medium |
+| Member-level or employer-level elected official enhanced credit history | Enhanced service and additional contributions require elected-official status and start date | Handbook and employer page give rules and additional contribution rates | Medium |
+| Employer reporting work-report import samples and data dictionary, fully archived | Useful to map employer files to model fields | Employer reporting page links design specifications and samples; this pass did not download them | Medium |
+| FY2025 ACFR | Useful for final audited financial statement reconciliation | FY2024 ACFR is latest listed on public APERS reports/publications pages; FY2025 valuation provides current funding values | Low to medium |
+| Experience Study dated May 10, 2023 | Needed to validate complete decrement basis and any smoothing/credibility choices | Valuation cites it and includes assumption tables; standalone report was not collected in this pass | Medium |
+
+## Public But Not Yet Digitized
+
+- Active members by attained age and years of service from the June 30, 2025
+  valuation, pages B-17 and following.
+- APERS retirement assumption tables, pages E-4 through E-6.
+- APERS separation, death, disability, and pay-increase assumptions, pages E-7
+  and E-8.
+- Salary increase actual-vs-expected schedule, pages C-13 and following.
+- APERS employer reporting import specifications and samples linked from the
+  employer reporting page.
+- APERS Funding Policy linked from the Board of Trustees page.
+
+## Recommended Requests To APERS
+
+1. Anonymized valuation census extract with date of birth, gender, actual
+   service, credited service, pay, contribution design, hire date, employer
+   group, elected-official status, enhanced service, reciprocal service, and
+   DROP status.
+2. Service-segment extract or tabulation splitting service by non-contributory,
+   contributory, pre-July 1 2007, post-July 1 2007, elected official enhanced
+   credit, and reciprocal service.
+3. Retiree census or tabulation by age, benefit amount, benefit type, option,
+   COLA cohort, DROP status, and employer group.
+4. DROP participant file with entry date, service at entry, frozen benefit,
+   account balance, interest credits, and elected payout form.
+5. Complete assumption workbook or machine-readable tables from the 2023
+   experience study.
+6. Employer reporting specifications and samples if the system will ingest
+   employer-submitted work reports directly.
+7. Machine-readable mortality table adjustments or confirmation to use SOA
+   Pub-2010 base tables with the valuation percentages and MP-2021 scale.
+

--- a/plans/ar_apers/source_notes/extraction_notes.md
+++ b/plans/ar_apers/source_notes/extraction_notes.md
@@ -1,0 +1,204 @@
+# Arkansas APERS Extraction Notes
+
+Collection date: 2026-04-28
+
+## Public Data Collected
+
+### Plan Identity
+
+| Field | Value | Source |
+| --- | --- | --- |
+| Plan id | `ar_apers` | Local collection plan |
+| Plan name | Arkansas Public Employees' Retirement System | APERS handbook, p. 6 |
+| Plan type | Governmental defined benefit plan qualified under IRC section 401(a) | APERS handbook, p. 6 |
+| Plan year | July 1 through June 30 | APERS handbook, p. 6 |
+| Valuation date | June 30, 2025 | APERS valuation |
+| Main employer groups | State, county, municipal, non-state, public schools closed group, Game and Fish wildlife officers, Military Department civilian firefighters, District Judges | APERS employer reporting page |
+
+### Membership And Service
+
+| Field | Collected value | Source |
+| --- | --- | --- |
+| Membership condition | Hired by an APERS participating employer with intent to work at least 90 consecutive calendar days, working at least 80 hours per month, and earning at least federal minimum wage | APERS handbook, p. 10 |
+| Member contribution applicability | Members first hired on or after July 1, 2005 contribute a portion of pre-tax salary | APERS handbook, p. 10 |
+| Actual service | One month per month worked if 80 hours are worked in the month; 11 months in a fiscal year credits 12 months | APERS handbook, p. 12 |
+| Partial service, employer FAQ | 20-39 hours = 1/4 month; 40-59 = 1/2 month; 60-79 = 3/4 month; 80+ = 1 month | APERS employers FAQ |
+| Elected official enhanced credit | County and municipal elected officials earn two months per month worked; contributory members capped at 10 years enhanced credit | APERS handbook, p. 12 |
+| Enhanced credit contributions | Non-contributory officials first elected on or after July 1, 2011 contribute 2.5%; contributory officials first elected on or after January 1, 2014 contribute an additional 2.5%; employer also contributes additional 2.5% | APERS handbook, p. 12 |
+
+### Contribution Rates
+
+| Field | Collected value | Source |
+| --- | --- | --- |
+| Standard employer group rate through June 30, 2025 | 15.32% | APERS employer reporting page |
+| Public Schools closed group employer rate through June 30, 2025 | 4.00% | APERS employer reporting page |
+| Game and Fish wildlife officers employer rate through June 30, 2025 | 27.32% | APERS employer reporting page |
+| Military Department civilian firefighters employer rate through June 30, 2025 | 27.32% | APERS employer reporting page |
+| ADJRS District Judges employer rate through June 30, 2025 | 67.13% | APERS employer reporting page |
+| Member contribution rate through June 30, 2022 | 5.00% | APERS employer reporting page |
+| Member contribution rate July 1, 2025 | 6.00% | APERS employer reporting page |
+| Member contribution rate July 1, 2027 | 6.50% | APERS employer reporting page and valuation |
+| Member contribution rate July 1, 2029 and later | 7.00% | APERS employer reporting page |
+| FY2028 preliminary computed employer contribution rate | 14.98% | APERS valuation, p. A-3 |
+| FY2028 board adopted minimum employer contribution rate | 15.32% | APERS valuation, p. A-3 |
+| Employer normal cost, total | 7.06% of active payroll | APERS valuation, p. A-3 |
+| UAAL contribution component | 7.92% of active payroll | APERS valuation, p. A-3 |
+| Total active payroll used for FY2028 contribution rate | $2,345,789,662 including DROP and returned-retiree payroll | APERS valuation, p. A-3 |
+
+### Retirement Provisions
+
+| Field | Collected value | Source |
+| --- | --- | --- |
+| Normal retirement | Age 65 with 5 years actual service; age 55 with 35 years credited service for enhanced-credit members; any age with 28 years actual service | APERS handbook, p. 18 |
+| Service beyond 28 years | Additional calculation for each month beyond 28 years using 0.5% multiplier | APERS handbook, p. 18 |
+| Early retirement | Age 55 with 5 years actual service; any age with at least 25 years actual service; within 10 years of normal retirement for enhanced-credit members | APERS handbook, p. 18 |
+| Early retirement reduction | Lesser of 0.5% per month from age 65 or 1.0% per month from 28 years of service | APERS handbook, p. 18 |
+| FAC for members first employed before July 1, 2022 | Highest 3 fiscal years | APERS handbook, p. 22 |
+| FAC for members first employed on or after July 1, 2022 | Highest 5 fiscal years | APERS handbook, p. 22 |
+| Non-contributory multiplier through June 30, 2007 | 1.75% | APERS handbook, p. 22 |
+| Non-contributory multiplier on or after July 1, 2007 | 1.72% | APERS handbook, p. 22 |
+| Contributory multiplier July 1, 2005 through June 30, 2007 | 2.03% | APERS handbook, p. 22 |
+| Contributory multiplier on or after July 1, 2007 | 2.00% | APERS handbook, p. 22 |
+| COLA, first hired before July 1, 2022 | 3% every July 1 after at least 12 months retired; also applies to DROP participants after at least 12 months | APERS handbook, p. 26 |
+| COLA, first hired after July 1, 2022 | Lesser of 3% or CPI-W change over the year ending the prior December | APERS handbook, p. 26 |
+| PAW | Lump sum up to 60 months of retirement benefit for members who work beyond unreduced eligibility; annuity reduced by actuarial factor | APERS handbook, p. 25 |
+| Refund | Refund of member contributions and accrued interest available 30 days after terminating covered employment; refund forfeits retirement benefit | APERS handbook, p. 25 |
+
+### DROP
+
+| Field | Collected value | Source |
+| --- | --- | --- |
+| DROP eligibility | 28 years actual service, including reciprocal service | APERS handbook, p. 28 |
+| DROP maximum duration | 120 months / 10 years | APERS handbook, p. 28; APERS valuation |
+| DROP benefit percentage at 28 years | 63% of calculated annuity for each month of DROP participation | APERS handbook, p. 28 |
+| DROP benefit percentage increase | +0.5% for each additional month of service, capped at 75% with 30 years actual service | APERS handbook, p. 28 |
+| DROP interest credit assumption | 3.0% | APERS valuation, p. E-10 |
+| DROP / returned retiree payroll | Approximately $138 million reported for the June 30, 2025 valuation | APERS valuation, p. E-10 |
+
+### Valuation And Funding
+
+| Field | Value | Source |
+| --- | ---: | --- |
+| Active members | 43,490 | APERS valuation, historical comparative schedule |
+| Valuation payroll, excluding DROP payroll | $2,207.6 million | APERS valuation, historical comparative schedule |
+| Average active pay | $50,761 | APERS valuation, historical comparative schedule |
+| Retired lives, including DROP members | 43,148 | APERS valuation, historical comparative schedule |
+| Annual retired-life benefits | $755.9 million | APERS valuation, historical comparative schedule |
+| Retired benefits as % of payroll | 34.2% | APERS valuation, historical comparative schedule |
+| Net assets from financial statements | $11,897,331,205 | APERS valuation, p. A-5 |
+| Market value adjustment | $(433,816,791) | APERS valuation, p. A-5 |
+| Funding / valuation assets | $11,463,514,414 | APERS valuation, p. A-5 |
+| AAL | $13,886,118,836 | APERS valuation, p. A-6 |
+| UAAL | $2,422,604,422 | APERS valuation, p. A-5/A-6 |
+| Funded ratio | 82.6% | APERS valuation, p. A-6 |
+| Present value of future employer contributions, normal cost | $1,066,495,487 | APERS valuation, p. A-5 |
+| Present value of future employer contributions, UAAL | $2,422,604,422 | APERS valuation, p. A-5 |
+| Present value of future member contributions | $1,151,447,615 | APERS valuation, p. A-5 |
+| APV of expected future benefit payments | $16,104,061,938 | APERS valuation, p. A-5 |
+| Liability for current retirees and beneficiaries | $7,326,551,498 | APERS valuation, p. A-6 |
+| Liability for vested terminated members | $732,262,193 | APERS valuation, p. A-5 |
+| Liability for present active and DROP members, prior service | $5,827,305,145 | APERS valuation, p. A-5 |
+| Liability for present active and DROP members, future service | $2,217,943,102 | APERS valuation, p. A-5 |
+| Weighted average remaining financing period | 15.5 years | APERS valuation, p. A-4 |
+
+### Deferred And Retiree Distribution Data
+
+| Field | Value | Source |
+| --- | ---: | --- |
+| Present inactive members with annuities likely to be paid | 15,351 | APERS valuation, p. B-17 |
+| Estimated annual inactive-member annuities | $99,212,364 | APERS valuation, p. B-17 |
+| Inactive-member deferred annuity liabilities | $732,262,193 | APERS valuation, p. B-17 |
+| New age-and-service retirees | 1,797 | APERS valuation, p. B-16 |
+| New age-and-service retiree average age | 63.3 | APERS valuation, p. B-16 |
+| New age-and-service retiree average service | 17.4 | APERS valuation, p. B-16 |
+| New age-and-service retiree average monthly benefit | $1,471 | APERS valuation, p. B-16 |
+| New disability retirees | 135 | APERS valuation, p. B-16 |
+| New disability retiree average age | 56.0 | APERS valuation, p. B-16 |
+| New disability retiree average service | 14.7 | APERS valuation, p. B-16 |
+| New disability retiree average monthly benefit | $1,033 | APERS valuation, p. B-16 |
+
+Public deferred-by-age data collected from valuation p. B-17:
+
+| Attained age | Count | Estimated annual annuity |
+| --- | ---: | ---: |
+| Under 40 | 1,684 | $10,745,952 |
+| 40-44 | 1,803 | $13,159,416 |
+| 45-49 | 2,384 | $17,017,284 |
+| 50-54 | 3,076 | $21,034,536 |
+| 55-59 | 2,931 | $18,213,876 |
+| 60-64 | 2,121 | $13,203,804 |
+| 65 and over | 1,352 | $5,837,496 |
+| Total | 15,351 | $99,212,364 |
+
+### Assumptions And Methods
+
+| Field | Collected value | Source |
+| --- | --- | --- |
+| Experience study basis | Experience Study for July 1, 2017 through June 30, 2022, report dated May 10, 2023 | APERS valuation, p. E-1 |
+| Investment return | 7.00%, compounded annually, net after investment expenses | APERS valuation, p. E-1 |
+| Wage inflation / payroll growth | 3.25% | APERS valuation, p. E-1 |
+| Price inflation | 2.50% | APERS valuation, p. E-1 |
+| Real wage growth | 0.75% | APERS valuation, p. E-1 |
+| Active headcount projection | Number of active members assumed to continue at present number | APERS valuation, p. E-1 |
+| Cost method | Individual entry-age normal actuarial cost method | APERS valuation, p. E-2 |
+| APERS amortization | Level percent-of-payroll; remaining UAAL from 2023 valuation over 17-year closed period; annual gains/losses and assumption changes over new 20-year closed periods | APERS valuation, p. E-2 |
+| Benefit provision increases | Closed 15-year period for active members and 5-year period for non-active members | APERS valuation, p. E-2 |
+| Benefit provision decreases | Closed 30-year period for active members and 15-year period for non-active members | APERS valuation, p. E-2 |
+| Asset method | Market-related value with differences between actual and assumed returns phased in over 4 years, bounded by 25% of market value | APERS valuation, p. E-2 |
+| Administrative expense load | 0.40% of payroll | APERS valuation, p. E-10 |
+| Pay increase timing | Beginning of fiscal year | APERS valuation, p. E-9 |
+| Decrement timing | Mid-year | APERS valuation, p. E-9 |
+| Normal form | Straight life | APERS valuation, p. E-9 |
+
+### Mortality Basis
+
+| Population | Basis | Source |
+| --- | --- | --- |
+| Healthy retirees | 114% male and 132% female of PubG-2010 Amount-Weighted Below-Median Income General Retiree Mortality tables | APERS valuation, p. E-1 |
+| Disabled retirees | 114% male and 132% female of PubNS-2010 Amount-Weighted Disabled Retiree Mortality tables | APERS valuation, p. E-1 |
+| Pre-retirement mortality | 75% of PubG-2010 Amount-Weighted Below-Median General Employee Mortality tables | APERS valuation, p. E-1 |
+| Improvement scale | MP-2021, fully generational | APERS valuation, p. E-1/E-3 |
+| Duty / ordinary deaths-in-service weighting | 0% duty / 100% ordinary | APERS valuation, p. E-10 |
+
+### Decrement And Experience Data Collected
+
+The valuation contains public decrement assumption tables on pages E-4 through
+E-8 and experience schedules on pages C-7 through C-13. This pass collected the
+high-level values needed to scope model inputs, but did not fully digitize the
+tables into repo CSV format.
+
+Useful public experience values:
+
+| Experience item, July 1, 2024 to June 30, 2025 | Actual | Expected | Source |
+| --- | ---: | ---: | --- |
+| Reduced early retirements | 205 | 318 | APERS valuation, p. C-8 |
+| Retirements with 28+ years of service | 337 | 480 | APERS valuation, p. C-9 |
+| DROP entries | 73 | Not available | APERS valuation, p. C-9 |
+| Disability retirements | 25 | 80 | APERS valuation, p. C-10 |
+| Vested separations | 943 | 1,059 | APERS valuation, p. C-11 |
+| Non-vested separations | 4,451 | 4,279 | APERS valuation, p. C-12 |
+
+### Calibration Targets For First Aggregate Model
+
+Recommended starting calibration targets:
+
+| Target | Value |
+| --- | ---: |
+| Active members | 43,490 |
+| Valuation payroll, excluding DROP payroll | $2,207,600,000 |
+| Total payroll for contribution rate, including DROP/returned retiree payroll | $2,345,789,662 |
+| Retired lives including DROP members | 43,148 |
+| Annual retired-life benefits | $755,900,000 |
+| Inactive deferred count | 15,351 |
+| Inactive estimated annual annuities | $99,212,364 |
+| AAL | $13,886,118,836 |
+| AVA / funding assets | $11,463,514,414 |
+| Net assets from financial statements | $11,897,331,205 |
+| UAAL | $2,422,604,422 |
+| Funded ratio | 82.6% |
+| Employer normal cost | 7.06% |
+| UAAL contribution component | 7.92% |
+| Preliminary computed employer rate | 14.98% |
+| Board adopted minimum employer rate | 15.32% |
+| Member contribution rate for valuation period beginning July 1, 2027 | 6.50% |
+

--- a/plans/ar_apers/source_notes/source_inventory.md
+++ b/plans/ar_apers/source_notes/source_inventory.md
@@ -1,0 +1,38 @@
+# Arkansas APERS Source Inventory
+
+Collection date: 2026-04-28
+
+This inventory records the public sources found for a first Arkansas APERS
+aggregate model and the local source archive files used by the first
+implementation slice.
+
+## Official Sources Found
+
+| Source | Status | URL | Notes |
+| --- | --- | --- | --- |
+| APERS member handbook, updated 12.12.2025 | Collected | https://apers.org/wp-content/uploads/APERS-Handbook_Updated_-12.12.2025.pdf | Newer than the 05-01-2025 handbook listed in the collection plan. |
+| APERS member handbook, updated 05-01-2025 | Superseded | https://www.apers.org/wp-content/uploads/APERS-Handbook_Updated_05-01-2025.pdf | Earlier handbook found during planning. |
+| APERS actuarial valuation, June 30, 2025 | Collected | https://apers.org/wp-content/uploads/APERS-June-30-2025-Pension-Valuation-Report.pdf | Current valuation found directly; report dated October 31, 2025. |
+| APERS employer reporting page | Collected | https://apers.org/employers/employer-reporting/ | Employer rates, member contribution ramp, reporting concepts, and links to import specs. |
+| APERS employers page | Collected | https://apers.org/employers/ | Eligibility and service-credit FAQ, including hours-to-service conversion. |
+| APERS ACFR FY2024 | Identified | https://apers.org/wp-content/uploads/APERS-ACFR-24-web.pdf | Latest ACFR listed on APERS publications/reports pages at collection time. |
+| APERS reports and resources page | Collected | https://apers.org/investments/reports-and-resources/ | Listed FY2024 and FY2023 ACFR and valuation links on the crawled page; direct FY2025 valuation URL was also available. |
+| APERS Board of Trustees page | Identified | https://apers.org/about/board-of-trustees/ | Links to Funding Policy, Investment Policy Statement, board meetings, and board rules. |
+
+## Local Source Archive
+
+| Local file | Source URL | SHA-256 |
+| --- | --- | --- |
+| `plans/ar_apers/source_docs/APERS-Handbook_Updated_-12.12.2025.pdf` | https://apers.org/wp-content/uploads/APERS-Handbook_Updated_-12.12.2025.pdf | `B81F0132039670FAE151E85CD33419718350C9DC01F1470A54FA0329DC31CDD5` |
+| `plans/ar_apers/source_docs/APERS-June-30-2025-Pension-Valuation-Report.pdf` | https://apers.org/wp-content/uploads/APERS-June-30-2025-Pension-Valuation-Report.pdf | `2CFB91A98744D3C0A1A3EEBEC627F0F11CA42ACF4DD3B082F1A141A1F0CCC0BE` |
+| `plans/ar_apers/source_docs/APERS-ACFR-24-web.pdf` | https://apers.org/wp-content/uploads/APERS-ACFR-24-web.pdf | `4A63EC82A44260BA8C50C5BBB09C63C5678326288D636B4460D746F8A6F774AC` |
+
+## Latest-Document Check
+
+- The collection plan's APERS handbook URL pointed to the 05-01-2025 version.
+  A newer handbook updated 12.12.2025 was found and used.
+- The June 30, 2025 pension valuation report was found and used as the main
+  valuation source. It determines the employer contribution rate for the fiscal
+  year beginning July 1, 2027.
+- The APERS publications/reports pages still listed FY2024 ACFR as the latest
+  ACFR at collection time. A FY2025 ACFR was not found in this pass.

--- a/plans/frs/config/plan_config.json
+++ b/plans/frs/config/plan_config.json
@@ -318,6 +318,8 @@
   "modeling": {
     "use_earliest_retire": false,
     "term_vested_method": "growing_annuity",
+    "cashflow_discount_basis": "baseline_dr_current",
+    "valuation_discount_basis": "scenario_dr_current",
     "male_mp_forward_shift": 0,
     "age_groups": [
       {"max_age": 24, "label": "under_25"},

--- a/src/pension_model/config_loading.py
+++ b/src/pension_model/config_loading.py
@@ -83,6 +83,8 @@ def load_plan_config(
     with open(config_path) as f:
         raw = json.load(f)
 
+    baseline_economic = dict(raw.get("economic", {}))
+
     scenario_name = None
     if scenario_path is not None:
         with open(scenario_path) as f:
@@ -90,6 +92,7 @@ def load_plan_config(
         scenario_name = scenario.get("name", scenario_path.stem)
         raw = _deep_merge(raw, scenario.get("overrides", {}))
 
+    raw["_baseline_economic"] = baseline_economic
     if scenario_name:
         raw["_scenario_name"] = scenario_name
 

--- a/src/pension_model/config_schema.py
+++ b/src/pension_model/config_schema.py
@@ -75,6 +75,37 @@ class PlanConfig:
     def scenario_name(self) -> Optional[str]:
         return self.raw.get("_scenario_name")
 
+    @property
+    def baseline_dr_current(self) -> float:
+        return self.raw.get("_baseline_economic", {}).get("dr_current", self.dr_current)
+
+    def _resolve_discount_rate_basis(self, basis: str) -> float:
+        basis_rates = {
+            "scenario_dr_current": self.dr_current,
+            "baseline_dr_current": self.baseline_dr_current,
+        }
+        try:
+            return basis_rates[basis]
+        except KeyError as exc:
+            valid = ", ".join(sorted(basis_rates))
+            raise ValueError(f"Unknown discount-rate basis {basis!r}; expected one of {valid}") from exc
+
+    @property
+    def cashflow_discount_basis(self) -> str:
+        return self.raw.get("modeling", {}).get("cashflow_discount_basis", "scenario_dr_current")
+
+    @property
+    def valuation_discount_basis(self) -> str:
+        return self.raw.get("modeling", {}).get("valuation_discount_basis", "scenario_dr_current")
+
+    @property
+    def cashflow_discount_rate(self) -> float:
+        return self._resolve_discount_rate_basis(self.cashflow_discount_basis)
+
+    @property
+    def valuation_discount_rate(self) -> float:
+        return self._resolve_discount_rate_basis(self.valuation_discount_basis)
+
     def resolve_data_dir(self) -> Path:
         data_cfg = self.raw.get("data", {})
         data_dir_str = data_cfg.get("data_dir", f"plans/{self.plan_name}/data")

--- a/src/pension_model/core/pipeline_current.py
+++ b/src/pension_model/core/pipeline_current.py
@@ -149,7 +149,8 @@ def compute_current_term_vested_liability(class_name: str, constants) -> pd.Data
     class_data = constants.class_data[class_name]
 
     pvfb_term_current = class_data.pvfb_term_current
-    discount_rate = constants.economic.dr_current
+    cashflow_discount_rate = constants.cashflow_discount_rate
+    valuation_discount_rate = constants.valuation_discount_rate
     payroll_growth = constants.economic.payroll_growth
     amo_period = constants.funding.amo_period_term
     years = list(range(ranges.start_year, ranges.start_year + ranges.model_period + 1))
@@ -163,10 +164,10 @@ def compute_current_term_vested_liability(class_name: str, constants) -> pd.Data
         )
         ann_ratio = amo_weights / amo_weights[0]
 
-        first_payment = pvfb_term_current / _npv(discount_rate, ann_ratio)
+        first_payment = pvfb_term_current / _npv(valuation_discount_rate, ann_ratio)
         term_payments = first_payment * ann_ratio
         full_stream = np.concatenate(([0.0], term_payments))
-        full_aal = _roll_npv(discount_rate, full_stream)
+        full_aal = _roll_npv(valuation_discount_rate, full_stream)
 
         retire_ben_term_est = np.zeros(len(years))
         aal_term_current = np.zeros(len(years))
@@ -176,7 +177,13 @@ def compute_current_term_vested_liability(class_name: str, constants) -> pd.Data
             if i < len(full_aal):
                 aal_term_current[i] = full_aal[i]
     else:
-        retire_ben_term = _get_pmt(discount_rate, payroll_growth, amo_period, pvfb_term_current, t=1)
+        retire_ben_term = _get_pmt(
+            cashflow_discount_rate,
+            payroll_growth,
+            amo_period,
+            pvfb_term_current,
+            t=1,
+        )
         amo_years = list(range(ranges.start_year + 1, ranges.start_year + 1 + amo_period))
         retire_ben_term_est = np.zeros(len(years))
         term_payments = _recur_grow3(retire_ben_term, payroll_growth, amo_period)
@@ -187,7 +194,7 @@ def compute_current_term_vested_liability(class_name: str, constants) -> pd.Data
                     retire_ben_term_est[i] = term_payments[idx]
 
         aal_term_current = _roll_pv(
-            discount_rate,
+            valuation_discount_rate,
             payroll_growth,
             amo_period,
             retire_ben_term_est,

--- a/tests/test_pension_model/test_plan_config_frs.py
+++ b/tests/test_pension_model/test_plan_config_frs.py
@@ -1,10 +1,12 @@
 """FRS-specific PlanConfig tests."""
 
+from pathlib import Path
+
 import pytest
 
 pytestmark = [pytest.mark.unit]
 
-from pension_model.plan_config import load_frs_config
+from pension_model.plan_config import load_frs_config, load_plan_config
 
 
 @pytest.fixture(scope="module")
@@ -38,3 +40,18 @@ class TestPlanConfigLoad:
         assert frs_config._tier_name_to_id == {"tier_1": 0, "tier_2": 1, "tier_3": 2}
         assert frs_config._tier_id_to_name == ("tier_1", "tier_2", "tier_3")
         assert frs_config._tier_id_to_fas_years == (5, 8, 8)
+
+    def test_frs_high_discount_rate_roles(self):
+        root = Path(__file__).parents[2]
+        config = load_plan_config(
+            root / "plans" / "frs" / "config" / "plan_config.json",
+            root / "plans" / "frs" / "config" / "calibration.json",
+            root / "scenarios" / "high_discount.json",
+        )
+
+        assert config.baseline_dr_current == 0.067
+        assert config.dr_current == 0.075
+        assert config.cashflow_discount_basis == "baseline_dr_current"
+        assert config.valuation_discount_basis == "scenario_dr_current"
+        assert config.cashflow_discount_rate == 0.067
+        assert config.valuation_discount_rate == 0.075


### PR DESCRIPTION
…baseline/scenario economics and add high discount rate plan docs/tests.

To Don: 

The high_discount scenario results mismatch between the R version and Python version came from current term-vested liabilities. R builds the nominal current term-vested payment stream with the baseline discount rate (6.7%), then revalues that stream with the scenario discount rate (7.5%). Python was using the scenario rate for both steps, which changed the payment stream itself and produced the R/Python differences.

This fix preserves baseline economics before scenario overrides, adds explicit cashflow_discount_rate (i.e. 6.7% in the scenario) and valuation_discount_rate (i.e. 7.5% in high discount rate scenario), and updates current term-vested liability logic to use the cashflow rate for payment construction and the valuation rate for present value calculations. The fix  is done in a generalizable way so that the separate cashflow discount rate and valuation discount rate can be used for other parts of the benefits and liabilities. 

Verification passed: all requested FRS/TXTRS scenario runs passed, and the full suite passed with

see "memory-bank\high_discount_rate_plan.md" for the context and plan. Step 1 and Step 2 are implemented in this pull request.