### PR TITLE
Add meta-docs/writing_style.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,7 @@ This is a Python pension simulation model. Three project-level reference docs ap
 - **[`meta-docs/repo_goals.md`](meta-docs/repo_goals.md)** — purpose, priority order (Match R → Generalize → Optimize → Extend), design principles, project procedures (feature-branch workflow, no merge without permission, file issues don't silently fix, phase-label every issue).
 - **[`meta-docs/pension_math.md`](meta-docs/pension_math.md)** — actuarial math reference. Many model operations have closed-form or recursive shortcuts (commutation functions, annuity factors); many current implementations are approximations with known limits and tracked issues. When proposing a change, ask whether the math can simplify or accelerate it before reaching for ad-hoc code.
 - **[`meta-docs/workflow.md`](meta-docs/workflow.md)** — how to update these meta files. Meta-doc edits go on their own short-lived branch with a PR, never bundled with feature work, never directly to main. Same workflow as feature work but separated.
+- **[`meta-docs/writing_style.md`](meta-docs/writing_style.md)** — plain-English writing rules for docs, PR descriptions, issue and PR comments, and end-of-task summaries. Default to plain English; translate jargon; cut dead words.
 
 ## Quick rules
 
@@ -12,10 +13,6 @@ This is a Python pension simulation model. Three project-level reference docs ap
 - Every open issue must carry exactly one phase label: `phase-r-is-truth` (R-phase work), `phase-post-r` (deferred), or `phase-anytime` (orthogonal — data-prep, provenance, docs, tooling).
 - The core projection (year-by-year solve from stage-3 inputs through final results) is the only place runtime matters. Data prep, loading, and tests can be slow.
 - Validation against R baselines must hold to floating-point precision (~1e-15 relative). "Inherent R-vs-Python differences" is not an acceptable explanation for divergence.
-
-## Writing style
-
-In docs, PR descriptions, comments, and any prose the user reads or shares with collaborators, **default to plain English, not actuarial/quant/programming jargon**. Reserve technical terms for code-level references (function names, config keys, column names). For prose, paraphrase: "synthetic payment stream" → "estimated stream of future payments"; "PV the cashflows" → "compute today's value of the cashflows"; "anchored to data meaning" → describe the actual constraint plainly. When in doubt, ask: would a smart engineer who hasn't touched actuarial work understand this sentence in isolation?
 
 ## Other docs
 

--- a/meta-docs/writing_style.md
+++ b/meta-docs/writing_style.md
@@ -44,6 +44,21 @@ sentence?
 | anchored to data meaning | (describe the actual constraint plainly) |
 | stage-3 inputs | model inputs |
 
+## Avoid developer shorthand
+
+These phrases are common in developer culture but read as insider talk
+to anyone outside it. Prefer the literal version.
+
+| Avoid | Use |
+|---|---|
+| Two things land here | This PR does two things |
+| this lands X | this adds X / this does X |
+| ship the feature | release the feature |
+| spin up a service | start a service |
+| stand up an environment | set up an environment |
+| kick off the run | start the run |
+| wire up | connect / hook up |
+
 ## When jargon is fine
 
 Identifiers — function names, configuration keys, column names, file

--- a/meta-docs/writing_style.md
+++ b/meta-docs/writing_style.md
@@ -1,0 +1,59 @@
+# Writing Style
+
+This applies to all prose a colleague might read: docs, PR descriptions,
+issue and PR comments, code review comments, commit messages, and
+end-of-task summaries.
+
+**Default to plain English.** Reserve technical terms for code-level
+references — function names, configuration keys, column names, formula
+identifiers, file paths.
+
+## Drop dead words
+
+Prefer the shorter form when it carries the same meaning.
+
+| Avoid | Use |
+|---|---|
+| build out | build |
+| leverage | use |
+| utilize | use |
+| in order to | to |
+| at this point in time | now |
+| due to the fact that | because |
+| a wide variety of | many |
+| in the event that | if |
+| with regard to | about |
+| has the ability to | can |
+
+## Translate jargon
+
+Don't expect a reader to know terms specific to actuarial, accounting,
+or programming traditions. Paraphrase. The rule of thumb: would a smart
+reader who hasn't worked in this domain understand the surrounding
+sentence?
+
+| Avoid | Use |
+|---|---|
+| scaffolding | (describe what was added) |
+| upstream prep system | tools for preparing input data |
+| source registry | record of source documents |
+| provenance ledger | record of where each piece of data came from |
+| AV-first plan | a plan built from its published valuation report |
+| synthetic payment stream | estimated stream of future payments |
+| PV the cashflows | compute today's value of those cashflows |
+| anchored to data meaning | (describe the actual constraint plainly) |
+| stage-3 inputs | model inputs |
+
+## When jargon is fine
+
+Identifiers — function names, configuration keys, column names, file
+paths, citations — stay as-is. Rewriting them loses precision.
+
+In code comments, write what the surrounding code does not already say.
+A clear name beats a comment that restates it.
+
+## Test before posting
+
+Read your draft as if you didn't write it. If a sentence makes you
+reach for a term's meaning, paraphrase. If a paragraph is dense, break
+it up. If a word is doing nothing, cut it.


### PR DESCRIPTION
## Summary

Promotes the short "Writing style" paragraph in `CLAUDE.md` into a discoverable meta-doc at `meta-docs/writing_style.md`, with concrete substitution tables for jargon and dead words.

The rule itself is unchanged — default to plain English, reserve technical terms for code-level identifiers. The new file just makes the rule easier to apply by listing common offenders side-by-side with the plain-English replacement, including some that have shown up recently in PR descriptions and comments ("scaffolding", "AV-first plan", "build out", "stage-3 inputs").

`CLAUDE.md` now points at the new file instead of carrying the rule inline.

## Why now

Writing-style drift in PR descriptions and comments has been noticeable. A discoverable, scannable reference is more useful than an inline paragraph buried in `CLAUDE.md`.

## Test plan
- [ ] `meta-docs/writing_style.md` opens cleanly and renders as expected on GitHub
- [ ] `CLAUDE.md` writing-style paragraph is replaced by a one-line pointer to the new file
- [ ] No code or runtime files are touched by this PR