### PR TITLE
Read current_term_vested_cashflow.csv from data prep (issue #76 part 2)

### DIFF
--- a/plans/frs/config/plan_config.json
+++ b/plans/frs/config/plan_config.json
@@ -317,7 +317,6 @@
 
   "modeling": {
     "use_earliest_retire": false,
-    "term_vested_method": "growing_annuity",
     "male_mp_forward_shift": 0,
     "age_groups": [
       {"max_age": 24, "label": "under_25"},

--- a/plans/txtrs-av/config/plan_config.json
+++ b/plans/txtrs-av/config/plan_config.json
@@ -257,7 +257,6 @@
     "scope_rule": "This file is built from valuation-supported plan shape and valuation-linked runtime needs, not by copying txtrs runtime semantics wholesale.",
     "omitted_runtime_legacy_fields": [
       "retire_refund_ratio",
-      "term_vested_method",
       "use_earliest_retire",
       "cash_balance",
       "dc",

--- a/plans/txtrs/config/plan_config.json
+++ b/plans/txtrs/config/plan_config.json
@@ -214,7 +214,6 @@
 
   "modeling": {
     "use_earliest_retire": true,
-    "term_vested_method": "bell_curve",
     "male_mp_forward_shift": 2,
     "entrant_salary_at_start_year": true
   },

--- a/src/pension_model/config_schema.py
+++ b/src/pension_model/config_schema.py
@@ -94,10 +94,6 @@ class PlanConfig:
         return self.raw.get("modeling", {}).get("use_earliest_retire", False)
 
     @property
-    def term_vested_method(self) -> str:
-        return self.raw.get("modeling", {}).get("term_vested_method", "growing_annuity")
-
-    @property
     def male_mp_forward_shift(self) -> int:
         return self.raw.get("modeling", {}).get("male_mp_forward_shift", 0)
 

--- a/src/pension_model/core/data_loader.py
+++ b/src/pension_model/core/data_loader.py
@@ -512,4 +512,39 @@ def load_plan_inputs(constants: PlanConfig) -> tuple[PlanConfig, dict]:
             raw_total = raw_inputs_by_class[cn]["_raw_headcount_total"]
         raw_inputs_by_class[cn]["_adjustment_ratio"] = target / raw_total
 
+    # Load current term-vested cashflow stream per class. Constructed in
+    # upstream data prep (see prep/{plan}/methods/term_vested_*.md).
+    # Per-class skip when pvfb_term_current=0 supports the calibration
+    # workflow, where the pipeline runs with neutral calibration before
+    # the per-class PVFBs are derived. float_precision='round_trip' on
+    # read is required to preserve bit-identical match against R-baseline
+    # truth tables.
+    data_dir = constants.resolve_data_dir()
+    cashflow_path = data_dir / "funding" / "current_term_vested_cashflow.csv"
+    cashflow_df = (
+        pd.read_csv(cashflow_path, float_precision="round_trip")
+        if cashflow_path.exists()
+        else None
+    )
+    for cn in classes:
+        pvfb = constants.class_data[cn].pvfb_term_current
+        if pvfb == 0 or cashflow_df is None:
+            raw_inputs_by_class[cn]["term_vested_cashflow"] = np.zeros(0)
+            continue
+        cn_rows = cashflow_df[cashflow_df["class_name"] == cn].sort_values("year_offset")
+        stream = cn_rows["payment"].to_numpy()
+        raw_inputs_by_class[cn]["term_vested_cashflow"] = stream
+        if len(stream) > 0:
+            baseline_rate = constants.baseline_dr_current
+            npv = float(np.sum(stream / (1.0 + baseline_rate) ** np.arange(1, len(stream) + 1)))
+            rel_err = abs(npv - pvfb) / abs(pvfb)
+            if rel_err > 1e-10:
+                raise ValueError(
+                    f"Plan '{constants.plan_name}' class '{cn}': term-vested "
+                    f"cashflow NPV {npv:.6e} at baseline rate "
+                    f"{baseline_rate} differs from pvfb_term_current "
+                    f"{pvfb:.6e} (rel err {rel_err:.2e}). Re-run the plan's "
+                    f"term-vested build script after calibration changes."
+                )
+
     return constants, raw_inputs_by_class

--- a/src/pension_model/core/pipeline.py
+++ b/src/pension_model/core/pipeline.py
@@ -290,7 +290,8 @@ def _build_current_liability_tables(
             constants,
         ),
         "current_term_vested_liability": compute_current_term_vested_liability(
-            class_name,
+            class_inputs.get("term_vested_cashflow", np.zeros(0)),
+            class_data.pvfb_term_current,
             constants,
         ),
     }

--- a/src/pension_model/core/pipeline_current.py
+++ b/src/pension_model/core/pipeline_current.py
@@ -137,66 +137,64 @@ def compute_current_retiree_liability(
     ).reset_index()
 
 
-def compute_current_term_vested_liability(class_name: str, constants) -> pd.DataFrame:
-    """
-    Compute current term vested AAL (R liability model lines 238-248 / 286-310).
+def compute_current_term_vested_liability(
+    cashflow_stream: np.ndarray,
+    pvfb_term_current: float,
+    constants,
+) -> pd.DataFrame:
+    """Project current term-vested AAL year-by-year from a pre-built cashflow stream.
 
-    Method is config-driven via ``funding.term_vested_method``:
-      - "growing_annuity": amortizes pvfb_term_current as a growing payment stream
-      - "bell_curve": uses normal distribution weighting of payments
+    The stream is constructed in upstream data prep (see
+    ``prep/{plan}/methods/term_vested_*.md``) and read from
+    ``plans/{plan}/data/funding/current_term_vested_cashflow.csv`` at
+    plan-load time. The runtime is method-agnostic: it just discounts
+    whatever per-year payments it gets at the scenario discount rate.
+
+    Args:
+        cashflow_stream: per-year payments at year_offset 1..N (length
+            depends on the per-plan method; e.g. 50 for FRS legacy,
+            D+L for the deferred-annuity method). Empty array when the
+            CSV is missing — supported during calibration where
+            pvfb_term_current is 0.
+        pvfb_term_current: per-class PVFB at baseline rate (the input
+            against which the stream was calibrated). Used here only
+            to detect the calibration-time "no stream and no PVFB"
+            case.
+        constants: PlanConfig.
     """
     ranges = constants.ranges
-    class_data = constants.class_data[class_name]
-
-    pvfb_term_current = class_data.pvfb_term_current
-    # The synthetic payment stream is sized at the rate the input PVFB
-    # was published at (baseline dr_current); the resulting stream is
-    # then PV'd at the scenario dr_current. See docs/design/discount_rate_scenarios.md.
-    cashflow_rate = constants.economic.baseline_dr_current
     valuation_rate = constants.economic.dr_current
-    payroll_growth = constants.economic.payroll_growth
-    amo_period = constants.funding.amo_period_term
-    years = list(range(ranges.start_year, ranges.start_year + ranges.model_period + 1))
+    n_years = ranges.model_period + 1
+    years = list(range(ranges.start_year, ranges.start_year + n_years))
 
-    if constants.term_vested_method == "bell_curve":
-        mid = amo_period / 2
-        spread = amo_period / 5
-        amo_seq = np.arange(1, amo_period + 1)
-        amo_weights = (1 / (spread * np.sqrt(2 * np.pi))) * np.exp(
-            -0.5 * ((amo_seq - mid) / spread) ** 2
+    if len(cashflow_stream) == 0:
+        if pvfb_term_current != 0:
+            raise FileNotFoundError(
+                "No term-vested cashflow stream available, but "
+                f"pvfb_term_current={pvfb_term_current}. Run the plan's "
+                "term-vested cashflow build script "
+                "(scripts/build/build_*_term_vested_cashflow.py) to "
+                "generate the per-plan "
+                "data/funding/current_term_vested_cashflow.csv."
+            )
+        return pd.DataFrame(
+            {
+                "year": years,
+                "retire_ben_term_est": np.zeros(n_years),
+                "aal_term_current_est": np.zeros(n_years),
+            }
         )
-        ann_ratio = amo_weights / amo_weights[0]
 
-        first_payment = pvfb_term_current / _npv(cashflow_rate, ann_ratio)
-        term_payments = first_payment * ann_ratio
-        full_stream = np.concatenate(([0.0], term_payments))
-        full_aal = _roll_npv(valuation_rate, full_stream)
+    full_stream = np.concatenate(([0.0], np.asarray(cashflow_stream, dtype=float)))
 
-        retire_ben_term_est = np.zeros(len(years))
-        aal_term_current = np.zeros(len(years))
-        for i in range(len(years)):
-            if i < len(full_stream):
-                retire_ben_term_est[i] = full_stream[i]
-            if i < len(full_aal):
-                aal_term_current[i] = full_aal[i]
-    else:
-        retire_ben_term = _get_pmt(cashflow_rate, payroll_growth, amo_period, pvfb_term_current, t=1)
-        amo_years = list(range(ranges.start_year + 1, ranges.start_year + 1 + amo_period))
-        retire_ben_term_est = np.zeros(len(years))
-        term_payments = _recur_grow3(retire_ben_term, payroll_growth, amo_period)
-        for i, year in enumerate(years):
-            if year in amo_years:
-                idx = year - (ranges.start_year + 1)
-                if idx < len(term_payments):
-                    retire_ben_term_est[i] = term_payments[idx]
+    retire_ben_term_est = np.zeros(n_years)
+    take = min(len(full_stream), n_years)
+    retire_ben_term_est[:take] = full_stream[:take]
 
-        aal_term_current = _roll_pv(
-            valuation_rate,
-            payroll_growth,
-            amo_period,
-            retire_ben_term_est,
-            t=1,
-        )
+    aal_full = _roll_npv(valuation_rate, full_stream)
+    aal_term_current = np.zeros(n_years)
+    take_aal = min(len(aal_full), n_years)
+    aal_term_current[:take_aal] = aal_full[:take_aal]
 
     return pd.DataFrame(
         {


### PR DESCRIPTION
## Summary

Second of two PRs implementing #76. The data-prep PR (#77) produces a per-plan `current_term_vested_cashflow.csv`. This PR makes the runtime read it.

**Stacked on #77** — base branch is `term-vested-cashflow-data-prep`. Merge #77 first; this PR's diff vs main will then be only the runtime changes once rebased.

## What changes

- `compute_current_term_vested_liability` now takes a pre-built cashflow stream and discounts it at the scenario rate. No method dispatch, no `_get_pmt`, no bell-curve construction inside the year loop.
- `data_loader.py` loads `plans/{plan}/data/funding/current_term_vested_cashflow.csv` once at config time and attaches the per-class array to `inputs_by_class[cn]["term_vested_cashflow"]`. Read uses `float_precision='round_trip'` to preserve bit-identical stream values.
- Input-load identity check: NPV at baseline rate ≈ `pvfb_term_current` to 1e-10 tolerance. Stale CSVs trip a clear error pointing at the build script.
- Per-class skip when `pvfb_term_current=0`. Required to keep the calibration workflow's neutral pre-pass working — when calibration zeros out the per-class plug values, the loader treats the CSV as absent for that class and the runtime produces a zero stream, exactly preserving the old calibration behavior.
- `term_vested_method` field removed from `config_schema.py` and from FRS, TXTRS, and TXTRS-AV plan configs.

## What does NOT change

Calibration philosophy is unchanged. The residual-plug calibration that puts active+retiree+survivor+nonvested modeling error into `pvfb_term_current` is preserved bit-for-bit. Replacing that with per-component AV-anchored calibration is the next layer (issues #65, #48), out of scope here while we're still in Match-R.

## Numerical impact

- **FRS, TXTRS R-baseline tests pass** at the same <0.01% tolerance as before. R-match preserved.
- **FRS** `aal_term_current_est` shifts ~6e-16 relative — year-0 PV is now computed via NPV summation instead of the closed-form `_pv_annuity` recursion. Within float64 epsilon; existing test tolerances unaffected.
- **TXTRS** unchanged at this level (already used `_roll_npv` on the full stream).
- **TXTRS-AV** year-by-year trajectory differs from prior runs because the stream shape changes from the runtime's old growing-annuity default to the deferred-annuity method (#77 introduced). Year-0 AAL still anchored to the same residual-plug `pvfb_term_current` as before.

## Calibration workflow note

The CSV must be regenerated whenever `calibration.json` changes:

```
pension-model calibrate <plan> --write
python scripts/build/build_<plan>_term_vested_cashflow.py
```

The identity check at input load enforces this — if you forget to regenerate, the next pipeline run errors with a message naming the build script.

## Test plan

- [x] All non-pre-existing tests pass (314 pass).
- [x] R-baseline tests pass (7 tests, max diff < 0.01%).
- [x] Calibration tests pass (per-class skip preserves the neutral pre-pass).
- [x] Truth-table tests pass for FRS and TXTRS.
- [ ] Funding-snapshot tests still fail at the same pre-existing column (`payroll_db_legacy`) as on main — issue #47, unrelated. 1-ULP float noise.

## Related

- Implements #76 part 2 (depends on #77)
- Will close #76 once both parts merge
- #65, #48 — future per-component calibration work, out of scope here

🤖 Generated with [Claude Code](https://claude.com/claude-code)