### PR TITLE
Add Makefile, cell-comparison tooling, and bounded-drift test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,109 @@
+# Pension model dev workflow.
+#
+# Three core commands drive everything else:
+#   make run plan=<p> scenario=<s>           run one cell, upsert long CSV
+#   make run-all                             run the full matrix
+#   make compare a=<p>/<s> b=<p>/<s>         pairwise diff between two cells
+#
+# Convenience targets wrap the test suite, term-vested CSV builds, and
+# calibration. `make help` prints this list.
+
+PYTHON ?= python
+
+PLANS ?= frs txtrs txtrs-av
+SCENARIOS ?= baseline low_return high_discount
+
+# Default scenario for `make run` if user omits scenario= argument.
+scenario ?= baseline
+
+ALL_RUNS_CSV = output/all_runs.csv
+
+.PHONY: help test r-match verify-cashflows build-cashflows \
+        calibrate run run-all compare \
+        compare-twin compare-txtrs-av-to-av all-checks
+
+help:
+	@echo "Core workflow commands:"
+	@echo "  make run plan=<p> scenario=<s>      run one (plan, scenario), upsert $(ALL_RUNS_CSV)"
+	@echo "  make run-all                        run every (plan, scenario) cell"
+	@echo "  make compare a=<p>/<s> b=<p>/<s>    pairwise diff between two cells"
+	@echo
+	@echo "Tests:"
+	@echo "  make test                           full pytest suite"
+	@echo "  make r-match                        FRS/TXTRS R-baseline scenario tests"
+	@echo
+	@echo "Term-vested cashflow:"
+	@echo "  make build-cashflows                rebuild all per-plan term-vested CSVs"
+	@echo "  make verify-cashflows               NPV identity + bit-match check"
+	@echo
+	@echo "Calibration (calibrates AND rebuilds CSV - no footgun):"
+	@echo "  make calibrate plan=<p>             $(PYTHON) -m pension_model calibrate <p> --write + build CSV"
+	@echo
+	@echo "Diagnostics:"
+	@echo "  make compare-txtrs-av-to-av         TXTRS-AV vs published AV Table 2"
+	@echo
+	@echo "Aggregate:"
+	@echo "  make all-checks                     test + r-match + verify-cashflows"
+	@echo
+	@echo "Variables:"
+	@echo "  PLANS=$(PLANS)"
+	@echo "  SCENARIOS=$(SCENARIOS)"
+
+test:
+	$(PYTHON) -m pytest tests/
+
+r-match:
+	$(PYTHON) -m pytest tests/test_pension_model/test_truth_table_scenarios.py -v
+
+verify-cashflows:
+	$(PYTHON) scripts/build/verify_term_vested_cashflow.py
+
+build-cashflows:
+	$(PYTHON) scripts/build/build_frs_term_vested_cashflow.py
+	$(PYTHON) scripts/build/build_txtrs_term_vested_cashflow.py
+	$(PYTHON) scripts/build/build_av_term_vested_cashflow.py txtrs-av
+
+calibrate:
+ifndef plan
+	$(error plan=<name> is required, e.g. make calibrate plan=txtrs)
+endif
+	$(PYTHON) -m pension_model calibrate $(plan) --write
+	@case "$(plan)" in \
+		frs)       $(PYTHON) scripts/build/build_frs_term_vested_cashflow.py ;; \
+		txtrs)     $(PYTHON) scripts/build/build_txtrs_term_vested_cashflow.py ;; \
+		txtrs-av|frs-av) $(PYTHON) scripts/build/build_av_term_vested_cashflow.py $(plan) ;; \
+		*) echo "WARNING: no term-vested build script known for plan=$(plan); update Makefile if needed" ;; \
+	esac
+
+run:
+ifndef plan
+	$(error plan=<name> is required, e.g. make run plan=txtrs scenario=baseline)
+endif
+	$(PYTHON) scripts/diagnostic/run_cell.py --plan $(plan) --scenario $(scenario)
+
+run-all:
+	@for p in $(PLANS); do \
+		for s in $(SCENARIOS); do \
+			echo "==> $$p / $$s"; \
+			$(PYTHON) scripts/diagnostic/run_cell.py --plan $$p --scenario $$s || exit $$?; \
+		done; \
+	done
+
+compare:
+ifndef a
+	$(error a=<plan>/<scenario> is required, e.g. make compare a=txtrs/baseline b=txtrs-av/baseline)
+endif
+ifndef b
+	$(error b=<plan>/<scenario> is required, e.g. make compare a=txtrs/baseline b=txtrs-av/baseline)
+endif
+	$(PYTHON) scripts/diagnostic/compare_cells.py --a $(a) --b $(b)
+
+compare-twin:
+	$(PYTHON) scripts/diagnostic/compare_cells.py --a txtrs/baseline --b txtrs-av/baseline
+	$(PYTHON) scripts/diagnostic/compare_cells.py --a txtrs/low_return --b txtrs-av/low_return
+	$(PYTHON) scripts/diagnostic/compare_cells.py --a txtrs/high_discount --b txtrs-av/high_discount
+
+compare-txtrs-av-to-av:
+	$(PYTHON) scripts/diagnostic/compare_txtrs_av_to_av.py
+
+all-checks: verify-cashflows r-match test

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -315,10 +315,22 @@ Closes the AAL gap: `pvfb_term_current = AV_AAL - model_AAL`. This liability com
 ### Running Calibration
 
 ```bash
-pension-model calibrate frs              # compute and print diagnostics
-pension-model calibrate frs --write      # write to plans/frs/config/calibration.json
+pension-model calibrate frs              # compute and print diagnostics (no write)
+make calibrate plan=frs                  # write calibration.json AND rebuild that
+                                         # plan's term-vested cashflow CSV in one
+                                         # step (preferred — see note below)
 pension-model run frs                    # verify output and tests pass
 ```
+
+**Why prefer `make calibrate` over `pension-model calibrate --write`:** the
+runtime reads the per-class term-vested benefit cashflow stream from
+`plans/{plan}/data/funding/current_term_vested_cashflow.csv`, which is
+generated from `pvfb_term_current` in `calibration.json`. When calibration
+writes new `pvfb_term_current` values, the CSV must be regenerated to match.
+The Make target does both. Doing them separately is fine but easy to forget;
+the runtime's input-load identity check (NPV at baseline rate ≈
+`pvfb_term_current`) will trip if the CSV is stale and point at the build
+script to fix.
 
 Calibration output includes:
 - **Normal cost calibration table**: model NC vs AV NC, nc_cal factor, flags for outliers
@@ -484,6 +496,23 @@ pytest tests/ -k "calibration" -v        # filter by name
 pension-model run frs                    # runs model + tests automatically
 pension-model run frs --test-only        # tests only, no model run
 ```
+
+The repo also has a `Makefile` that bundles common workflows. `make help` lists
+all targets. The most useful ones:
+
+```bash
+make r-match                             # FRS/TXTRS R-baseline scenario tests
+make verify-cashflows                    # term-vested CSV identity check
+make calibrate plan=frs                  # calibrate + rebuild that plan's term-vested CSV
+make run plan=txtrs scenario=baseline    # run one cell, append rows to output/all_runs.csv
+make run-all                             # run every (plan, scenario) cell
+make compare a=txtrs/baseline b=txtrs-av/baseline
+                                         # pairwise long-format diff between two cells
+```
+
+The compare target writes `output/compare_<a>__vs__<b>.csv` (long format) and
+prints a per-metric summary. Works for any pair — across plans, across
+scenarios, or both.
 
 For the proposed long-run taxonomy, retention rules, and run-profile model,
 see [testing_strategy.md](testing_strategy.md). The current suite still mixes

--- a/scripts/diagnostic/compare_cells.py
+++ b/scripts/diagnostic/compare_cells.py
@@ -17,7 +17,6 @@ canonical scenario name for "no scenario overrides applied".
 from __future__ import annotations
 
 import argparse
-import sys
 from pathlib import Path
 
 import numpy as np
@@ -80,7 +79,6 @@ def print_summary(comparison: pd.DataFrame, a_label: str, b_label: str) -> None:
     print()
     summary_rows = []
     for metric, grp in comparison.groupby("metric", sort=False):
-        max_abs = grp["abs_diff"].abs().max()
         max_pct = grp["pct_diff"].abs().max()
         y0 = grp[grp["year"] == grp["year"].min()].iloc[0] if len(grp) else None
         ylast = grp[grp["year"] == grp["year"].max()].iloc[0] if len(grp) else None

--- a/scripts/diagnostic/compare_cells.py
+++ b/scripts/diagnostic/compare_cells.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Pairwise comparison between two (plan, scenario) cells in all_runs.csv.
+
+Reads ``output/all_runs.csv`` (produced by ``run_cell.py``), filters to
+the two requested cells, joins on ``(year, metric)``, and emits a
+long-format diff CSV. Also prints a per-metric summary to stdout so the
+user gets something useful without opening the file.
+
+Usage:
+    python scripts/diagnostic/compare_cells.py --a txtrs/baseline --b txtrs-av/baseline
+    python scripts/diagnostic/compare_cells.py --a txtrs-av/baseline --b txtrs-av/high_discount
+
+The cell identifier syntax is ``plan/scenario``. ``baseline`` is the
+canonical scenario name for "no scenario overrides applied".
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+ALL_RUNS_PATH = PROJECT_ROOT / "output" / "all_runs.csv"
+COMPARE_DIR = PROJECT_ROOT / "output"
+
+
+def _parse_cell(cell: str) -> tuple[str, str]:
+    if "/" not in cell:
+        raise ValueError(
+            f"Cell identifier must be 'plan/scenario'; got {cell!r}"
+        )
+    plan, scenario = cell.split("/", 1)
+    if not plan or not scenario:
+        raise ValueError(
+            f"Cell identifier must be 'plan/scenario' with both parts non-empty; got {cell!r}"
+        )
+    return plan, scenario
+
+
+def _filter_cell(df: pd.DataFrame, plan: str, scenario: str) -> pd.DataFrame:
+    cell = df[(df["plan"] == plan) & (df["scenario"] == scenario)]
+    if cell.empty:
+        available = sorted({(p, s) for p, s in zip(df["plan"], df["scenario"])})
+        raise SystemExit(
+            f"No rows for plan={plan} scenario={scenario} in {ALL_RUNS_PATH}. "
+            f"Run `make run plan={plan} scenario={scenario}` first.\n"
+            f"Available cells: {available}"
+        )
+    return cell[["year", "metric", "value"]].copy()
+
+
+def build_comparison(
+    all_runs: pd.DataFrame,
+    a_plan: str,
+    a_scenario: str,
+    b_plan: str,
+    b_scenario: str,
+) -> pd.DataFrame:
+    a = _filter_cell(all_runs, a_plan, a_scenario).rename(columns={"value": "value_a"})
+    b = _filter_cell(all_runs, b_plan, b_scenario).rename(columns={"value": "value_b"})
+    merged = a.merge(b, on=["year", "metric"], how="outer")
+    merged["abs_diff"] = merged["value_b"] - merged["value_a"]
+    denom = merged["value_a"].where(np.abs(merged["value_a"]) > 1e-12, np.nan)
+    merged["pct_diff"] = merged["abs_diff"] / np.abs(denom) * 100.0
+    merged.insert(0, "plan_a", a_plan)
+    merged.insert(1, "scenario_a", a_scenario)
+    merged.insert(2, "plan_b", b_plan)
+    merged.insert(3, "scenario_b", b_scenario)
+    return merged.sort_values(["metric", "year"]).reset_index(drop=True)
+
+
+def print_summary(comparison: pd.DataFrame, a_label: str, b_label: str) -> None:
+    print(f"\n{a_label}  vs  {b_label}")
+    print(f"  rows: {len(comparison)}")
+    print()
+    summary_rows = []
+    for metric, grp in comparison.groupby("metric", sort=False):
+        max_abs = grp["abs_diff"].abs().max()
+        max_pct = grp["pct_diff"].abs().max()
+        y0 = grp[grp["year"] == grp["year"].min()].iloc[0] if len(grp) else None
+        ylast = grp[grp["year"] == grp["year"].max()].iloc[0] if len(grp) else None
+        summary_rows.append({
+            "metric": metric,
+            "y0_a": float(y0["value_a"]) if y0 is not None else np.nan,
+            "y0_b": float(y0["value_b"]) if y0 is not None else np.nan,
+            "y0_pct": float(y0["pct_diff"]) if y0 is not None else np.nan,
+            "ylast_pct": float(ylast["pct_diff"]) if ylast is not None else np.nan,
+            "max_abs_pct": float(max_pct) if pd.notna(max_pct) else np.nan,
+        })
+    summary = pd.DataFrame(summary_rows)
+    with pd.option_context(
+        "display.max_rows", None,
+        "display.max_columns", None,
+        "display.width", 140,
+        "display.float_format", lambda v: f"{v:,.4g}" if abs(v) >= 1 else f"{v:.4g}",
+    ):
+        print(summary.to_string(index=False))
+    print()
+
+
+def output_path(a_plan: str, a_scenario: str, b_plan: str, b_scenario: str) -> Path:
+    name = f"compare_{a_plan}_{a_scenario}__vs__{b_plan}_{b_scenario}.csv"
+    return COMPARE_DIR / name
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--a", required=True, help="cell A as plan/scenario (e.g. txtrs/baseline)")
+    parser.add_argument("--b", required=True, help="cell B as plan/scenario")
+    parser.add_argument(
+        "--input",
+        type=Path,
+        default=ALL_RUNS_PATH,
+        help=f"long-format CSV to read (default: {ALL_RUNS_PATH})",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="output CSV path (default: output/compare_<a>__vs__<b>.csv)",
+    )
+    args = parser.parse_args()
+
+    a_plan, a_scenario = _parse_cell(args.a)
+    b_plan, b_scenario = _parse_cell(args.b)
+
+    if not args.input.exists():
+        raise SystemExit(
+            f"{args.input} not found. Run `make run-all` (or `make run plan=<p> scenario=<s>`) first."
+        )
+
+    all_runs = pd.read_csv(args.input)
+    comparison = build_comparison(all_runs, a_plan, a_scenario, b_plan, b_scenario)
+
+    out_path = args.output or output_path(a_plan, a_scenario, b_plan, b_scenario)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    comparison.to_csv(out_path, index=False, float_format="%.17g")
+
+    print_summary(comparison, args.a, args.b)
+    print(f"Full long-format diff: {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/diagnostic/run_cell.py
+++ b/scripts/diagnostic/run_cell.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Run one (plan, scenario) and upsert long-format rows into output/all_runs.csv.
+
+The all-runs CSV is the canonical comparison surface across plans and
+scenarios. Schema:
+
+    plan, scenario, year, metric, value
+
+Re-running the same (plan, scenario) replaces any prior rows for that
+cell so the file stays current.
+
+Usage:
+    python scripts/diagnostic/run_cell.py --plan txtrs --scenario baseline
+    python scripts/diagnostic/run_cell.py --plan txtrs-av --scenario high_discount
+
+``--scenario baseline`` (the default) means no scenario overrides; any
+other name is looked up as ``scenarios/<name>.json``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(PROJECT_ROOT / "src"))
+
+from pension_model.runners import run_truth_table
+
+ALL_RUNS_PATH = PROJECT_ROOT / "output" / "all_runs.csv"
+
+NON_METRIC_COLS = {"plan", "year"}
+
+
+def truth_table_to_long(plan: str, scenario: str, df: pd.DataFrame) -> pd.DataFrame:
+    """Reshape a truth-table DataFrame into the canonical long format."""
+    metric_cols = [
+        c for c in df.columns
+        if c not in NON_METRIC_COLS and pd.api.types.is_numeric_dtype(df[c])
+    ]
+    long = df.melt(
+        id_vars=["year"],
+        value_vars=metric_cols,
+        var_name="metric",
+        value_name="value",
+    )
+    long.insert(0, "scenario", scenario)
+    long.insert(0, "plan", plan)
+    return long[["plan", "scenario", "year", "metric", "value"]]
+
+
+def upsert_rows(new_rows: pd.DataFrame, path: Path) -> None:
+    """Replace any rows for the same (plan, scenario) and append the new ones."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.exists():
+        existing = pd.read_csv(path)
+        plan = new_rows["plan"].iloc[0]
+        scenario = new_rows["scenario"].iloc[0]
+        keep = existing[
+            ~((existing["plan"] == plan) & (existing["scenario"] == scenario))
+        ]
+        combined = pd.concat([keep, new_rows], ignore_index=True)
+    else:
+        combined = new_rows
+    combined.to_csv(path, index=False, float_format="%.17g")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--plan", required=True, help="plan name (e.g. txtrs)")
+    parser.add_argument(
+        "--scenario",
+        default="baseline",
+        help="scenario name (default: baseline). Any value other than 'baseline' "
+        "must correspond to a scenarios/<name>.json file.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=ALL_RUNS_PATH,
+        help=f"long-format CSV to upsert into (default: {ALL_RUNS_PATH})",
+    )
+    args = parser.parse_args()
+
+    tt = run_truth_table(args.plan, args.scenario)
+    long = truth_table_to_long(args.plan, args.scenario, tt)
+    upsert_rows(long, args.output)
+    print(
+        f"Wrote {len(long)} rows for plan={args.plan} scenario={args.scenario} "
+        f"to {args.output}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/pension_model/runners.py
+++ b/src/pension_model/runners.py
@@ -1,0 +1,49 @@
+"""Convenience runners for one-off pipeline runs.
+
+These wrap the standard pipeline / funding / truth-table chain so
+scripts and tests don't each repeat the boilerplate. Not intended for
+high-throughput use - data prep, calibration CLI, and the cell-level
+diagnostic scripts each go through here.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+import pandas as pd
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _scenario_path(scenario: Optional[str]) -> Optional[Path]:
+    if scenario is None or scenario == "baseline":
+        return None
+    return PROJECT_ROOT / "scenarios" / f"{scenario}.json"
+
+
+def run_truth_table(plan: str, scenario: Optional[str] = None) -> pd.DataFrame:
+    """Run the full pipeline for ``(plan, scenario)`` and return its truth table.
+
+    ``scenario=None`` and ``scenario="baseline"`` both mean "no scenario
+    overrides" - the plan's defaults stand. Any other string is looked
+    up as ``scenarios/<name>.json``.
+    """
+    from pension_model.config_loading import load_plan_config
+    from pension_model.core.funding_model import load_funding_inputs, run_funding_model
+    from pension_model.core.pipeline import run_plan_pipeline
+    from pension_model.truth_table import build_python_truth_table
+
+    config_path = PROJECT_ROOT / "plans" / plan / "config" / "plan_config.json"
+    calibration_path = PROJECT_ROOT / "plans" / plan / "config" / "calibration.json"
+    constants = load_plan_config(
+        config_path,
+        calibration_path=calibration_path,
+        scenario_path=_scenario_path(scenario),
+    )
+    liability = run_plan_pipeline(constants)
+    funding_dir = constants.resolve_data_dir() / "funding"
+    funding_inputs = load_funding_inputs(funding_dir)
+    funding = run_funding_model(liability, funding_inputs, constants)
+    return build_python_truth_table(plan, liability, funding, constants)

--- a/tests/test_pension_model/test_av_vs_r_twin.py
+++ b/tests/test_pension_model/test_av_vs_r_twin.py
@@ -1,0 +1,158 @@
+"""Bounded-drift test: AV-first plan vs its R-anchored twin.
+
+The AV-first plans (today: txtrs-av) and their R-anchored twins (txtrs)
+model the same underlying pension at the same valuation vintage. They
+SHOULD agree at year 0 because both calibrate to the same AV-published
+total AAL. They will drift over the projection because the plans use
+different prep methods (AV-first extraction vs legacy R reconstruction),
+different mortality bases, different retiree-distribution methods, and
+different term-vested cashflow shapes.
+
+This test does not assert that the drift is "right". It bounds the
+drift at thresholds chosen to pass today's behavior with headroom.
+The point is to fail loudly if a future change moves the drift
+materially - we want that as a flag, not a silent regression.
+
+If you legitimately need to widen these thresholds, do it in the same
+PR as the change that widened them, with a comment explaining why.
+
+Pairs covered today:
+  - txtrs (R-anchored) vs txtrs-av (AV-first), in baseline + low_return + high_discount.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from pension_model.runners import run_truth_table
+
+
+PAIRS = [
+    ("txtrs", "txtrs-av"),
+]
+SCENARIOS = ["baseline", "low_return", "high_discount"]
+
+# Year-0 anchors: tight bound. Both plans calibrate to the same
+# AV-published year-0 totals, so any meaningful drift here means
+# calibration has changed shape on one side.
+Y0_ANCHOR_METRICS = [
+    "aal_boy",
+    "ava_boy",
+    "mva_boy",
+    "fr_ava_boy",
+    "fr_mva_boy",
+    "payroll",
+    "n_active_boy",
+]
+Y0_ANCHOR_REL_TOL = 0.01  # 1% relative
+
+# Multi-year drift bounds: looser, set to today's worst case + headroom.
+# Today's worst observed: aal/ava/mva ~12-19%, funded ratios ~6%.
+# Per-metric maximum across all years and all scenarios.
+DRIFT_BOUNDS_PCT = {
+    "aal_boy": 25.0,
+    "ava_boy": 25.0,
+    "mva_boy": 25.0,
+    "fr_ava_boy": 10.0,
+    "fr_mva_boy": 10.0,
+    "payroll": 1.0,
+    "n_active_boy": 1.0,
+}
+
+
+@pytest.fixture(scope="module")
+def truth_tables():
+    """Build truth tables once per (plan, scenario) and reuse across cases."""
+    cache: dict[tuple[str, str], pd.DataFrame] = {}
+    for plan_a, plan_b in PAIRS:
+        for plan in (plan_a, plan_b):
+            for scenario in SCENARIOS:
+                key = (plan, scenario)
+                if key not in cache:
+                    cache[key] = run_truth_table(plan, scenario)
+    return cache
+
+
+def _rel_pct(value_a: float, value_b: float) -> float:
+    if not np.isfinite(value_a) or not np.isfinite(value_b):
+        return np.nan
+    if abs(value_a) < 1e-12:
+        return np.nan
+    return abs(value_b - value_a) / abs(value_a) * 100.0
+
+
+@pytest.mark.parametrize(
+    "plan_a,plan_b,scenario",
+    [(a, b, s) for a, b in PAIRS for s in SCENARIOS],
+    ids=[f"{a}-vs-{b}-{s}" for a, b in PAIRS for s in SCENARIOS],
+)
+def test_year0_anchor_agreement(truth_tables, plan_a, plan_b, scenario):
+    """Year-0 anchors must agree within Y0_ANCHOR_REL_TOL across both plans."""
+    a = truth_tables[(plan_a, scenario)]
+    b = truth_tables[(plan_b, scenario)]
+
+    y0_year = min(a["year"].min(), b["year"].min())
+    a0 = a[a["year"] == y0_year].iloc[0]
+    b0 = b[b["year"] == y0_year].iloc[0]
+
+    failures = []
+    for metric in Y0_ANCHOR_METRICS:
+        if metric not in a0.index or metric not in b0.index:
+            continue
+        rel = _rel_pct(float(a0[metric]), float(b0[metric]))
+        if not np.isfinite(rel):
+            continue
+        if rel > Y0_ANCHOR_REL_TOL * 100:
+            failures.append(
+                f"{metric}: {plan_a}={a0[metric]:.6g} vs {plan_b}={b0[metric]:.6g} "
+                f"(rel diff {rel:.4f}%)"
+            )
+    assert not failures, (
+        f"Year-{y0_year} anchors diverge beyond {Y0_ANCHOR_REL_TOL*100:.2f}% "
+        f"for {plan_a} vs {plan_b} in {scenario}:\n  "
+        + "\n  ".join(failures)
+    )
+
+
+@pytest.mark.parametrize(
+    "plan_a,plan_b,scenario",
+    [(a, b, s) for a, b in PAIRS for s in SCENARIOS],
+    ids=[f"{a}-vs-{b}-{s}" for a, b in PAIRS for s in SCENARIOS],
+)
+def test_drift_within_bounds(truth_tables, plan_a, plan_b, scenario):
+    """Per-metric max drift across all years stays within DRIFT_BOUNDS_PCT."""
+    a = truth_tables[(plan_a, scenario)].set_index("year")
+    b = truth_tables[(plan_b, scenario)].set_index("year")
+    common_years = sorted(set(a.index).intersection(b.index))
+
+    failures = []
+    for metric, bound_pct in DRIFT_BOUNDS_PCT.items():
+        if metric not in a.columns or metric not in b.columns:
+            continue
+        va = a.loc[common_years, metric].astype(float).to_numpy()
+        vb = b.loc[common_years, metric].astype(float).to_numpy()
+        denom = np.where(np.abs(va) > 1e-12, np.abs(va), np.nan)
+        rel_pct = np.abs(vb - va) / denom * 100.0
+        max_rel = float(np.nanmax(rel_pct)) if np.isfinite(rel_pct).any() else 0.0
+        if max_rel > bound_pct:
+            argmax = int(np.nanargmax(rel_pct))
+            year = common_years[argmax]
+            failures.append(
+                f"{metric}: max rel drift {max_rel:.2f}% > bound {bound_pct:.1f}% "
+                f"(year {year}: {plan_a}={va[argmax]:.6g}, {plan_b}={vb[argmax]:.6g})"
+            )
+    assert not failures, (
+        f"Drift exceeds bounds for {plan_a} vs {plan_b} in {scenario}:\n  "
+        + "\n  ".join(failures)
+        + "\n\nIf the change is intentional, widen DRIFT_BOUNDS_PCT in this file "
+        "with a comment explaining why."
+    )


### PR DESCRIPTION
## Summary

Adds the missing plan-vs-plan comparison surface and bundles the dev workflow into a Makefile.

The existing `truth_tables.xlsx` holds plan-vs-R, but it doesn't model plan-vs-plan, and its sheet count grows like (plans × scenarios × 3) — already 18 sheets, would balloon as more plans / scenarios appear. Replaces that scaling pressure with a single long-format CSV.

## What's added

**Long-format runs file** — `output/all_runs.csv`, columns: `plan, scenario, year, metric, value`. Adding plans or scenarios adds rows, not columns or files. Comparisons are SQL-style filters/joins.

**Three core commands:**

| command | what it does |
|---|---|
| `make run plan=<p> scenario=<s>` | run one (plan, scenario), upsert the corresponding rows |
| `make run-all` | run the full matrix (3 plans × 3 scenarios = 9 cells) |
| `make compare a=<plan>/<scenario> b=<plan>/<scenario>` | pairwise diff between any two cells |

`make compare` writes `output/compare_<a>__vs__<b>.csv` (long format) and prints a per-metric summary. Works for any pair: across plans, across scenarios, or both. Examples:
- `make compare a=txtrs/baseline b=txtrs-av/baseline` (cross-plan, same scenario)
- `make compare a=txtrs-av/baseline b=txtrs-av/high_discount` (within-plan, cross-scenario)
- (Future) `make compare a=txtrs-av-2024/baseline b=txtrs-av-2025/baseline` (vintage drift)

**Convenience targets:** `test`, `r-match`, `verify-cashflows`, `build-cashflows`, `compare-twin`, `compare-txtrs-av-to-av`, `all-checks`, plus `make calibrate plan=<p>` — calibrates AND rebuilds the plan's term-vested cashflow CSV in one step (eliminates the post-calibration-regen footgun).

**New bounded-drift test** — `test_av_vs_r_twin.py` runs txtrs vs txtrs-av across baseline + low_return + high_discount and asserts:
- year-0 anchors agree within 1% (calibration pins both to the same AV-published total)
- per-metric multi-year drift stays within `DRIFT_BOUNDS_PCT` (25% on AAL/AVA/MVA, 10% on funded ratios, 1% on payroll/headcount)

Today's observed worst case sits well below the bounds (~12% AAL drift at year 30, ~19% AVA in low_return, ~6% funded ratio). The point isn't to assert "this is the right number"; it's to fail loudly if a future change moves the drift, so we don't get silent regressions.

## What's NOT in this PR

- **The 12%-drift investigation itself.** Separate follow-up — decompose the drift into causes (mortality basis, retiree distribution, term-vested shape, calibration plug), decide whether each component leaves us better/worse/different. This PR just gives us the tooling to do that investigation cleanly.
- **Removing `truth_tables.xlsx`.** Still useful for human-eyeballing a single (plan × scenario) cell against R. Long-format CSV complements rather than replaces.

## Test plan

- [x] `make help` lists targets cleanly
- [x] `make run-all` populates all 9 cells (frs/txtrs/txtrs-av × baseline/low_return/high_discount), 4185 rows total
- [x] `make compare a=txtrs/baseline b=txtrs-av/baseline` writes diff CSV and prints summary
- [x] `make compare a=txtrs-av/baseline b=txtrs-av/high_discount` (within-plan scenario sensitivity) works
- [x] `make r-match` — 6 R-baseline scenario tests pass
- [x] `make verify-cashflows` — all CSVs verify
- [x] `make test` — 320 pass (added 6 new bounded-drift tests on top of prior 314); 2 pre-existing snapshot failures unchanged (issue #47)
- [x] New bounded-drift test passes for all 3 (txtrs, txtrs-av) scenario pairs

## Files

- `Makefile` — workflow bundle
- `src/pension_model/runners.py` — shared `run_truth_table(plan, scenario)` helper
- `scripts/diagnostic/run_cell.py` — runs one cell, upserts long CSV
- `scripts/diagnostic/compare_cells.py` — pairwise comparator
- `tests/test_pension_model/test_av_vs_r_twin.py` — bounded-drift test
- `docs/developer.md` — brief Makefile pointer + note that `make calibrate` is preferred over `pension-model calibrate --write` because it also rebuilds the term-vested CSV

🤖 Generated with [Claude Code](https://claude.com/claude-code)