### PR TITLE
Distinguish metadata from engine choices in runtime-only

### DIFF
--- a/prep/common/input_checklist_template.csv
+++ b/prep/common/input_checklist_template.csv
@@ -1,7 +1,7 @@
 category,item,description,runtime_location,required,status,source_type,source_doc,printed_page,pdf_page,table_or_section,method_id,notes
-plan_meta,plan_name,Plan identifier,plan_config.json:plan_name,required,,,,,,,,
-plan_meta,plan_description,Human-readable plan name,plan_config.json:plan_description,required,,,,,,,,
-plan_meta,data_dir,Path to plan data directory,plan_config.json:data.data_dir,required,,,runtime-only,,,,,
+plan_meta,plan_name,Plan identifier,plan_config.json:plan_name,required,,,runtime-only,,,,,"Metadata / identifier — not subject to provenance review."
+plan_meta,plan_description,Human-readable plan name,plan_config.json:plan_description,required,,,runtime-only,,,,,"Metadata / human label — not subject to provenance review."
+plan_meta,data_dir,Path to plan data directory,plan_config.json:data.data_dir,required,,,runtime-only,,,,,"Wiring / file path — not subject to provenance review. Typically derivable from plan_name."
 economic,dr_current,Discount rate for current/legacy members,plan_config.json:economic.dr_current,required,,,,,,,,
 economic,dr_new,Discount rate for new entrants,plan_config.json:economic.dr_new,required,,,,,,,,
 economic,dr_old,Legacy discount rate (often equal to dr_current),plan_config.json:economic.dr_old,required,,,,,,,,

--- a/prep/common/reports/input_checklist_README.md
+++ b/prep/common/reports/input_checklist_README.md
@@ -59,6 +59,31 @@ The `source_type` column says how strong the source link is. For partial or
 have rows, fill in `source_doc`, `printed_page`, `pdf_page`, and
 `table_or_section` so a reader can verify.
 
+## What `runtime-only` covers
+
+`runtime-only` is the source_type for items that are not statements about
+the plan and therefore have no AV (or other authoritative document)
+provenance. Inside this category there are two sub-flavors that the
+`notes` column should distinguish:
+
+1. **Modeling-engine choices that affect output** — e.g., cohort grid
+   bounds (`min_age`, `max_age`, `max_yos`), projection horizon
+   (`model_period`), engine structure choices (`class_groups`,
+   `plan_design.*`, `modeling.*`). These are real decisions the modeler
+   makes; different choices give different numbers. They get a row in
+   the checklist so reviewers can see them.
+2. **Metadata / wiring** — e.g., `plan_name`, `plan_description`,
+   `data_dir`. These are identifiers, human labels, and file-path
+   wiring. They are not subject to provenance review at all. They
+   appear in the checklist only so the row set stays complete and we
+   do not silently forget about them. The `notes` column should say
+   "Metadata / identifier — not subject to provenance review" or
+   similar.
+
+Don't use `runtime-only` as a parking spot for unverified plan facts.
+A value that should trace to the AV but hasn't been verified yet is
+`partial / source-unverified` (or `missing`), not `runtime-only`.
+
 ## Relationship to other prep artifacts
 
 This checklist is a **planning view**. It is complementary to:

--- a/prep/txtrs-av/input_checklist.csv
+++ b/prep/txtrs-av/input_checklist.csv
@@ -1,7 +1,7 @@
 category,item,description,runtime_location,required,status,source_type,source_doc,printed_page,pdf_page,table_or_section,method_id,notes
-plan_meta,plan_name,Plan identifier,plan_config.json:plan_name,required,have,runtime-only,,,,,,
-plan_meta,plan_description,Human-readable plan name,plan_config.json:plan_description,required,have,runtime-only,,,,,,
-plan_meta,data_dir,Path to plan data directory,plan_config.json:data.data_dir,required,have,runtime-only,,,,,,
+plan_meta,plan_name,Plan identifier,plan_config.json:plan_name,required,have,runtime-only,,,,,,"Metadata / identifier — not subject to provenance review."
+plan_meta,plan_description,Human-readable plan name,plan_config.json:plan_description,required,have,runtime-only,,,,,,"Metadata / human label — not subject to provenance review."
+plan_meta,data_dir,Path to plan data directory,plan_config.json:data.data_dir,required,have,runtime-only,,,,,,"Wiring / file path — not subject to provenance review. Typically derivable from plan_name."
 economic,dr_current,Discount rate for current/legacy members,plan_config.json:economic.dr_current,required,have,AV-direct,AV_2024,60,67,"Appendix 2 §1 Investment Return Rate",,"Verified 2026-05-01: ""Investment Return Rate 7.00% per annum, compounded annually, composed of an assumed 2.30% inflation rate and a 4.70% real rate of return, net of investment expenses."""
 economic,dr_new,Discount rate for new entrants,plan_config.json:economic.dr_new,required,have,AV-direct,AV_2024,60,67,"Appendix 2 §1 Investment Return Rate",,"Verified 2026-05-01: AV cites a single 7.00% investment return rate; we apply the same rate to new entrants as a modeling default consistent with US public-pension convention."
 economic,dr_old,Legacy discount rate,plan_config.json:economic.dr_old,required,have,AV-direct,AV_2024,60,67,"Appendix 2 §1 Investment Return Rate",,"Verified 2026-05-01: 7.00% AV investment return rate. Used by the cashflow-estimation pathway anchored to the published-rate quantity."

--- a/prep/txtrs-av/reports/input_checklist.md
+++ b/prep/txtrs-av/reports/input_checklist.md
@@ -37,9 +37,9 @@ Rows with status `missing` or `partial`.
 
 | item | required | status | source_type | source citation | notes |
 | --- | --- | --- | --- | --- | --- |
-| data_dir | required | have | runtime-only | — |  |
-| plan_description | required | have | runtime-only | — |  |
-| plan_name | required | have | runtime-only | — |  |
+| data_dir | required | have | runtime-only | — | Wiring / file path — not subject to provenance review. Typically derivable from plan_name. |
+| plan_description | required | have | runtime-only | — | Metadata / human label — not subject to provenance review. |
+| plan_name | required | have | runtime-only | — | Metadata / identifier — not subject to provenance review. |
 
 ### Economic assumptions
 


### PR DESCRIPTION
The plan_meta rows (plan_name, plan_description, data_dir) were labeled runtime-only with no further distinction, lumping them with real engine choices like model_period or min_age. They are different in kind: identifiers, human labels, and file-path wiring are not subject to provenance review at all.

This commit:

- Annotates the three plan_meta rows in template and txtrs-av instance with explicit "metadata / not subject to provenance review" notes.
- Sharpens the README's runtime-only definition to distinguish two sub-flavors: modeling-engine choices that affect output (kept in the checklist for review) and metadata / wiring (kept only so the row set stays complete).
- Regenerates the txtrs-av markdown view.

Rows kept rather than dropped per the user's preference: better to have them present with clear notes than to risk silently forgetting them.