### PR TITLE
A1a: remove plan-specific config loaders and plan-named error paths

### DIFF
--- a/src/pension_model/config_loading.py
+++ b/src/pension_model/config_loading.py
@@ -209,13 +209,3 @@ def load_plan_config_by_name(
     else:
         cal_path = calibration_path
     return load_plan_config(config_path, cal_path)
-
-
-def load_frs_config(calibration_path: Optional[Path] = None) -> PlanConfig:
-    """Convenience: load the FRS plan config (debug/tests only)."""
-    return load_plan_config_by_name("frs", calibration_path)
-
-
-def load_txtrs_config(calibration_path: Optional[Path] = None) -> PlanConfig:
-    """Convenience: load the TRS plan config (debug/tests only)."""
-    return load_plan_config_by_name("txtrs", calibration_path)

--- a/src/pension_model/core/_funding_setup.py
+++ b/src/pension_model/core/_funding_setup.py
@@ -162,8 +162,8 @@ def resolve_er_rate_components(stat_rates: dict) -> list:
     if components is None:
         raise ValueError(
             "funding.statutory_rates.er_rate_components is required when "
-            "using the statutory contribution strategy. See "
-            "plans/txtrs/config/plan_config.json for an example schema."
+            "using the statutory contribution strategy. See an existing "
+            "plan's plan_config.json for an example schema."
         )
     return [RateComponent.from_config(c) for c in components]
 

--- a/src/pension_model/core/data_loader.py
+++ b/src/pension_model/core/data_loader.py
@@ -255,8 +255,8 @@ def _resolve_age_group_breaks(constants: PlanConfig) -> list:
     if not groups_cfg:
         raise ValueError(
             "modeling.age_groups is required in plan config when the "
-            "plan uses YOS-only termination rate tables. See "
-            "plans/frs/config/plan_config.json for an example schema."
+            "plan uses YOS-only termination rate tables. See an existing "
+            "plan's plan_config.json for an example schema."
         )
     breaks = []
     for g in groups_cfg:

--- a/src/pension_model/plan_config.py
+++ b/src/pension_model/plan_config.py
@@ -13,10 +13,8 @@ from pension_model.config_helpers import (
 )
 from pension_model.config_loading import (
     discover_plans,
-    load_frs_config,
     load_plan_config,
     load_plan_config_by_name,
-    load_txtrs_config,
 )
 from pension_model.config_resolvers import (
     get_ben_mult,
@@ -46,10 +44,8 @@ __all__ = [
     "get_sep_type",
     "get_tier",
     "get_tier_vectorized",
-    "load_frs_config",
     "load_plan_config",
     "load_plan_config_by_name",
-    "load_txtrs_config",
     "resolve_ben_mult_vec",
     "resolve_cola_scalar",
     "resolve_cola_vec",

--- a/tests/test_pension_model/test_benefit_table_contracts.py
+++ b/tests/test_pension_model/test_benefit_table_contracts.py
@@ -10,12 +10,12 @@ pytestmark = [pytest.mark.regression]
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
 
 from pension_model.core.pipeline import prepare_plan_run
-from pension_model.plan_config import load_frs_config, load_txtrs_config
+from pension_model.plan_config import load_plan_config_by_name
 
 
-@pytest.fixture(scope="module", params=[load_frs_config, load_txtrs_config], ids=["frs", "txtrs"])
+@pytest.fixture(scope="module", params=["frs", "txtrs"], ids=["frs", "txtrs"])
 def prepared_plan_tables(request):
-    constants = request.param()
+    constants = load_plan_config_by_name(request.param)
     prepared = prepare_plan_run(constants, research_mode=True)
     return prepared.constants.plan_name, prepared.retained_plan_tables
 

--- a/tests/test_pension_model/test_benefit_tables.py
+++ b/tests/test_pension_model/test_benefit_tables.py
@@ -42,8 +42,8 @@ class TestSalaryHeadcountTable:
 
     def _get_adjustment_ratio(self, class_name):
         """Compute headcount adjustment ratio matching R model."""
-        from pension_model.plan_config import load_frs_config
-        c = load_frs_config()
+        from pension_model.plan_config import load_plan_config_by_name
+        c = load_plan_config_by_name("frs")
 
         if class_name in ("eco", "eso", "judges"):
             # R uses a shared ratio: combined_total / combined_raw_count
@@ -65,7 +65,7 @@ class TestSalaryHeadcountTable:
     def test_salary_headcount_matches_r(self, class_name, salary_growth):
         """Verify Python salary_headcount_table matches R for each class."""
         from pension_model.core.benefit_tables import build_salary_headcount_table
-        from pension_model.plan_config import load_frs_config
+        from pension_model.plan_config import load_plan_config_by_name
 
         sal, hc = self._load_raw(class_name)
         adj_ratio = self._get_adjustment_ratio(class_name)
@@ -77,7 +77,7 @@ class TestSalaryHeadcountTable:
             class_name=class_name,
             adjustment_ratio=adj_ratio,
             start_year=2022,
-            constants=load_frs_config(),
+            constants=load_plan_config_by_name("frs"),
         )
 
         r = self._load_r_result(class_name)
@@ -132,9 +132,9 @@ class TestSeparationRateTable:
             build_entrant_profile,
             build_separation_rate_table,
         )
-        from pension_model.plan_config import load_frs_config
+        from pension_model.plan_config import load_plan_config_by_name
 
-        constants = load_frs_config()
+        constants = load_plan_config_by_name("frs")
         sg = pd.read_csv(FRS_BASELINES / "salary_growth_table.csv")
 
         # ESO uses Regular's separation table (R line 588)
@@ -196,9 +196,9 @@ class TestAnnFactorTable:
             build_entrant_profile, build_salary_benefit_table,
         )
         from pension_model.core.mortality_builder import build_compact_mortality_from_excel
-        from pension_model.plan_config import load_frs_config
+        from pension_model.plan_config import load_plan_config_by_name
 
-        constants = load_frs_config()
+        constants = load_plan_config_by_name("frs")
         cm = build_compact_mortality_from_excel(
             self.RAW_DIR / "pub-2010-headcount-mort-rates.xlsx",
             self.RAW_DIR / "mortality-improvement-scale-mp-2018-rates.xlsx",
@@ -272,9 +272,9 @@ class TestSalaryBenefitTable:
             build_entrant_profile,
             build_salary_benefit_table,
         )
-        from pension_model.plan_config import load_frs_config
+        from pension_model.plan_config import load_plan_config_by_name
 
-        constants = load_frs_config()
+        constants = load_plan_config_by_name("frs")
         salary_growth = pd.read_csv(FRS_BASELINES / "salary_growth_table.csv")
         sal = pd.read_csv(FRS_BASELINES / f"{class_name}_salary.csv")
         hc = pd.read_csv(FRS_BASELINES / f"{class_name}_headcount.csv")

--- a/tests/test_pension_model/test_calibration.py
+++ b/tests/test_pension_model/test_calibration.py
@@ -25,7 +25,7 @@ CLASSES = ["regular", "special", "admin", "eco", "eso", "judges", "senior_manage
 def calibration_results():
     """Run calibration and return (results, targets, constants)."""
     from pension_model.core.pipeline import run_plan_pipeline
-    from pension_model.plan_config import load_frs_config
+    from pension_model.plan_config import load_plan_config_by_name
     from pension_model.core.calibration import (
         build_targets_from_config, run_calibration,
     )
@@ -33,7 +33,7 @@ def calibration_results():
     # Load with calibration file to get cal_factor (a calibration parameter,
     # not plan design), but neutralize nc_cal and pvfb_term_current so the
     # calibration module re-derives them from scratch.
-    constants = load_frs_config()
+    constants = load_plan_config_by_name("frs")
     # Reset per-class calibration values to neutral in the underlying dict
     for cn in constants.calibration:
         constants.calibration[cn]["nc_cal"] = 1.0

--- a/tests/test_pension_model/test_consistency.py
+++ b/tests/test_pension_model/test_consistency.py
@@ -23,9 +23,9 @@ def model_results():
     """Run full pipeline once and return (liability, funding, constants)."""
     from pension_model.core.pipeline import run_plan_pipeline
     from pension_model.core.funding_model import load_funding_inputs, run_funding_model
-    from pension_model.plan_config import load_frs_config
+    from pension_model.plan_config import load_plan_config_by_name
 
-    constants = load_frs_config()
+    constants = load_plan_config_by_name("frs")
     liability = run_plan_pipeline(constants)
     funding_dir = constants.resolve_data_dir() / "funding"
     funding_inputs = load_funding_inputs(funding_dir)

--- a/tests/test_pension_model/test_funding_baseline.py
+++ b/tests/test_pension_model/test_funding_baseline.py
@@ -33,9 +33,9 @@ def funding_results():
     """Run the full pipeline once and cache results for all tests."""
     from pension_model.core.pipeline import run_plan_pipeline
     from pension_model.core.funding_model import load_funding_inputs, run_funding_model
-    from pension_model.plan_config import load_frs_config
+    from pension_model.plan_config import load_plan_config_by_name
 
-    constants = load_frs_config()
+    constants = load_plan_config_by_name("frs")
     liability = run_plan_pipeline(constants)
     funding_dir = constants.resolve_data_dir() / "funding"
     funding_inputs = load_funding_inputs(funding_dir)

--- a/tests/test_pension_model/test_funding_snapshots.py
+++ b/tests/test_pension_model/test_funding_snapshots.py
@@ -52,14 +52,11 @@ def _run_funding(plan_name: str) -> dict:
     """Run the full pipeline and return the funding dict for ``plan_name``."""
     from pension_model.core.pipeline import run_plan_pipeline
     from pension_model.core.funding_model import load_funding_inputs, run_funding_model
-    from pension_model.plan_config import load_frs_config, load_txtrs_config
+    from pension_model.plan_config import load_plan_config_by_name
 
-    if plan_name == "frs":
-        constants = load_frs_config()
-    elif plan_name == "txtrs":
-        constants = load_txtrs_config()
-    else:
+    if plan_name not in ("frs", "txtrs"):
         raise ValueError(f"Unknown plan: {plan_name}")
+    constants = load_plan_config_by_name(plan_name)
 
     liability = run_plan_pipeline(constants)
     funding_inputs = load_funding_inputs(constants.resolve_data_dir() / "funding")

--- a/tests/test_pension_model/test_multi_class_gainloss.py
+++ b/tests/test_pension_model/test_multi_class_gainloss.py
@@ -30,9 +30,9 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
 def two_class_gainloss_outputs():
     from pension_model.core.pipeline import run_plan_pipeline
     from pension_model.core.funding_model import load_funding_inputs, run_funding_model
-    from pension_model.plan_config import load_txtrs_config
+    from pension_model.plan_config import load_plan_config_by_name
 
-    constants = load_txtrs_config()
+    constants = load_plan_config_by_name("txtrs")
     liability = run_plan_pipeline(constants)
     funding_inputs = load_funding_inputs(constants.resolve_data_dir() / "funding")
 

--- a/tests/test_pension_model/test_plan_config_frs.py
+++ b/tests/test_pension_model/test_plan_config_frs.py
@@ -7,12 +7,12 @@ import pytest
 pytestmark = [pytest.mark.unit]
 
 from pension_model.config_loading import load_plan_config
-from pension_model.plan_config import load_frs_config
+from pension_model.plan_config import load_plan_config_by_name
 
 
 @pytest.fixture(scope="module")
 def frs_config():
-    return load_frs_config()
+    return load_plan_config_by_name("frs")
 
 
 class TestPlanConfigLoad:

--- a/tests/test_pension_model/test_plan_config_txtrs.py
+++ b/tests/test_pension_model/test_plan_config_txtrs.py
@@ -4,11 +4,11 @@ import pytest
 
 pytestmark = [pytest.mark.unit]
 
-from pension_model.plan_config import load_txtrs_config
+from pension_model.plan_config import load_plan_config_by_name
 
 
 def test_txtrs_loads():
-    config = load_txtrs_config()
+    config = load_plan_config_by_name("txtrs")
     assert config.plan_name == "txtrs"
     assert len(config.classes) == 1
     assert config.classes[0] == "all"

--- a/tests/test_pension_model/test_rundown.py
+++ b/tests/test_pension_model/test_rundown.py
@@ -48,9 +48,9 @@ def rundown_results():
     """
     from pension_model.core.pipeline import run_plan_pipeline
     from pension_model.core.funding_model import load_funding_inputs, run_funding_model
-    from pension_model.plan_config import load_frs_config
+    from pension_model.plan_config import load_plan_config_by_name
 
-    constants = load_frs_config()
+    constants = load_plan_config_by_name("frs")
     # PlanConfig stores model_period as a top-level field; ranges is a derived
     # property, so we override the field directly.
     constants = replace(constants, model_period=RUNDOWN_PERIOD)

--- a/tests/test_pension_model/test_runtime_contracts.py
+++ b/tests/test_pension_model/test_runtime_contracts.py
@@ -25,12 +25,12 @@ from pension_model.core.profiling import (
     write_runtime_baseline,
 )
 from pension_model.core.runtime_contracts import ClassRuntimeTables
-from pension_model.plan_config import load_txtrs_config
+from pension_model.plan_config import load_plan_config_by_name
 
 
 @pytest.fixture(scope="module")
 def txtrs_constants():
-    return load_txtrs_config()
+    return load_plan_config_by_name("txtrs")
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_pension_model/test_stage3_loader.py
+++ b/tests/test_pension_model/test_stage3_loader.py
@@ -52,8 +52,8 @@ FRS_BASELINES = Path(__file__).parent.parent.parent / "plans" / "frs" / "baselin
 
 @pytest.fixture(scope="module")
 def frs_config():
-    from pension_model.plan_config import load_frs_config
-    return load_frs_config()
+    from pension_model.plan_config import load_plan_config_by_name
+    return load_plan_config_by_name("frs")
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_pension_model/test_truth_table_frs.py
+++ b/tests/test_pension_model/test_truth_table_frs.py
@@ -15,9 +15,9 @@ def frs_truth_table():
     """Run the FRS pipeline and build the truth table."""
     from pension_model.core.pipeline import run_plan_pipeline
     from pension_model.core.funding_model import load_funding_inputs, run_funding_model
-    from pension_model.plan_config import load_frs_config
+    from pension_model.plan_config import load_plan_config_by_name
 
-    constants = load_frs_config()
+    constants = load_plan_config_by_name("frs")
     liability = run_plan_pipeline(constants)
     funding_dir = constants.resolve_data_dir() / "funding"
     funding_inputs = load_funding_inputs(funding_dir)

--- a/tests/test_pension_model/test_truth_table_txtrs.py
+++ b/tests/test_pension_model/test_truth_table_txtrs.py
@@ -15,9 +15,9 @@ def txtrs_truth_table():
     """Run the TXTRS pipeline and build the truth table."""
     from pension_model.core.pipeline import run_plan_pipeline
     from pension_model.core.funding_model import load_funding_inputs, run_funding_model
-    from pension_model.plan_config import load_txtrs_config
+    from pension_model.plan_config import load_plan_config_by_name
 
-    constants = load_txtrs_config()
+    constants = load_plan_config_by_name("txtrs")
     liability = run_plan_pipeline(constants)
     funding_dir = constants.resolve_data_dir() / "funding"
     funding_inputs = load_funding_inputs(funding_dir)

--- a/tests/test_pension_model/test_vectorized_resolvers_frs.py
+++ b/tests/test_pension_model/test_vectorized_resolvers_frs.py
@@ -10,7 +10,7 @@ from pension_model.plan_config import (
     get_ben_mult,
     get_reduce_factor,
     get_tier,
-    load_frs_config,
+    load_plan_config_by_name,
     resolve_ben_mult_vec,
     resolve_cola_vec,
     resolve_reduce_factor_vec,
@@ -26,7 +26,7 @@ from ._vectorized_resolver_test_support import (
 
 
 def test_resolve_tiers_vec_matches_scalar_frs():
-    config = load_frs_config()
+    config = load_plan_config_by_name("frs")
     rows = build_frs_grid()
     cn, ey, age, yos = rows_to_arrays(rows)
 
@@ -49,7 +49,7 @@ def test_resolve_tiers_vec_matches_scalar_frs():
 
 
 def test_resolve_tiers_vec_accepts_categorical_class_name():
-    config = load_frs_config()
+    config = load_plan_config_by_name("frs")
     rows = build_frs_grid()[:500]
     cn, ey, age, yos = rows_to_arrays(rows)
 
@@ -63,7 +63,7 @@ def test_resolve_tiers_vec_accepts_categorical_class_name():
 
 
 def test_resolve_tiers_vec_entry_age_override_frs():
-    config = load_frs_config()
+    config = load_plan_config_by_name("frs")
     cn = np.array(["regular", "regular"], dtype=object)
     ey = np.array([2000, 2000], dtype=np.int64)
     age = np.array([40, 40], dtype=np.int64)
@@ -79,7 +79,7 @@ def test_resolve_tiers_vec_entry_age_override_frs():
 
 
 def test_resolve_cola_vec_matches_scalar_frs():
-    config = load_frs_config()
+    config = load_plan_config_by_name("frs")
     rows = build_frs_grid()
     cn, ey, age, yos = rows_to_arrays(rows)
 
@@ -98,7 +98,7 @@ def test_resolve_cola_vec_matches_scalar_frs():
 
 
 def test_resolve_ben_mult_vec_matches_scalar_frs():
-    config = load_frs_config()
+    config = load_plan_config_by_name("frs")
     rows = build_frs_grid()
     cn, ey, age, yos = rows_to_arrays(rows)
 
@@ -119,7 +119,7 @@ def test_resolve_ben_mult_vec_matches_scalar_frs():
 
 
 def test_resolve_ben_mult_vec_accepts_categorical_class_name():
-    config = load_frs_config()
+    config = load_plan_config_by_name("frs")
     rows = build_frs_grid()[:500]
     cn, ey, age, yos = rows_to_arrays(rows)
     tier_id, ret_status = resolve_tiers_vec(config, cn, ey, age, yos)
@@ -136,7 +136,7 @@ def test_resolve_ben_mult_vec_accepts_categorical_class_name():
 
 
 def test_resolve_reduce_factor_vec_matches_scalar_frs():
-    config = load_frs_config()
+    config = load_plan_config_by_name("frs")
     rows = build_frs_grid()
     cn, ey, age, yos = rows_to_arrays(rows)
 
@@ -167,7 +167,7 @@ def test_resolve_reduce_factor_vec_matches_scalar_frs():
 
 
 def test_resolve_reduce_factor_vec_accepts_categorical_class_name():
-    config = load_frs_config()
+    config = load_plan_config_by_name("frs")
     rows = build_frs_grid()[:500]
     cn, ey, age, yos = rows_to_arrays(rows)
     tier_id, ret_status = resolve_tiers_vec(config, cn, ey, age, yos)

--- a/tests/test_pension_model/test_vectorized_resolvers_txtrs.py
+++ b/tests/test_pension_model/test_vectorized_resolvers_txtrs.py
@@ -9,7 +9,7 @@ from pension_model.plan_config import (
     get_ben_mult,
     get_reduce_factor,
     get_tier,
-    load_txtrs_config,
+    load_plan_config_by_name,
     resolve_ben_mult_vec,
     resolve_cola_vec,
     resolve_reduce_factor_vec,
@@ -25,7 +25,7 @@ from ._vectorized_resolver_test_support import (
 
 
 def test_resolve_tiers_vec_matches_scalar_txtrs():
-    config = load_txtrs_config()
+    config = load_plan_config_by_name("txtrs")
     rows = build_txtrs_grid()
     cn, ey, age, yos = rows_to_arrays(rows)
 
@@ -48,7 +48,7 @@ def test_resolve_tiers_vec_matches_scalar_txtrs():
 
 
 def test_resolve_cola_vec_matches_scalar_txtrs():
-    config = load_txtrs_config()
+    config = load_plan_config_by_name("txtrs")
     rows = build_txtrs_grid()
     cn, ey, age, yos = rows_to_arrays(rows)
 
@@ -67,7 +67,7 @@ def test_resolve_cola_vec_matches_scalar_txtrs():
 
 
 def test_resolve_ben_mult_vec_matches_scalar_txtrs():
-    config = load_txtrs_config()
+    config = load_plan_config_by_name("txtrs")
     rows = build_txtrs_grid()
     cn, ey, age, yos = rows_to_arrays(rows)
 
@@ -88,7 +88,7 @@ def test_resolve_ben_mult_vec_matches_scalar_txtrs():
 
 
 def test_resolve_reduce_factor_vec_matches_scalar_txtrs():
-    config = load_txtrs_config()
+    config = load_plan_config_by_name("txtrs")
     rows = build_txtrs_grid()
     cn, ey, age, yos = rows_to_arrays(rows)
 


### PR DESCRIPTION
First PR in the Phase A generalization sequence. Closes #98 once merged.

## Summary

- Delete `load_frs_config()` and `load_txtrs_config()` from `config_loading.py`; remove from `plan_config.py` exports.
- Migrate ~15 test files to `load_plan_config_by_name("frs" | "txtrs")`.
- Replace literal `plans/frs/...` / `plans/txtrs/...` strings in two error messages with a generic "an existing plan's plan_config.json" reference.

## Why

Per `meta-docs/repo_goals.md`, the model should support any number of plans through configuration alone. Plan-named loaders and plan-named error strings leak plan identity into the public API and into user-facing diagnostics. `load_plan_config_by_name(plan)` already covers the same need without naming a plan in code.

## Validation

- ` make r-match ` passes — FRS and TXTRS x {baseline, low_return, high_discount} at relative diff < 1e-10.
- ` make test ` passes — 322 passed, 2 skipped (unrelated snapshot updaters).

## Out of scope

The `PLAN_TEST_FILES` dict in `cli.py` and the `_frs` / `_txtrs` test-file naming convention will be addressed in A1b.

## Test plan

- [x] `make r-match` (6/6 truth-table cells pass)
- [x] `make test` (322 passed)
- [ ] Owner review of the diff

Refs #98