### PR TITLE
A1b: replace PLAN_TEST_FILES with per-plan test manifests

### DIFF
--- a/plans/frs/test_manifest.json
+++ b/plans/frs/test_manifest.json
@@ -1,0 +1,15 @@
+{
+  "tests": [
+    "tests/test_pension_model/test_cli_frs.py",
+    "tests/test_pension_model/test_plan_config_frs.py",
+    "tests/test_pension_model/test_vectorized_resolvers_frs.py",
+    "tests/test_pension_model/test_data_integrity.py",
+    "tests/test_pension_model/test_consistency.py",
+    "tests/test_pension_model/test_calibration.py",
+    "tests/test_pension_model/test_funding_baseline.py",
+    "tests/test_pension_model/test_benefit_tables.py",
+    "tests/test_pension_model/test_stage3_loader.py",
+    "tests/test_pension_model/test_truth_table_frs.py",
+    "tests/test_pension_model/test_rundown.py"
+  ]
+}

--- a/plans/txtrs/test_manifest.json
+++ b/plans/txtrs/test_manifest.json
@@ -1,0 +1,9 @@
+{
+  "tests": [
+    "tests/test_pension_model/test_cli_txtrs.py",
+    "tests/test_pension_model/test_plan_config_txtrs.py",
+    "tests/test_pension_model/test_vectorized_resolvers_txtrs.py",
+    "tests/test_pension_model/test_truth_table_txtrs.py",
+    "tests/test_pension_model/test_multi_class_gainloss.py"
+  ]
+}

--- a/src/pension_model/cli.py
+++ b/src/pension_model/cli.py
@@ -452,35 +452,33 @@ DEFAULT_CORE_TEST_FILES = [
     "tests/test_pension_model/test_cli_shared.py",
 ]
 
-PLAN_TEST_FILES = {
-    "frs": [
-        "tests/test_pension_model/test_cli_frs.py",
-        "tests/test_pension_model/test_plan_config_frs.py",
-        "tests/test_pension_model/test_vectorized_resolvers_frs.py",
-        "tests/test_pension_model/test_data_integrity.py",
-        "tests/test_pension_model/test_consistency.py",
-        "tests/test_pension_model/test_calibration.py",
-        "tests/test_pension_model/test_funding_baseline.py",
-        "tests/test_pension_model/test_benefit_tables.py",
-        "tests/test_pension_model/test_stage3_loader.py",
-        "tests/test_pension_model/test_truth_table_frs.py",
-        "tests/test_pension_model/test_rundown.py",
-    ],
-    "txtrs": [
-        "tests/test_pension_model/test_cli_txtrs.py",
-        "tests/test_pension_model/test_plan_config_txtrs.py",
-        "tests/test_pension_model/test_vectorized_resolvers_txtrs.py",
-        "tests/test_pension_model/test_truth_table_txtrs.py",
-        "tests/test_pension_model/test_multi_class_gainloss.py",
-    ],
-}
+
+def _load_plan_test_manifest(plan_name: str) -> list[str]:
+    """Read a plan's CLI-test list from plans/<plan>/test_manifest.json.
+
+    The manifest schema is ``{"tests": [<repo-relative test paths>]}``.
+    A plan with no manifest contributes no plan-specific tests; the CLI
+    will run only ``DEFAULT_CORE_TEST_FILES`` for that plan.
+    """
+    import json
+    from pension_model.config_loading import discover_plans
+
+    plans = discover_plans()
+    if plan_name not in plans:
+        return []
+    manifest_path = plans[plan_name].parent.parent / "test_manifest.json"
+    if not manifest_path.exists():
+        return []
+    with manifest_path.open() as f:
+        manifest = json.load(f)
+    return list(manifest.get("tests", []))
 
 
 def _get_test_targets(plan_name: str | None = None) -> list[str]:
     """Return the pytest targets for a full-suite or plan-scoped CLI run."""
     if plan_name is None:
         return ["tests/test_pension_model/"]
-    return [*DEFAULT_CORE_TEST_FILES, *PLAN_TEST_FILES.get(plan_name, [])]
+    return [*DEFAULT_CORE_TEST_FILES, *_load_plan_test_manifest(plan_name)]
 
 
 def run_tests(plan_name: str | None = None):


### PR DESCRIPTION
Second PR in the Phase A generalization sequence. Closes #100 once merged.

## Summary

- Add `plans/frs/test_manifest.json` and `plans/txtrs/test_manifest.json` listing the plan-coupled tests for `pension-model run <plan> --test-only`.
- Replace the `PLAN_TEST_FILES` dict in `src/pension_model/cli.py` with `_load_plan_test_manifest(plan_name)`, which reads each plan's manifest at runtime.

Manifest schema: ``{"tests": ["tests/test_pension_model/...", ...]}``. A plan with no manifest contributes no plan-specific tests.

## Why

`PLAN_TEST_FILES` was the last plan-name-keyed dict in `cli.py`. With this change, adding a new plan no longer requires a Python edit just to wire up `--test-only` — the manifest ships alongside the plan's config and data.

The manifest sits at the top of `plans/<plan>/` (next to `data/`, `baselines/`) rather than under `config/`, because it points at tests rather than at config.

## Validation

- ``_get_test_targets("frs")`` and ``_get_test_targets("txtrs")`` return byte-identical lists to what `PLAN_TEST_FILES` produced.
- ``make r-match`` passes — FRS and TXTRS x {baseline, low_return, high_discount} at relative diff < 1e-10.

## Test plan

- [x] `make r-match`
- [x] Manual check: `_get_test_targets()` returns the expected lists for frs, txtrs, and None
- [ ] Owner review

Refs #100