### PR TITLE
A3: per-tier discount_rate_key replaces hardcoded tier_3 string check

### DIFF
--- a/plans/frs/config/plan_config.json
+++ b/plans/frs/config/plan_config.json
@@ -155,7 +155,8 @@
       "entry_year_max": null,
       "eligibility_same_as": "tier_2",
       "early_retire_reduction_same_as": "tier_2",
-      "cola_key": "tier_3_active"
+      "cola_key": "tier_3_active",
+      "discount_rate_key": "dr_new"
     }
   ],
 

--- a/src/pension_model/config_loading.py
+++ b/src/pension_model/config_loading.py
@@ -59,17 +59,21 @@ def _build_tier_metadata(
     tier_defs_raw: list[dict],
     *,
     fas_default: int,
-) -> tuple[dict[str, int], tuple[str, ...], tuple[str, ...], tuple[int, ...]]:
+) -> tuple[dict[str, int], tuple[str, ...], tuple[str, ...], tuple[int, ...], tuple[str, ...]]:
     """Build tier lookup tables cached on ``PlanConfig``."""
     tier_name_to_id = {td["name"]: i for i, td in enumerate(tier_defs_raw)}
     tier_id_to_name = tuple(td["name"] for td in tier_defs_raw)
     tier_id_to_cola_key = tuple(td["cola_key"] for td in tier_defs_raw)
     tier_id_to_fas_years = tuple(td.get("fas_years", fas_default) for td in tier_defs_raw)
+    tier_id_to_dr_key = tuple(
+        td.get("discount_rate_key", "dr_current") for td in tier_defs_raw
+    )
     return (
         tier_name_to_id,
         tier_id_to_name,
         tier_id_to_cola_key,
         tier_id_to_fas_years,
+        tier_id_to_dr_key,
     )
 
 
@@ -118,6 +122,7 @@ def load_plan_config(
         tier_id_to_name,
         tier_id_to_cola_key,
         tier_id_to_fas_years,
+        tier_id_to_dr_key,
     ) = _build_tier_metadata(
         tier_defs_raw,
         fas_default=ben.get("fas_years_default", 5),
@@ -170,6 +175,7 @@ def load_plan_config(
         _tier_id_to_name=tier_id_to_name,
         _tier_id_to_cola_key=tier_id_to_cola_key,
         _tier_id_to_fas_years=tier_id_to_fas_years,
+        _tier_id_to_dr_key=tier_id_to_dr_key,
     )
 
     for warning in config.validate():

--- a/src/pension_model/config_schema.py
+++ b/src/pension_model/config_schema.py
@@ -71,6 +71,7 @@ class PlanConfig:
     _tier_id_to_name: Tuple[str, ...] = ()
     _tier_id_to_cola_key: Tuple[str, ...] = ()
     _tier_id_to_fas_years: Tuple[int, ...] = ()
+    _tier_id_to_dr_key: Tuple[str, ...] = ()
 
     @property
     def scenario_name(self) -> Optional[str]:

--- a/src/pension_model/core/benefit_tables.py
+++ b/src/pension_model/core/benefit_tables.py
@@ -1364,8 +1364,12 @@ def build_benefit_val_table(
 
     ret_status_arr = sbt["ret_status"].to_numpy(dtype=np.int8, copy=False)
     sep_kind_arr = _resolve_sep_kind_vec(ret_status_arr)
-    tier_3_id = constants._tier_name_to_id.get("tier_3", -1)
-    dr_arr = np.where(sbt["tier_id"] == tier_3_id, econ.dr_new, econ.dr_current)
+    dr_by_tier_id = np.array(
+        [econ.dr_new if k == "dr_new" else econ.dr_current
+         for k in constants._tier_id_to_dr_key],
+        dtype=np.float64,
+    )
+    dr_arr = dr_by_tier_id[sbt["tier_id"].to_numpy()]
 
     # PVFB at termination: mix of annuity and refund based on sep_type.
     # Retirees get full annuity PV; vested get retire_refund_ratio-weighted

--- a/src/pension_model/core/cohort_calculator.py
+++ b/src/pension_model/core/cohort_calculator.py
@@ -23,6 +23,18 @@ from pension_model.config_helpers import (
 from pension_model.core.compact_mortality import CompactMortality
 
 
+def _dr_key_for_tier(tier: str, constants) -> str:
+    """Look up the discount-rate key for a tier+status string.
+
+    ``get_tier`` returns names like ``"tier_3_norm"`` or ``"current_vested"``;
+    match the leading portion against the configured tier base names.
+    """
+    for name, tid in constants._tier_name_to_id.items():
+        if tier == name or tier.startswith(name + "_"):
+            return constants._tier_id_to_dr_key[tid]
+    return "dr_current"
+
+
 def compute_cohort_salary(
     entry_age: int,
     entry_year: int,
@@ -124,7 +136,7 @@ def compute_cohort_annuity_factors(
 
         term_year = entry_year + yos
         tier = get_tier(class_name, entry_year, term_age, yos, r.new_year)
-        dr = dr_new if "tier_3" in tier else dr_current
+        dr = dr_new if _dr_key_for_tier(tier, constants) == "dr_new" else dr_current
 
         # Determine distribution age
         # Vested: defer to earliest normal retirement age
@@ -281,7 +293,7 @@ def compute_cohort_benefits(
     dr_vec = np.full(n, econ.dr_current)
     for yos in range(n):
         tier = get_tier(class_name, entry_year, entry_age + yos, yos, r.new_year)
-        if "tier_3" in tier:
+        if _dr_key_for_tier(tier, constants) == "dr_new":
             dr_vec[yos] = econ.dr_new
 
     pvfb_current = _get_pvfb(sep_rates, dr_vec, pvfb_wealth_at_term)


### PR DESCRIPTION
Fourth PR in the Phase A generalization sequence. Closes #104 once merged.

## Summary

Replace the literal ``tier_3`` string check that selected ``dr_new`` over ``dr_current`` with a per-tier ``discount_rate_key`` configuration field.

Three call sites updated:
- ``benefit_tables.py:1367`` — vectorized: builds a per-tier-id discount-rate array from the config and indexes into it.
- ``cohort_calculator.py:127`` and ``cohort_calculator.py:284`` — scalar yos loops: a small helper ``_dr_key_for_tier`` matches the leading portion of a tier+status string (e.g. ``tier_3_norm``, ``current_vested``) against configured tier base names.

Schema additions:
- ``PlanConfig._tier_id_to_dr_key: Tuple[str, ...]`` built in ``_build_tier_metadata``.
- ``plans/frs/config/plan_config.json`` adds ``"discount_rate_key": "dr_new"`` to ``tier_3``. All other tiers default to ``"dr_current"``. TXTRS and TXTRS-AV have no ``tier_3``, so the old code already routed them to ``dr_current`` — no config change needed there.

## Why

The literal ``"tier_3"`` baked a plan-specific naming convention into the engine. Any plan with a different naming scheme — or a different tier needing the discount-rate override — could not express it. Per-tier ``discount_rate_key`` makes the policy explicit at the tier definition.

## Validation

- ``make r-match`` — 6/6 truth-table cells pass at relative diff < 1e-10.
- ``make test`` — 322 passed, 2 skipped (unrelated snapshot updaters).

## Test plan

- [x] ``make r-match``
- [x] ``make test``
- [ ] Owner review

Refs #104