### PR TITLE
A4: replace before_2018/after_2018 with plan-agnostic before_cutoff/after_cutoff

### DIFF
--- a/plans/frs/config/plan_config.json
+++ b/plans/frs/config/plan_config.json
@@ -230,13 +230,13 @@
   "plan_design": {
     "cutoff_year": 2018,
     "special_group": {
-      "before_2018": 0.95,
-      "after_2018": 0.85,
+      "before_cutoff": 0.95,
+      "after_cutoff": 0.85,
       "new": 0.75
     },
     "regular_group": {
-      "before_2018": 0.75,
-      "after_2018": 0.25,
+      "before_cutoff": 0.75,
+      "after_cutoff": 0.25,
       "new": 0.25
     }
   },

--- a/plans/txtrs-av/config/plan_config.json
+++ b/plans/txtrs-av/config/plan_config.json
@@ -230,7 +230,7 @@
   "plan_design": {
     "cutoff_year": null,
     "default": {
-      "before_new_year": 1.0,
+      "before_cutoff": 1.0,
       "new_db": 1.0
     }
   },

--- a/plans/txtrs/config/plan_config.json
+++ b/plans/txtrs/config/plan_config.json
@@ -220,7 +220,7 @@
   "plan_design": {
     "cutoff_year": null,
     "default": {
-      "before_new_year": 1.0,
+      "before_cutoff": 1.0,
       "new_db": 1.0,
       "new_cb": 0.0
     }

--- a/src/pension_model/config_compat.py
+++ b/src/pension_model/config_compat.py
@@ -83,8 +83,8 @@ def build_plan_design_namespace(config) -> SimpleNamespace:
     def _get_ratios(is_special: bool) -> tuple:
         group = "special_group" if is_special else "default"
         ratios = config.plan_design_defs.get(group, config.plan_design_defs.get("default", {}))
-        before = ratios.get("before_2018", ratios.get("before_new_year", 1.0))
-        after = ratios.get("after_2018", ratios.get("after_new_year", before))
+        before = ratios.get("before_cutoff", 1.0)
+        after = ratios.get("after_cutoff", before)
         new = ratios.get("new", ratios.get("new_db", 1.0))
         return before, after, new
 

--- a/src/pension_model/config_helpers.py
+++ b/src/pension_model/config_helpers.py
@@ -145,7 +145,7 @@ def get_plan_design_ratios(config: PlanConfig, class_name: str) -> Tuple[float, 
     """Return ``(before, after, new)`` DB plan-design ratios."""
     group = config.class_group(class_name)
     ratios = config.plan_design_defs.get(group, config.plan_design_defs.get("default", {}))
-    before = ratios.get("before_2018", ratios.get("before_new_year", 1.0))
-    after = ratios.get("after_2018", ratios.get("after_new_year", before))
+    before = ratios.get("before_cutoff", 1.0)
+    after = ratios.get("after_cutoff", before)
     new = ratios.get("new", ratios.get("new_db", 1.0))
     return before, after, new

--- a/src/pension_model/config_schema.py
+++ b/src/pension_model/config_schema.py
@@ -194,8 +194,8 @@ class PlanConfig:
         result = {}
         for bt in self.benefit_types:
             if bt == "db":
-                before = ratios.get("before_2018", ratios.get("before_new_year", 1.0))
-                after = ratios.get("after_2018", ratios.get("after_new_year", before))
+                before = ratios.get("before_cutoff", 1.0)
+                after = ratios.get("after_cutoff", before)
                 new = ratios.get("new", ratios.get("new_db", 1.0))
                 result["db"] = (before, after, new)
             elif bt == "cb":


### PR DESCRIPTION
Fifth PR in the Phase A generalization sequence. Closes #106 once merged.

## Summary

Three source files looked up DB design ratios through a dual-fallback chain that hardcoded the FRS cutoff year (\`before_2018\`/\`after_2018\`) with a TXTRS-leaning fallback (\`before_new_year\`/\`after_new_year\`). The plan_design section already carries an explicit \`cutoff_year\` field used elsewhere — only the dict keys needed plan-agnostic naming.

This PR renames to \`before_cutoff\`/\`after_cutoff\` in all three source-code lookups and in all three plan configs (FRS, TXTRS, TXTRS-AV). The lookup simplifies to:

\`\`\`python
before = ratios.get("before_cutoff", 1.0)
after  = ratios.get("after_cutoff", before)
\`\`\`

\`plans/frs/baselines/input_params.json\` keeps its R-style names — that file is a reference snapshot and isn't read by the runtime.

## Why

\`before_2018\` baked an FRS-specific year into the lookup. The dual-fallback chain was confusing and asymmetric. The cutoff year stays in \`plan_design.cutoff_year\` as a real engine field; the dict keys are now plan-agnostic.

## Validation

- \`make r-match\` — 6/6 truth-table cells pass at relative diff < 1e-10.
- \`make test\` — 322 passed, 2 skipped (unrelated snapshot updaters).

## Test plan

- [x] \`make r-match\`
- [x] \`make test\`
- [ ] Owner review

Refs #106