### PR TITLE
A5: remove is_special() helper and dead build_plan_design_namespace

### DIFF
--- a/src/pension_model/config_compat.py
+++ b/src/pension_model/config_compat.py
@@ -75,13 +75,3 @@ def build_class_data_namespace(config) -> dict:
     return result
 
 
-def build_plan_design_namespace(config) -> SimpleNamespace:
-    def _get_ratios(is_special: bool) -> tuple:
-        group = "special_group" if is_special else "default"
-        ratios = config.plan_design_defs.get(group, config.plan_design_defs.get("default", {}))
-        before = ratios.get("before_cutoff", 1.0)
-        after = ratios.get("after_cutoff", before)
-        new = ratios.get("new", ratios.get("new_db", 1.0))
-        return before, after, new
-
-    return SimpleNamespace(get_ratios=_get_ratios)

--- a/src/pension_model/config_schema.py
+++ b/src/pension_model/config_schema.py
@@ -10,7 +10,6 @@ from pension_model.config_compat import (
     build_class_data_namespace,
     build_economic_namespace,
     build_funding_namespace,
-    build_plan_design_namespace,
     build_ranges_namespace,
 )
 from pension_model.config_validation import validate_config, validate_data_files
@@ -185,10 +184,6 @@ class PlanConfig:
     def class_data(self) -> dict:
         return build_class_data_namespace(self)
 
-    @property
-    def plan_design(self) -> SimpleNamespace:
-        return build_plan_design_namespace(self)
-
     def get_design_ratios(self, class_name: str) -> Dict[str, Tuple[float, float, float]]:
         group = self.design_ratio_group_map.get(class_name, self.class_group(class_name))
         ratios = self.plan_design_defs.get(group, self.plan_design_defs.get("default", {}))
@@ -217,9 +212,6 @@ class PlanConfig:
 
     def class_group(self, class_name: str) -> str:
         return self._class_to_group.get(class_name, "default")
-
-    def is_special(self, class_name: str) -> bool:
-        return self.class_group(class_name) == "special_group"
 
     def get_fas_years(self, tier_name: str) -> int:
         tier_base = tier_name.split("_")[0]

--- a/tests/test_pension_model/test_plan_config_frs.py
+++ b/tests/test_pension_model/test_plan_config_frs.py
@@ -27,9 +27,6 @@ class TestPlanConfigLoad:
         assert frs_config.class_group("regular") == "regular_group"
         assert frs_config.class_group("special") == "special_group"
         assert frs_config.class_group("admin") == "special_group"
-        assert frs_config.is_special("special")
-        assert frs_config.is_special("admin")
-        assert not frs_config.is_special("regular")
 
     def test_frs_acfr(self, frs_config):
         acfr = frs_config.get_class_inputs("regular")


### PR DESCRIPTION
Sixth PR in the Phase A generalization sequence. Closes #108 once merged.

## Summary

Two pieces of plan-name leakage removed:

- ``PlanConfig.is_special(class_name)`` — returned ``class_group(class_name) == "special_group"``. The literal ``"special_group"`` baked an FRS-specific class-group name into the engine API. Used only in three test asserts that duplicated equivalent ``class_group`` checks on the lines above.
- ``build_plan_design_namespace`` and the ``.plan_design`` property — the function hardcoded ``"special_group" if is_special else "default"``. Repo-wide grep shows zero callers — pure dead code, parallel to the COLA namespace removed in A2.

## Why

The class-group schema is already config-driven: FRS declares ``regular_group``/``special_group``; TXTRS and TXTRS-AV declare ``default``. Plans pick whatever group names they want. Only those two API methods (one helper, one dead) froze the FRS names into the engine surface.

The ``"default"`` fallback inside ``class_group()`` stays — it's load-bearing for TXTRS where every class falls back to ``default``. Tightening to "error if no group matches" is Phase B-shaped (changes behavior, needs validation).

## Validation

- ``make r-match`` — 6/6 truth-table cells pass at relative diff < 1e-10.
- ``make test`` — 322 passed, 2 skipped (unrelated snapshot updaters).

## Test plan

- [x] ``make r-match``
- [x] ``make test``
- [ ] Owner review

Refs #108