### PR TITLE
A6: remove silent Python defaults for fas_years_default and vesting_yos

### DIFF
--- a/src/pension_model/config_helpers.py
+++ b/src/pension_model/config_helpers.py
@@ -94,7 +94,7 @@ def extract_normal_retirement_params(
                 nra_yos = rule["min_yos"]
 
     if nra_yos is None:
-        nra_yos = eligibility.get("vesting_yos", 5)
+        nra_yos = eligibility["vesting_yos"]
 
     return nra, nra_yos, yos_threshold
 

--- a/src/pension_model/config_loading.py
+++ b/src/pension_model/config_loading.py
@@ -125,7 +125,7 @@ def load_plan_config(
         tier_id_to_dr_key,
     ) = _build_tier_metadata(
         tier_defs_raw,
-        fas_default=ben.get("fas_years_default", 5),
+        fas_default=ben["fas_years_default"],
     )
 
     config = PlanConfig(
@@ -144,7 +144,7 @@ def load_plan_config(
         db_ee_interest_rate=ben.get("db_ee_interest_rate", 0.0),
         cal_factor=ben.get("cal_factor", 1.0),
         retire_refund_ratio=ben.get("retire_refund_ratio", 1.0),
-        fas_years_default=ben.get("fas_years_default", 5),
+        fas_years_default=ben["fas_years_default"],
         benefit_types=tuple(ben.get("benefit_types", ["db"])),
         cola=ben.get("cola", {}),
         cash_balance=ben.get("cash_balance"),

--- a/src/pension_model/config_resolvers_scalar.py
+++ b/src/pension_model/config_resolvers_scalar.py
@@ -79,7 +79,7 @@ def get_tier(
     if _matches_any(eligibility.get("early", []), age, yos, entry_year, entry_age):
         return f"{tier_name}_early"
 
-    vesting_yos = eligibility.get("vesting_yos", 5)
+    vesting_yos = eligibility["vesting_yos"]
     if yos >= vesting_yos:
         return f"{tier_name}_vested"
 

--- a/src/pension_model/config_resolvers_vectorized.py
+++ b/src/pension_model/config_resolvers_vectorized.py
@@ -175,7 +175,7 @@ def resolve_tiers_vec(
             sub_yos = yos[combo_mask]
             norm_mask = _matches_any_vec(eligibility.get("normal", []), sub_age, sub_yos)
             early_mask = _matches_any_vec(eligibility.get("early", []), sub_age, sub_yos) & ~norm_mask
-            vested_mask = (sub_yos >= eligibility.get("vesting_yos", 5)) & ~norm_mask & ~early_mask
+            vested_mask = (sub_yos >= eligibility["vesting_yos"]) & ~norm_mask & ~early_mask
 
             sub_status = np.full(combo_mask.sum(), NON_VESTED, dtype=np.int8)
             sub_status[norm_mask] = NORM

--- a/src/pension_model/core/benefit_tables.py
+++ b/src/pension_model/core/benefit_tables.py
@@ -386,7 +386,7 @@ def build_salary_benefit_table(
     if cb_cfg is not None and actual_icr_series is not None:
         ee_credit = cb_cfg["ee_pay_credit"]
         er_credit = cb_cfg["er_pay_credit"]
-        cb_vesting = cb_cfg.get("vesting_yos", 5)
+        cb_vesting = cb_cfg["vesting_yos"]
 
         df["cb_ee_cont"] = ee_credit * df["salary"]
         df["cb_er_cont"] = er_credit * df["salary"]
@@ -980,7 +980,7 @@ def build_benefit_table(
         cb_vesting = 5
         cb_cfg = constants.cash_balance
         if cb_cfg is not None:
-            cb_vesting = cb_cfg.get("vesting_yos", 5)
+            cb_vesting = cb_cfg["vesting_yos"]
         is_vested = (df["yos"] >= cb_vesting).astype(float)
         df["pv_cb_benefit"] = (
             is_vested * df["cb_benefit"] * df["ann_factor_term"]
@@ -1336,7 +1336,7 @@ def build_benefit_val_table(
     if has_cb:
         cb_cfg = constants.cash_balance
         if cb_cfg is not None:
-            cb_vesting = cb_cfg.get("vesting_yos", 5)
+            cb_vesting = cb_cfg["vesting_yos"]
 
     # Start from salary_benefit_table
     sbt = salary_benefit_table.copy()


### PR DESCRIPTION
Seventh PR in the Phase A generalization sequence. Closes #110 once merged.

## Summary

Six call sites used \`.get(key, default)\` to substitute hardcoded values when a plan field was missing. All six fallbacks turned out to be dead code — every plan declares the field. Drop the defaults; let a missing field raise a clear \`KeyError\` instead of silently producing wrong numbers.

\`fas_years_default\` (plan-level): \`config_loading.py:128, 147\`.
\`vesting_yos\` (per-tier / cash-balance): \`config_resolvers_scalar.py:82\`, \`config_resolvers_vectorized.py:178\`, \`config_helpers.py:97\`, \`benefit_tables.py:389/983/1339\`.

## Why

Per \`repo_goals.md\` design principle "Explicit over implicit", silent Python fallbacks for required plan parameters can mask plan-config bugs by substituting numbers that don't match the plan's intent. After this PR, missing fields produce a clear error.

## Out of scope

The literal \`65\` NRA fallbacks at \`config_resolvers_*.py:187/198\` and \`345/367\` are at deeper config paths (per-class maps, per-rule values) and don't fit a single plan-level default. They're left for a scoped follow-up.

## Validation

- \`make r-match\` — 6/6 truth-table cells pass at relative diff < 1e-10.
- \`make test\` — 322 passed, 2 skipped (unrelated snapshot updaters).

## Test plan

- [x] \`make r-match\`
- [x] \`make test\`
- [ ] Owner review

Refs #110