### PR TITLE
A7: replace silent FRS-flavored reduction-factor fallback with explicit error

### DIFF
--- a/src/pension_model/config_resolver_common.py
+++ b/src/pension_model/config_resolver_common.py
@@ -141,23 +141,6 @@ def _lookup_reduce_table(table, table_key: str, dist_age: int, yos: int) -> floa
     return float(row.iloc[0][col])
 
 
-def _default_reduce_factor(dist_age: int) -> float:
-    factors = {
-        55: 0.43,
-        56: 0.46,
-        57: 0.50,
-        58: 0.55,
-        59: 0.59,
-        60: 0.64,
-        61: 0.70,
-        62: 0.76,
-        63: 0.84,
-        64: 0.91,
-        65: 1.00,
-    }
-    return factors.get(dist_age, 1.0 if dist_age >= 65 else float("nan"))
-
-
 def _entry_year_in_tier_vec(entry_year: np.ndarray, tier_def: dict, new_year: int) -> np.ndarray:
     if tier_def.get("assignment") == "grandfathered_rule":
         return np.zeros(len(entry_year), dtype=bool)

--- a/src/pension_model/config_resolvers_scalar.py
+++ b/src/pension_model/config_resolvers_scalar.py
@@ -8,7 +8,6 @@ import numpy as np
 
 from pension_model.config_resolver_common import (
     _check_reduce_condition,
-    _default_reduce_factor,
     _entry_year_in_tier,
     _get_eligibility,
     _is_grandfathered,
@@ -201,7 +200,11 @@ def get_reduce_factor(
                 table_key = rule.get("table_key", "")
                 if config.reduce_tables and table_key in config.reduce_tables:
                     return _lookup_reduce_table(config.reduce_tables[table_key], table_key, dist_age, yos)
-                return _default_reduce_factor(dist_age)
+                raise ValueError(
+                    f"early-retire reduction rule references table_key={table_key!r} "
+                    f"but no matching reduction table is loaded for plan {config.plan_name!r}. "
+                    f"Provide the table CSV under the plan's data directory."
+                )
         return float("nan")
 
     return float("nan")

--- a/src/pension_model/config_resolvers_vectorized.py
+++ b/src/pension_model/config_resolvers_vectorized.py
@@ -12,7 +12,6 @@ from pension_model.config_resolver_common import (
     NORM,
     VESTED,
     _STATUS_SUFFIX,
-    _default_reduce_factor,
     _entry_year_in_tier_vec,
     _get_eligibility,
     _is_grandfathered_vec,
@@ -369,16 +368,19 @@ def resolve_reduce_factor_vec(
                     assigned |= cond_mask
                 elif formula == "table":
                     table_key = rule.get("table_key", "")
+                    if not (config.reduce_tables and table_key in config.reduce_tables):
+                        raise ValueError(
+                            f"early-retire reduction rule references table_key={table_key!r} "
+                            f"but no matching reduction table is loaded for plan {config.plan_name!r}. "
+                            f"Provide the table CSV under the plan's data directory."
+                        )
                     for local_index in np.where(cond_mask)[0]:
-                        if config.reduce_tables and table_key in config.reduce_tables:
-                            sub_vals[local_index] = _lookup_reduce_table(
-                                config.reduce_tables[table_key],
-                                table_key,
-                                int(sub_age[local_index]),
-                                int(sub_yos[local_index]),
-                            )
-                        else:
-                            sub_vals[local_index] = _default_reduce_factor(int(sub_age[local_index]))
+                        sub_vals[local_index] = _lookup_reduce_table(
+                            config.reduce_tables[table_key],
+                            table_key,
+                            int(sub_age[local_index]),
+                            int(sub_yos[local_index]),
+                        )
                     assigned |= cond_mask
             result[idx_arr] = sub_vals
 

--- a/src/pension_model/core/data_loader.py
+++ b/src/pension_model/core/data_loader.py
@@ -22,6 +22,26 @@ from pension_model.config_schema import PlanConfig
 from pension_model.core.returns import build_return_stream
 
 
+def load_reduction_tables(constants: PlanConfig) -> dict | None:
+    """Load early-retire reduction tables from a plan's decrements directory.
+
+    Returns ``{"reduced_gft": <wide DataFrame>, "reduced_others": <DataFrame>}``
+    if both reduction CSVs exist, otherwise ``None``. The keys match the
+    ``table_key`` strings expected by tier ``early_retire_reduction.rules``.
+    """
+    decr_dir = constants.resolve_data_dir() / "decrements"
+    gft_path = decr_dir / "reduction_gft.csv"
+    others_path = decr_dir / "reduction_others.csv"
+    if not (gft_path.exists() and others_path.exists()):
+        return None
+    gft = pd.read_csv(gft_path)
+    gft_wide = gft.pivot(index="yos", columns="age", values="reduce_factor").reset_index()
+    gft_wide.columns = ["yos"] + [int(c) for c in gft_wide.columns[1:]]
+    others = pd.read_csv(others_path)
+    others = others[["age", "reduce_factor"]]
+    return {"reduced_gft": gft_wide, "reduced_others": others}
+
+
 def _load_retiree_distribution(path: Path) -> pd.DataFrame:
     """Load retiree distribution with computed ratio columns.
 
@@ -443,17 +463,9 @@ def _build_years_from_nr_decrements(
     ].reset_index(drop=True)
 
     # Load reduction tables if they exist
-    gft_path = decr_dir / "reduction_gft.csv"
-    others_path = decr_dir / "reduction_others.csv"
-    if gft_path.exists() and others_path.exists():
-        gft = pd.read_csv(gft_path)
-        # Pivot back to wide format expected by get_reduce_factor
-        gft_wide = gft.pivot(index="yos", columns="age", values="reduce_factor").reset_index()
-        gft_wide.columns = ["yos"] + [int(c) for c in gft_wide.columns[1:]]
-
-        others = pd.read_csv(others_path)
-        others = others[["age", "reduce_factor"]]
-        inputs["_reduction_tables"] = {"reduced_gft": gft_wide, "reduced_others": others}
+    reduction_tables = load_reduction_tables(constants)
+    if reduction_tables is not None:
+        inputs["_reduction_tables"] = reduction_tables
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_pension_model/test_vectorized_resolvers_txtrs.py
+++ b/tests/test_pension_model/test_vectorized_resolvers_txtrs.py
@@ -88,7 +88,11 @@ def test_resolve_ben_mult_vec_matches_scalar_txtrs():
 
 
 def test_resolve_reduce_factor_vec_matches_scalar_txtrs():
+    from dataclasses import replace
+    from pension_model.core.data_loader import load_reduction_tables
+
     config = load_plan_config_by_name("txtrs")
+    config = replace(config, reduce_tables=load_reduction_tables(config))
     rows = build_txtrs_grid()
     cn, ey, age, yos = rows_to_arrays(rows)
 


### PR DESCRIPTION
Eighth PR in the Phase A generalization sequence. Closes #112 once merged.

## Summary

\`config_resolver_common.py\` held a \`_default_reduce_factor()\` helper with a hardcoded age-55-to-65 dictionary that fell back silently when a \`formula: "table"\` rule referenced a \`table_key\` not in \`config.reduce_tables\`. The fallback was never reached by any current plan — FRS uses \`formula: "linear"\`, TXTRS / TXTRS-AV load real CSVs — but it would have silently substituted FRS-flavored numbers for any new plan whose CSV failed to load.

This PR:
- Deletes \`_default_reduce_factor\`. Both call sites now raise a clear \`ValueError\` naming the missing \`table_key\` and plan.
- Extracts a small \`load_reduction_tables(constants)\` helper in \`core/data_loader.py\` so unit tests (and other callers) can populate \`reduce_tables\` without going through the full \`load_plan_inputs\` pipeline.
- Updates one test that was relying on the silent fallback.

## Why

Per \`repo_goals.md\`'s "Explicit over implicit", a silent FRS-flavored substitution for a missing table CSV is the wrong default. A loud error pointing at the missing key is the right behavior.

## Validation

- \`make r-match\` — 6/6 truth-table cells pass at relative diff < 1e-10.
- \`make test\` — 322 passed, 2 skipped (unrelated snapshot updaters). One test updated to load reduce_tables explicitly.

## Test plan

- [x] \`make r-match\`
- [x] \`make test\`
- [ ] Owner review

Refs #112