### PR TITLE
A8: replace plan-specific truth-table builders with a generic manifest-driven one

### DIFF
--- a/plans/frs/baselines/r_truth_table_manifest.json
+++ b/plans/frs/baselines/r_truth_table_manifest.json
@@ -1,0 +1,26 @@
+{
+  "plan_name": "frs",
+  "funding_csv": "frs_funding.csv",
+  "year_column": "year",
+  "n_active": {
+    "source": "per_class",
+    "csv_pattern": "{class}_liability.csv",
+    "column": "total_n_active",
+    "classes": ["regular", "special", "admin", "eco", "eso", "judges", "senior_management"]
+  },
+  "metrics": {
+    "mva":           "total_mva",
+    "aal":           "total_aal",
+    "ava":           "total_ava",
+    "fr_mva":        "fr_mva",
+    "fr_ava":        "fr_ava",
+    "payroll":       "total_payroll",
+    "er_cont_total": "total_er_cont",
+    "er_db_cont":    "total_er_db_cont",
+    "ee_cont":       {"sum_with_fillna": ["ee_nc_cont_legacy", "ee_nc_cont_new"]},
+    "benefits":      "total_ben_payment",
+    "refunds":       "total_refund",
+    "admin_exp":     {"sum_with_fillna": ["admin_exp_legacy", "admin_exp_new"]},
+    "net_cf":        {"sum_with_fillna": ["net_cf_legacy", "net_cf_new"]}
+  }
+}

--- a/plans/txtrs/baselines/r_truth_table_manifest.json
+++ b/plans/txtrs/baselines/r_truth_table_manifest.json
@@ -1,0 +1,25 @@
+{
+  "plan_name": "txtrs",
+  "funding_csv": "funding_fresh.csv",
+  "year_column": "fy",
+  "n_active": {
+    "source": "csv",
+    "csv": "baseline_fresh.csv",
+    "column": "n.active"
+  },
+  "metrics": {
+    "mva":           "MVA",
+    "aal":           "AAL",
+    "ava":           "AVA",
+    "fr_mva":        "FR_MVA",
+    "fr_ava":        "FR_AVA",
+    "payroll":       "payroll",
+    "er_cont_total": "er_cont",
+    "er_db_cont":    "er_cont",
+    "ee_cont":       {"sum_with_fillna": ["ee_nc_cont_legacy", "ee_nc_cont_new"]},
+    "benefits":      {"sum_with_fillna": ["ben_payment_legacy", "ben_payment_new"]},
+    "refunds":       {"sum_with_fillna": ["refund_legacy", "refund_new"]},
+    "admin_exp":     {"sum_with_fillna": ["admin_exp_legacy", "admin_exp_new"]},
+    "net_cf":        {"sum_with_fillna": ["net_cf_legacy", "net_cf_new"]}
+  }
+}

--- a/scripts/build/build_r_truth_tables.py
+++ b/scripts/build/build_r_truth_tables.py
@@ -25,8 +25,7 @@ ROOT = Path(__file__).resolve().parent.parent.parent
 sys.path.insert(0, str(ROOT / "src"))
 
 from pension_model.truth_table import (  # noqa: E402
-    build_r_truth_table_frs,
-    build_r_truth_table_txtrs,
+    build_r_truth_table,
     upsert_sheet_to_excel,
     format_truth_table_for_log,
     write_diff_sheet_with_formulas,
@@ -34,20 +33,20 @@ from pension_model.truth_table import (  # noqa: E402
 
 
 def main():
-    baseline_dir = ROOT / "baseline_outputs"
-    trs_r_dir = ROOT / "R_model" / "R_model_txtrs"
+    frs_baseline_dir = ROOT / "plans" / "frs" / "baselines"
+    txtrs_baseline_dir = ROOT / "R_model" / "R_model_txtrs"
     out_path = ROOT / "output" / "truth_tables.xlsx"
 
     print("Building frozen R truth tables")
     print("=" * 60)
 
-    print(f"\n[1/2] FRS from {baseline_dir.relative_to(ROOT)}/")
-    frs_r = build_r_truth_table_frs(baseline_dir)
+    print(f"\n[1/2] FRS from {frs_baseline_dir.relative_to(ROOT)}/")
+    frs_r = build_r_truth_table("frs", frs_baseline_dir)
     print(format_truth_table_for_log(frs_r, max_rows=6))
     print(f"  ... ({len(frs_r)} rows total)")
 
-    print(f"\n[2/2] TRS from {trs_r_dir.relative_to(ROOT)}/")
-    txtrs_r = build_r_truth_table_txtrs(trs_r_dir)
+    print(f"\n[2/2] TXTRS from {txtrs_baseline_dir.relative_to(ROOT)}/")
+    txtrs_r = build_r_truth_table("txtrs", txtrs_baseline_dir)
     print(format_truth_table_for_log(txtrs_r, max_rows=6))
     print(f"  ... ({len(txtrs_r)} rows total)")
 

--- a/src/pension_model/truth_table.py
+++ b/src/pension_model/truth_table.py
@@ -116,104 +116,91 @@ def _actual_invest_income(mva, net_cf):
 
 
 # ---------------------------------------------------------------------------
-# R-side builders — read from R output CSVs, produce a truth table
+# R-side builder — read from R output CSVs, produce a truth table
 # ---------------------------------------------------------------------------
 
-def build_r_truth_table_frs(baseline_dir: Path) -> pd.DataFrame:
-    """Build the frozen FRS R truth table from the R model's output CSVs.
+def _read_metric(funding_df: pd.DataFrame, spec) -> np.ndarray:
+    """Resolve a metric spec from the manifest into a numeric array.
 
-    Sources:
-      - `frs_funding.csv`: plan-wide aggregate of 7 classes + DROP (payroll,
-        AAL, MVA, AVA, contributions, benefits, investment income, funded ratios)
-      - `{class}_liability.csv` × 7: per-class total_n_active, summed for
-        plan-wide n_active
+    A spec is either a string (single column name in the funding CSV) or a
+    dict ``{"sum_with_fillna": ["col_a", "col_b"]}`` (sum the listed columns,
+    treating NaN as zero).
+    """
+    if isinstance(spec, str):
+        return funding_df[spec].values
+    if isinstance(spec, dict) and "sum_with_fillna" in spec:
+        cols = spec["sum_with_fillna"]
+        total = None
+        for c in cols:
+            vals = funding_df[c].fillna(0).values
+            total = vals if total is None else total + vals
+        return total
+    raise ValueError(f"Unsupported metric spec: {spec!r}")
+
+
+def _read_n_active(spec: dict, baseline_dir: Path) -> np.ndarray:
+    """Resolve the n_active spec from the manifest into a numeric array."""
+    source = spec["source"]
+    if source == "csv":
+        df = pd.read_csv(baseline_dir / spec["csv"])
+        return df[spec["column"]].values
+    if source == "per_class":
+        column = spec["column"]
+        classes = spec["classes"]
+        pattern = spec["csv_pattern"]
+        total = None
+        for cn in classes:
+            df = pd.read_csv(baseline_dir / pattern.format(**{"class": cn}))
+            vals = df[column].values
+            total = vals if total is None else total + vals
+        return total
+    raise ValueError(f"Unsupported n_active source: {source!r}")
+
+
+def build_r_truth_table(plan_name: str, baseline_dir: Path) -> pd.DataFrame:
+    """Build the frozen R truth table for a plan from its manifest.
+
+    The manifest at ``plans/<plan>/baselines/r_truth_table_manifest.json``
+    declares the funding CSV, year column, n_active source, and column-name
+    mapping for the unified truth-table schema. This lets a new plan ship a
+    manifest alongside its R baseline without any Python changes.
 
     Not reported (NA) because R does not emit them:
       - n_retired_boy, n_inactive_boy
     """
-    f = pd.read_csv(baseline_dir / "frs_funding.csv")
+    import json
 
-    # Sum active headcount across all 7 FRS classes (per-year)
-    frs_classes = ["regular", "special", "admin", "eco", "eso",
-                   "judges", "senior_management"]
-    n_active = None
-    for cn in frs_classes:
-        liab = pd.read_csv(baseline_dir / f"{cn}_liability.csv")
-        col = liab["total_n_active"].values
-        n_active = col if n_active is None else n_active + col
+    repo_root = Path(__file__).resolve().parents[2]
+    manifest_path = repo_root / "plans" / plan_name / "baselines" / "r_truth_table_manifest.json"
+    with manifest_path.open() as fh:
+        manifest = json.load(fh)
 
-    net_cf = f["net_cf_legacy"].values + f["net_cf_new"].values
-    mva = f["total_mva"].values
+    f = pd.read_csv(baseline_dir / manifest["funding_csv"])
+    metrics = manifest["metrics"]
+
+    mva = _read_metric(f, metrics["mva"])
+    net_cf = _read_metric(f, metrics["net_cf"])
     invest_income = _actual_invest_income(mva, net_cf)
-    ee = f["ee_nc_cont_legacy"].values + f["ee_nc_cont_new"].values
-    er_db = f["total_er_db_cont"].values
-    benefits = f["total_ben_payment"].values
-    refunds = f["total_refund"].values
-    admin = f["admin_exp_legacy"].values + f["admin_exp_new"].values
+    n_active = _read_n_active(manifest["n_active"], baseline_dir)
 
     df = pd.DataFrame({
-        "plan": "frs",
-        "year": f["year"].astype(int).values,
+        "plan": plan_name,
+        "year": f[manifest["year_column"]].astype(int).values,
         "mva_boy": mva,
-        "er_db_cont": er_db,
-        "ee_cont": ee,
+        "er_db_cont": _read_metric(f, metrics["er_db_cont"]),
+        "ee_cont": _read_metric(f, metrics["ee_cont"]),
         "invest_income": invest_income,
-        "benefits": benefits,
-        "refunds": refunds,
-        "admin_exp": admin,
+        "benefits": _read_metric(f, metrics["benefits"]),
+        "refunds": _read_metric(f, metrics["refunds"]),
+        "admin_exp": _read_metric(f, metrics["admin_exp"]),
         "mva_eoy": mva + net_cf + invest_income,
-        "aal_boy": f["total_aal"].values,
-        "ava_boy": f["total_ava"].values,
-        "fr_mva_boy": f["fr_mva"].values,
-        "fr_ava_boy": f["fr_ava"].values,
+        "aal_boy": _read_metric(f, metrics["aal"]),
+        "ava_boy": _read_metric(f, metrics["ava"]),
+        "fr_mva_boy": _read_metric(f, metrics["fr_mva"]),
+        "fr_ava_boy": _read_metric(f, metrics["fr_ava"]),
         "n_active_boy": n_active,
-        "payroll": f["total_payroll"].values,
-        "er_cont_total": f["total_er_cont"].values,
-    })
-    return df[TRUTH_TABLE_COLUMNS]
-
-
-def build_r_truth_table_txtrs(trs_r_dir: Path) -> pd.DataFrame:
-    """Build the frozen TRS R truth table from the R model's output CSVs.
-
-    Sources:
-      - `baseline_fresh.csv`: liability output (n.active)
-      - `funding_fresh.csv`: funding output (payroll, AAL, MVA, AVA,
-        contributions, benefits, investment income, funded ratios)
-
-    Not reported (NA) because R does not emit them:
-      - n_retired_boy, n_inactive_boy
-    """
-    liab = pd.read_csv(trs_r_dir / "baseline_fresh.csv")
-    f = pd.read_csv(trs_r_dir / "funding_fresh.csv")
-
-    net_cf = f["net_cf_legacy"].fillna(0).values + f["net_cf_new"].fillna(0).values
-    mva = f["MVA"].values
-    invest_income = _actual_invest_income(mva, net_cf)
-    er_db = f["er_cont"].values  # TRS has no DC plan
-    ee = f["ee_nc_cont_legacy"].fillna(0).values + f["ee_nc_cont_new"].fillna(0).values
-    benefits = f["ben_payment_legacy"].fillna(0).values + f["ben_payment_new"].fillna(0).values
-    refunds = f["refund_legacy"].fillna(0).values + f["refund_new"].fillna(0).values
-    admin = f["admin_exp_legacy"].fillna(0).values + f["admin_exp_new"].fillna(0).values
-
-    df = pd.DataFrame({
-        "plan": "txtrs",
-        "year": f["fy"].astype(int).values,
-        "mva_boy": mva,
-        "er_db_cont": er_db,
-        "ee_cont": ee,
-        "invest_income": invest_income,
-        "benefits": benefits,
-        "refunds": refunds,
-        "admin_exp": admin,
-        "mva_eoy": mva + net_cf + invest_income,
-        "aal_boy": f["AAL"].values,
-        "ava_boy": f["AVA"].values,
-        "fr_mva_boy": f["FR_MVA"].values,
-        "fr_ava_boy": f["FR_AVA"].values,
-        "n_active_boy": liab["n.active"].values,
-        "payroll": f["payroll"].values,
-        "er_cont_total": er_db,  # same as er_db for TRS (no DC)
+        "payroll": _read_metric(f, metrics["payroll"]),
+        "er_cont_total": _read_metric(f, metrics["er_cont_total"]),
     })
     return df[TRUTH_TABLE_COLUMNS]
 


### PR DESCRIPTION
Final PR in the Phase A generalization sequence. Closes #114 once merged.

## Summary

\`build_r_truth_table_frs\` and \`build_r_truth_table_txtrs\` become a single \`build_r_truth_table(plan_name, baseline_dir)\` that reads a per-plan manifest at \`plans/<plan>/baselines/r_truth_table_manifest.json\`.

Files added:
- \`plans/frs/baselines/r_truth_table_manifest.json\`
- \`plans/txtrs/baselines/r_truth_table_manifest.json\`

The manifest captures everything that varied between the two old builders: funding CSV name, year column, n_active source, and per-metric column-name mapping (with a ``{"sum_with_fillna": [...]}`` form for the legacy/new pairs that R splits).

\`scripts/build/build_r_truth_tables.py\` updated to call the new builder; a stale ``baseline_outputs/`` reference fixed in passing.

## Why

These were the last plan-named functions in the validation tooling. A new plan now ships a manifest alongside its R baseline — no Python edit needed.

## Validation

- The new builder reproduces the existing frozen ``r_truth_table.csv`` files exactly (numeric tolerance 1e-12, all 31 rows × 17 columns) for both FRS and TXTRS, verified before running tests.
- \`make r-match\` — 6/6 truth-table cells pass at relative diff < 1e-10.
- \`make test\` — 322 passed, 2 skipped (unrelated snapshot updaters).

## End of Phase A

This closes the eight-PR Phase A sequence (A1a, A1b, A2, A3, A4, A5, A6, A7, A8). Recommend revisiting \`scratch/generalization_plan.md\` before starting Phase B — the asset-leg generalization (B4) has the largest blast radius and merits its own check-in on scope and naming.

## Test plan

- [x] Direct comparison of new builder output vs frozen CSVs (identical at 1e-12)
- [x] \`make r-match\`
- [x] \`make test\`
- [ ] Owner review

Refs #114