### PR TITLE
B5: decouple in-loop aggregate accumulation from class count

### DIFF
--- a/src/pension_model/core/_funding_core.py
+++ b/src/pension_model/core/_funding_core.py
@@ -189,7 +189,7 @@ def _run_phase2_for_class(
     _maybe_accumulate(ctx, agg, f, i, ["ee_nc_cont_legacy", "ee_nc_cont_new"])
     _maybe_accumulate(ctx, agg, f, i, ["admin_exp_legacy", "admin_exp_new"])
 
-    if ctx.is_multi_class:
+    if ctx.builds_aggregate_in_loop:
         if "total_er_db_cont" in ctx.init_funding.columns:
             f.loc[i, "total_er_db_cont"] = (
                 f.loc[i, "er_nc_cont_legacy"] + f.loc[i, "er_nc_cont_new"]
@@ -203,7 +203,7 @@ def _run_phase2_for_class(
 
     roa = _resolve_roa(ret_scen, year, dr_current)
     f.loc[i, "roa"] = roa
-    if ctx.is_multi_class:
+    if ctx.builds_aggregate_in_loop:
         agg.loc[i, "roa"] = roa
 
     _phase_cash_flow_and_solvency(f, i, roa)
@@ -252,15 +252,17 @@ def _compute_funding(
     selection is config-driven via :class:`FundingContext`:
     ``ava_strategy`` and ``cont_strategy`` come from
     plan_config.json; capability flags (``has_dc``, ``has_cb``,
-    ``has_drop``, ``is_multi_class``) gate the appropriate code paths
-    inside the year loop.
+    ``has_drop``, ``builds_aggregate_in_loop``) gate the appropriate
+    code paths inside the year loop.
 
     Returns:
         Dict mapping class_name -> funding DataFrame, plus an
-        aggregate frame keyed by ``constants.plan_name``. For
-        single-class plans the aggregate is a distinct copy of the
-        sole class frame (no DataFrame aliasing). Plans with
-        ``has_drop=true`` also get a ``"drop"`` frame.
+        aggregate frame keyed by ``constants.plan_name``. When the
+        aggregate is not built up inside the loop (single class,
+        class-level smoothing) the aggregate frame is a distinct copy
+        of the sole class frame at end of compute (no DataFrame
+        aliasing). Plans with ``has_drop=true`` also get a ``"drop"``
+        frame.
     """
     ctx = resolve_funding_context(constants, funding_inputs)
     dr_current = ctx.dr_current
@@ -282,7 +284,7 @@ def _compute_funding(
         for cn in ctx.class_names:
             _run_phase1_for_class(cn, i, funding, liability_results, agg, ctx, dr_current, dr_new)
 
-        if ctx.is_multi_class:
+        if ctx.builds_aggregate_in_loop:
             _nc_rate_agg(agg, i, ctx)
         if ctx.has_drop:
             _phase_drop_projection(funding, agg, i, ctx)
@@ -303,15 +305,15 @@ def _compute_funding(
         for cn in ctx.all_classes:
             _run_phase3_for_class(cn, i, funding, agg, ctx)
 
-        if ctx.is_multi_class:
+        if ctx.builds_aggregate_in_loop:
             _finalize_aggregate_row(agg, i)
 
         _phase_amort_rolling(funding, amort_state, i, ctx)
 
-    # For single-class plans the aggregate is a distinct copy of the
-    # sole class frame (no aliasing). Multi-class plans built the
-    # aggregate via _maybe_accumulate during the loop.
-    if not ctx.is_multi_class:
+    # When the aggregate wasn't built up during the loop, populate the
+    # aggregate frame as a distinct copy of the sole class frame (no
+    # aliasing). Otherwise it was filled in via _maybe_accumulate.
+    if not ctx.builds_aggregate_in_loop:
         funding[agg_name] = funding[ctx.class_names[0]].copy()
 
     return funding

--- a/src/pension_model/core/_funding_helpers.py
+++ b/src/pension_model/core/_funding_helpers.py
@@ -309,17 +309,22 @@ def _accumulate_to_aggregate(target, source, i, cols):
 
 
 def _maybe_accumulate(ctx, target, source, i, cols):
-    """Accumulate per-class values into the aggregate iff multi-class.
+    """Accumulate per-class values into the aggregate when needed.
 
-    For single-class plans the aggregate frame is just a copy of the
-    sole class frame at the end of the compute, so per-row
-    accumulation is wasted work — and would double-count if the
-    aggregate dict key happened to alias the class frame. The compute
-    functions wrap every aggregate-accumulation call in this helper so
-    the same orchestration shape works for both single- and
-    multi-class plans (Step 2.G.2).
+    Two reasons the in-loop aggregate is needed:
+      * more than one class — there's a real plan-level output frame
+        to maintain;
+      * smoothing strategy reads from the aggregate mid-loop (corridor
+        smooths at the plan level then allocates earnings to classes).
+
+    When neither holds, the aggregate frame is just a copy of the sole
+    class frame at the end of the compute, so per-row accumulation is
+    wasted work — and would double-count if the aggregate dict key
+    happened to alias the class frame. The compute functions wrap
+    every aggregate-accumulation call in this helper so the same
+    orchestration shape works for both shapes (Step 2.G.2).
     """
-    if ctx.is_multi_class:
+    if ctx.builds_aggregate_in_loop:
         _accumulate_to_aggregate(target, source, i, cols)
 
 

--- a/src/pension_model/core/_funding_setup.py
+++ b/src/pension_model/core/_funding_setup.py
@@ -44,7 +44,7 @@ class FundingContext:
     has_drop: bool
     drop_ref_class: Optional[str]
     all_classes: list
-    is_multi_class: bool
+    builds_aggregate_in_loop: bool
     has_cb: bool
     has_dc: bool
     funding_policy: str
@@ -72,7 +72,6 @@ def resolve_funding_context(
     has_drop = constants.has_drop
     drop_ref_class = constants.drop_reference_class or (class_names[0] if class_names else None)
     all_classes = class_names + (["drop"] if has_drop else [])
-    is_multi_class = len(class_names) > 1
 
     has_cb = "cb" in constants.benefit_types
     has_dc = "payroll_dc_legacy" in funding_inputs["init_funding"].columns
@@ -87,6 +86,18 @@ def resolve_funding_context(
             f"Unknown funding.ava_smoothing.method: {method!r}. "
             f"Supported: 'corridor', 'gain_loss'."
         )
+
+    # The plan-aggregate frame is built up inside the year-loop when
+    # either (a) there's more than one class and we want a plan-level
+    # output frame, or (b) the smoothing strategy reads from the
+    # aggregate mid-loop (corridor smooths at plan level then allocates
+    # earnings to classes). Class count alone is insufficient: a
+    # single-class plan with corridor smoothing still needs the
+    # aggregate built up so the allocate-back step has values to read.
+    builds_aggregate_in_loop = (
+        len(class_names) > 1
+        or ava_strategy.aggregation_level == "plan"
+    )
 
     stat_rates = constants.statutory_rates
     if stat_rates:
@@ -123,7 +134,7 @@ def resolve_funding_context(
         has_drop=has_drop,
         drop_ref_class=drop_ref_class,
         all_classes=all_classes,
-        is_multi_class=is_multi_class,
+        builds_aggregate_in_loop=builds_aggregate_in_loop,
         has_cb=has_cb,
         has_dc=has_dc,
         funding_policy=fund.funding_policy,

--- a/tests/test_pension_model/test_multi_class_gainloss.py
+++ b/tests/test_pension_model/test_multi_class_gainloss.py
@@ -100,7 +100,7 @@ def test_multi_class_gainloss_aggregate_sums_flow_cols(two_class_gainloss_output
 
 
 def test_multi_class_gainloss_aggregate_rates_populated(two_class_gainloss_outputs):
-    """is_multi_class-gated aggregate rate writes fire."""
+    """builds_aggregate_in_loop-gated aggregate rate writes fire."""
     funding, constants = two_class_gainloss_outputs
     agg = funding[constants.plan_name]
     assert agg.loc[5, "fr_mva"] != 0


### PR DESCRIPTION
First PR of Phase B. Closes #119.

## What this changes

Renames the `FundingContext` flag `is_multi_class` → `builds_aggregate_in_loop` and redefines it as:

```python
builds_aggregate_in_loop = (
    len(class_names) > 1
    or ava_strategy.aggregation_level == "plan"
)
```

Class count alone was the wrong test. Corridor smoothing reads from the plan-aggregate frame mid-loop (`CorridorSmoothing.allocate_to_classes` at `_funding_strategies.py:193-209`), so a single-class plan with corridor smoothing would silently produce wrong class-level AVAs because the aggregate frame would never be populated. The new flag captures the actual condition: "is the in-loop aggregate needed for any reason?"

Files touched:
- `src/pension_model/core/_funding_setup.py` — rename dataclass field, redefine the flag, reorder `ava_strategy` resolution before the flag computation, add a comment explaining the disjunction.
- `src/pension_model/core/_funding_core.py` — five conditional sites + one docstring.
- `src/pension_model/core/_funding_helpers.py` — one conditional + the `_maybe_accumulate` docstring rewritten to explain both reasons the aggregate is built.
- `tests/test_pension_model/test_multi_class_gainloss.py` — one test docstring referencing the old name.

## Why this is the right Phase B item to do first

- Small (4 files, +46 / -28 lines).
- No numerical change for FRS or TXTRS — both plans evaluate the new flag to the same value the old one did, so the truth-table diff is exactly zero.
- Closes a latent correctness gap (1-class corridor case).
- Establishes the strategy-driven dispatch pattern that B1, B2, and B6 will reuse.

## Why we keep smooth-then-allocate-to-classes

Verified against the FRS 2022 actuarial valuation (Milliman): Table 2-3 computes one plan-level smoothed AVA, Table 2-4 explicitly allocates that AVA back to each membership class on an "AVA basis" (proportional to each class's asset position during the year). The model's mechanism matches AV practice; this is not an artifact of the R reference model. See issue #119 for the full reasoning.

## Validation

- `make r-match` — 8/8 truth-table cells pass at relative diff < 1e-10 (FRS and TXTRS × {baseline, low_return, high_discount, asset_shock}).
- `make test` — 324 passed, 2 skipped (unrelated snapshot updaters).

## Out of scope

- Making `funding.contribution_strategy` an explicit config field. Currently dispatched on presence of `funding.statutory_rates`; could be tightened in a small follow-up PR.
- Vectorizing the per-class loop into 3D NumPy arrays. Performance pass for after Match-R, not a generalization concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)