### PR TITLE
B1: drive retirement-rate construction off config.tier_defs

### DIFF
--- a/plans/frs/config/plan_config.json
+++ b/plans/frs/config/plan_config.json
@@ -110,7 +110,8 @@
         }
       },
       "cola_key": "tier_1_active",
-      "prorate_cola": true
+      "prorate_cola": true,
+      "retirement_rate_tier_key": "tier_1"
     },
     {
       "name": "tier_2",
@@ -146,7 +147,8 @@
           "default": 65
         }
       },
-      "cola_key": "tier_2_active"
+      "cola_key": "tier_2_active",
+      "retirement_rate_tier_key": "tier_2"
     },
     {
       "name": "tier_3",
@@ -156,7 +158,8 @@
       "eligibility_same_as": "tier_2",
       "early_retire_reduction_same_as": "tier_2",
       "cola_key": "tier_3_active",
-      "discount_rate_key": "dr_new"
+      "discount_rate_key": "dr_new",
+      "retirement_rate_tier_key": "tier_2"
     }
   ],
 

--- a/src/pension_model/config_loading.py
+++ b/src/pension_model/config_loading.py
@@ -59,7 +59,14 @@ def _build_tier_metadata(
     tier_defs_raw: list[dict],
     *,
     fas_default: int,
-) -> tuple[dict[str, int], tuple[str, ...], tuple[str, ...], tuple[int, ...], tuple[str, ...]]:
+) -> tuple[
+    dict[str, int],
+    tuple[str, ...],
+    tuple[str, ...],
+    tuple[int, ...],
+    tuple[str, ...],
+    tuple[str, ...],
+]:
     """Build tier lookup tables cached on ``PlanConfig``."""
     tier_name_to_id = {td["name"]: i for i, td in enumerate(tier_defs_raw)}
     tier_id_to_name = tuple(td["name"] for td in tier_defs_raw)
@@ -68,12 +75,19 @@ def _build_tier_metadata(
     tier_id_to_dr_key = tuple(
         td.get("discount_rate_key", "dr_current") for td in tier_defs_raw
     )
+    # Default: each tier maps to a CSV tier key with its own name. FRS
+    # tier_3 declares "tier_2" explicitly so the implicit fallback in
+    # the old boolean-cascade dispatch becomes a config-driven choice.
+    tier_id_to_retire_rate_key = tuple(
+        td.get("retirement_rate_tier_key", td["name"]) for td in tier_defs_raw
+    )
     return (
         tier_name_to_id,
         tier_id_to_name,
         tier_id_to_cola_key,
         tier_id_to_fas_years,
         tier_id_to_dr_key,
+        tier_id_to_retire_rate_key,
     )
 
 
@@ -123,6 +137,7 @@ def load_plan_config(
         tier_id_to_cola_key,
         tier_id_to_fas_years,
         tier_id_to_dr_key,
+        tier_id_to_retire_rate_key,
     ) = _build_tier_metadata(
         tier_defs_raw,
         fas_default=ben["fas_years_default"],
@@ -177,6 +192,7 @@ def load_plan_config(
         _tier_id_to_cola_key=tier_id_to_cola_key,
         _tier_id_to_fas_years=tier_id_to_fas_years,
         _tier_id_to_dr_key=tier_id_to_dr_key,
+        _tier_id_to_retire_rate_key=tier_id_to_retire_rate_key,
     )
 
     for warning in config.validate():

--- a/src/pension_model/config_schema.py
+++ b/src/pension_model/config_schema.py
@@ -72,6 +72,7 @@ class PlanConfig:
     _tier_id_to_cola_key: Tuple[str, ...] = ()
     _tier_id_to_fas_years: Tuple[int, ...] = ()
     _tier_id_to_dr_key: Tuple[str, ...] = ()
+    _tier_id_to_retire_rate_key: Tuple[str, ...] = ()
 
     @property
     def scenario_name(self) -> Optional[str]:

--- a/src/pension_model/core/benefit_tables.py
+++ b/src/pension_model/core/benefit_tables.py
@@ -432,10 +432,8 @@ def build_salary_benefit_table(
 
 def build_separation_rate_table(
     term_rate_avg: pd.DataFrame,
-    normal_retire_rate_tier1: pd.DataFrame,
-    normal_retire_rate_tier2: pd.DataFrame,
-    early_retire_rate_tier1: pd.DataFrame,
-    early_retire_rate_tier2: pd.DataFrame,
+    normal_retire_rate_by_tier: dict,
+    early_retire_rate_by_tier: dict,
     entrant_profile: pd.DataFrame,
     class_name: str,
     constants,
@@ -449,8 +447,10 @@ def build_separation_rate_table(
 
     Args:
         term_rate_avg: Gender-averaged withdrawal rates (yos × age_group).
-        normal_retire_rate_tier1/2: Normal retirement rates by age.
-        early_retire_rate_tier1/2: Early retirement rates by age.
+        normal_retire_rate_by_tier: Mapping {csv_tier_key: DataFrame[age, normal_retire_rate]}.
+        early_retire_rate_by_tier: Mapping {csv_tier_key: DataFrame[age, early_retire_rate]}.
+            Each plan tier resolves to one of these keys via
+            ``constants._tier_id_to_retire_rate_key``.
         entrant_profile: Entrant profile with entry_age column.
         class_name: Membership class name.
         constants: PlanConfig.
@@ -506,14 +506,17 @@ def build_separation_rate_table(
     # Join withdrawal rates
     df = df.merge(term_long, on=["yos", "age_group"], how="left")
 
-    # Join retirement rates by term_age — rename the source "age" column
-    # to "_ret_age" to avoid left/right collision on the join.
-    for tbl, col_name in [
-        (normal_retire_rate_tier1, "normal_retire_rate_tier_1"),
-        (normal_retire_rate_tier2, "normal_retire_rate_tier_2"),
-        (early_retire_rate_tier1, "early_retire_rate_tier_1"),
-        (early_retire_rate_tier2, "early_retire_rate_tier_2"),
-    ]:
+    # Join retirement rates by term_age — one column per CSV tier key
+    # for each ret_type. Source "age" column renamed to "_ret_age" to
+    # avoid left/right collision on the join. Merge order: all normals
+    # first, then all earlies (preserved from the original four-arg
+    # version for bit-identity).
+    merge_specs: list[tuple[pd.DataFrame, str]] = []
+    for tier_key, tbl in normal_retire_rate_by_tier.items():
+        merge_specs.append((tbl, f"normal_retire_rate_{tier_key}"))
+    for tier_key, tbl in early_retire_rate_by_tier.items():
+        merge_specs.append((tbl, f"early_retire_rate_{tier_key}"))
+    for tbl, col_name in merge_specs:
         rate_col = [c for c in tbl.columns if c != "age"][0]
         sub = tbl[["age", rate_col]].rename(
             columns={"age": "_ret_age", rate_col: col_name}
@@ -545,25 +548,24 @@ def build_separation_rate_table(
     df["tier_id"] = tid_arr
     df["ret_status"] = rs_arr
 
-    # Separation rate depends on tier_id and ret_status
-    t1_id = constants._tier_name_to_id.get("tier_1", -1)
-    is_tier_1 = tid_arr == t1_id
-    is_tier_23 = ~is_tier_1
+    # Separation rate depends on tier_id and ret_status. Each plan
+    # tier maps to a CSV retirement-rate tier key via
+    # _tier_id_to_retire_rate_key (e.g., FRS tier_3 → "tier_2"). Vested
+    # and non-vested rows fall through to the withdrawal rate.
     is_norm = rs_arr == NORM
     is_early = rs_arr == EARLY
-    df["separation_rate"] = np.where(
-        is_tier_23 & is_norm, df["normal_retire_rate_tier_2"],
-        np.where(
-            is_tier_23 & is_early, df["early_retire_rate_tier_2"],
-            np.where(
-                is_tier_1 & is_norm, df["normal_retire_rate_tier_1"],
-                np.where(
-                    is_tier_1 & is_early, df["early_retire_rate_tier_1"],
-                    df["term_rate"],  # vested or non_vested
-                ),
-            ),
-        ),
+    retire_key_by_tid = np.array(
+        constants._tier_id_to_retire_rate_key, dtype=object
     )
+    retire_keys_per_row = retire_key_by_tid[tid_arr]
+    sep_rate = df["term_rate"].values.copy()
+    for tier_key in normal_retire_rate_by_tier:
+        mask_key = retire_keys_per_row == tier_key
+        norm_col = f"normal_retire_rate_{tier_key}"
+        early_col = f"early_retire_rate_{tier_key}"
+        sep_rate = np.where(mask_key & is_norm, df[norm_col].values, sep_rate)
+        sep_rate = np.where(mask_key & is_early, df[early_col].values, sep_rate)
+    df["separation_rate"] = sep_rate
 
     # Compute remaining_prob = cumprod(1 - lag(separation_rate, default=0))
     df = df.sort_values(["entry_year", "entry_age", "yos"]).reset_index(drop=True)

--- a/src/pension_model/core/data_loader.py
+++ b/src/pension_model/core/data_loader.py
@@ -296,8 +296,9 @@ def _build_yos_only_decrements(
 
     The existing build_separation_rate_table() expects:
       - term_rate_avg: yos × age_group wide format
-      - normal_retire_tier1/2: age × rate
-      - early_retire_tier1/2: age × rate
+      - normal_retire_rate_by_tier / early_retire_rate_by_tier:
+        ``{csv_tier_key: DataFrame[age, rate]}`` dicts, one entry per
+        unique tier value in the retirement-rate CSV.
 
     Age group bands are read from ``modeling.age_groups`` in plan config
     via ``_resolve_age_group_breaks``.
@@ -334,15 +335,20 @@ def _build_yos_only_decrements(
 
     inputs["term_rate_avg"] = term_wide
 
-    # Convert retirement rates: (age, tier, retire_type, retire_rate) → per-tier DataFrames
-    for tier_name, tier_key in [("tier_1", "tier1"), ("tier_2", "tier2")]:
-        for ret_type, input_key in [("normal", f"normal_retire_{tier_key}"),
-                                     ("early", f"early_retire_{tier_key}")]:
-            mask = (ret_df["tier"] == tier_name) & (ret_df["retire_type"] == ret_type)
+    # Convert retirement rates to dicts keyed by the CSV's tier values.
+    # Each plan tier maps to one of these via retirement_rate_tier_key
+    # in plan_config.json (defaults to the plan-tier's own name).
+    csv_tier_keys = list(ret_df["tier"].unique())
+    normal_by_tier: dict[str, pd.DataFrame] = {}
+    early_by_tier: dict[str, pd.DataFrame] = {}
+    for tier_key in csv_tier_keys:
+        for ret_type, target in [("normal", normal_by_tier), ("early", early_by_tier)]:
+            mask = (ret_df["tier"] == tier_key) & (ret_df["retire_type"] == ret_type)
             subset = ret_df[mask][["age", "retire_rate"]].copy()
             rate_col = f"{ret_type}_retire_rate"
-            subset = subset.rename(columns={"retire_rate": rate_col})
-            inputs[input_key] = subset
+            target[tier_key] = subset.rename(columns={"retire_rate": rate_col})
+    inputs["normal_retire_rate_by_tier"] = normal_by_tier
+    inputs["early_retire_rate_by_tier"] = early_by_tier
 
 
 def _build_years_from_nr_decrements(

--- a/src/pension_model/core/pipeline.py
+++ b/src/pension_model/core/pipeline.py
@@ -194,10 +194,8 @@ def _build_class_benefit_prelude(
     else:
         separation_rate = build_separation_rate_table(
             inputs["term_rate_avg"],
-            inputs["normal_retire_tier1"],
-            inputs["normal_retire_tier2"],
-            inputs["early_retire_tier1"],
-            inputs["early_retire_tier2"],
+            inputs["normal_retire_rate_by_tier"],
+            inputs["early_retire_rate_by_tier"],
             entrant_profile,
             class_name,
             constants,

--- a/tests/test_pension_model/test_benefit_tables.py
+++ b/tests/test_pension_model/test_benefit_tables.py
@@ -157,10 +157,14 @@ class TestSeparationRateTable:
         dt = FRS_BASELINES / "decrement_tables"
         sep = build_separation_rate_table(
             term_rate_avg=pd.read_csv(dt / f"{sep_class}_term_rate_avg.csv"),
-            normal_retire_rate_tier1=pd.read_csv(dt / f"{sep_class}_normal_retire_rate_tier1.csv"),
-            normal_retire_rate_tier2=pd.read_csv(dt / f"{sep_class}_normal_retire_rate_tier2.csv"),
-            early_retire_rate_tier1=pd.read_csv(dt / f"{sep_class}_early_retire_rate_tier1.csv"),
-            early_retire_rate_tier2=pd.read_csv(dt / f"{sep_class}_early_retire_rate_tier2.csv"),
+            normal_retire_rate_by_tier={
+                "tier_1": pd.read_csv(dt / f"{sep_class}_normal_retire_rate_tier1.csv"),
+                "tier_2": pd.read_csv(dt / f"{sep_class}_normal_retire_rate_tier2.csv"),
+            },
+            early_retire_rate_by_tier={
+                "tier_1": pd.read_csv(dt / f"{sep_class}_early_retire_rate_tier1.csv"),
+                "tier_2": pd.read_csv(dt / f"{sep_class}_early_retire_rate_tier2.csv"),
+            },
             entrant_profile=ep,
             class_name=sep_class,
             constants=constants,


### PR DESCRIPTION
Second PR of Phase B. Closes #121.

## What this changes

Generalizes the retirement-rate side of decrement construction so a plan with any number of tiers (and any number of tier-keyed rate tables in its CSV) works without code changes. Replaces three closed-coded sites that assumed FRS's exact 2-tier-keyed rate-table shape.

**Config schema.** Adds per-tier \`retirement_rate_tier_key\` field. Default: each tier's own name. FRS sets tier_3 → \`\"tier_2\"\` to make the implicit fallback explicit.

**Loader.** \`_build_yos_only_decrements\` iterates over unique CSV tier values, producing two dicts:
\`\`\`python
inputs[\"normal_retire_rate_by_tier\"] = {csv_tier_key: DataFrame, ...}
inputs[\"early_retire_rate_by_tier\"]  = {csv_tier_key: DataFrame, ...}
\`\`\`

**Builder.** \`build_separation_rate_table\` takes those two dicts in place of four positional args. Merge step iterates over the dicts. Dispatch replaces the \`is_tier_1 / is_tier_23 = ~is_tier_1\` boolean cascade with a per-tier-id lookup driven by \`_tier_id_to_retire_rate_key\`.

**Call sites.** \`pipeline.py:195\` and \`tests/test_pension_model/test_benefit_tables.py:158\` pass the new dict-shaped args.

## FRS-only impact

TXTRS and TXTRS-AV use \`tier=\"all\"\` CSVs and go through \`_build_years_from_nr_decrements\` (a separate path not touched here). Their truth-table outputs cannot change.

## Bit-identity preservation

The dispatch rewrite was the highest-risk part. For each row, the new \`np.where\` sequence selects exactly the same float value the old cascade did:

| Row | Old cascade | New per-tier loop |
|---|---|---|
| tier_1, NORM | \`is_tier_1 & is_norm\` → \`normal_retire_rate_tier_1\` | \`mask_key=='tier_1' & is_norm\` → \`normal_retire_rate_tier_1\` |
| tier_1, EARLY | \`is_tier_1 & is_early\` → \`early_retire_rate_tier_1\` | \`mask_key=='tier_1' & is_early\` → \`early_retire_rate_tier_1\` |
| tier_2, NORM | \`is_tier_23 & is_norm\` → \`normal_retire_rate_tier_2\` | \`mask_key=='tier_2' & is_norm\` → \`normal_retire_rate_tier_2\` |
| tier_3, NORM | \`is_tier_23 & is_norm\` → \`normal_retire_rate_tier_2\` | \`mask_key=='tier_2' & is_norm\` (tier_3 maps to \"tier_2\") → \`normal_retire_rate_tier_2\` |
| vested/non_vested | falls through to \`term_rate\` | initial \`term_rate\` never overwritten |

Same float selected for every row. Merge order is preserved (all normals first, then all earlies, in CSV first-seen order — which for FRS is tier_1 then tier_2).

## Validation

- \`make r-match\` — 8/8 truth-table cells pass at relative diff < 1e-10 (FRS and TXTRS × {baseline, low_return, high_discount, asset_shock}).
- \`tests/test_pension_model/test_benefit_tables.py::TestSeparationRateTable\` — 7/7 FRS classes match R baseline at 1e-10.
- \`make test\` — 324 passed, 2 skipped (unrelated snapshot updaters).

## Out of scope

- The years-from-NR path uses \`df[\"tier\"].str.contains(\"norm|early|reduced\")\` for tier-name parsing. That belongs to B3.
- \`scripts/build/decrement_builder.py\` (offline data-prep tool, not imported by runtime) still produces \`normal_retire_tier1/2\` style intermediate keys. Out of scope; data-prep cleanup tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)