### PR TITLE
B2: declare decrement method in plan_config instead of sniffing the CSV

### DIFF
--- a/plans/frs/config/plan_config.json
+++ b/plans/frs/config/plan_config.json
@@ -51,6 +51,10 @@
     }
   },
 
+  "decrements": {
+    "method": "yos_only"
+  },
+
   "ranges": {
     "min_age": 18,
     "max_age": 120,

--- a/plans/txtrs-av/config/plan_config.json
+++ b/plans/txtrs-av/config/plan_config.json
@@ -75,6 +75,10 @@
     }
   },
 
+  "decrements": {
+    "method": "years_from_nr"
+  },
+
   "ranges": {
     "min_age": 20,
     "max_age": 120,

--- a/plans/txtrs/config/plan_config.json
+++ b/plans/txtrs/config/plan_config.json
@@ -96,6 +96,10 @@
     }
   },
 
+  "decrements": {
+    "method": "years_from_nr"
+  },
+
   "ranges": {
     "min_age": 20,
     "max_age": 120,

--- a/src/pension_model/config_schema.py
+++ b/src/pension_model/config_schema.py
@@ -143,6 +143,19 @@ class PlanConfig:
         return self.raw.get("funding", {}).get("amo_period_current")
 
     @property
+    def decrements_method(self) -> str:
+        decr = self.raw.get("decrements")
+        if not decr or "method" not in decr:
+            raise KeyError(
+                f"Plan {self.plan_name!r}: required field "
+                f"'decrements.method' is missing from plan_config.json. "
+                f"Set it to 'yos_only' (FRS-style) or 'years_from_nr' "
+                f"(TXTRS-style) — see an existing plan's plan_config.json "
+                f"for an example."
+            )
+        return decr["method"]
+
+    @property
     def design_ratio_group_map(self) -> Dict[str, str]:
         return self.raw.get("design_ratio_group_map", {})
 

--- a/src/pension_model/core/data_loader.py
+++ b/src/pension_model/core/data_loader.py
@@ -231,11 +231,9 @@ def _load_decrements(
     {class_name}_retirement_rates.csv in the standard lookup_type format,
     falling back to unprefixed filenames for single-class plans.
 
-    For plans with years_from_nr termination rates, builds the full
-    separation rate table directly.
-
-    For plans with yos-only termination rates, converts back to the
-    term_rate_avg + retirement rate table format.
+    Dispatches to the builder named by ``decrements.method`` in
+    plan_config.json. Supported methods are listed in
+    ``_DECREMENT_BUILDERS``.
     """
     term_path = decr_dir / f"{class_name}_termination_rates.csv"
     if not term_path.exists():
@@ -249,15 +247,14 @@ def _load_decrements(
 
     ret_df = pd.read_csv(ret_path)
 
-    # Check if plan has years_from_nr termination rates
-    has_years_from_nr = "years_from_nr" in term_df["lookup_type"].values
-
-    if has_years_from_nr:
-        # Years-from-normal-retirement lookup: build separation rate table
-        _build_years_from_nr_decrements(inputs, constants, term_df, ret_df, decr_dir, class_name)
-    else:
-        # YOS-only lookup: convert to wide format for existing builder
-        _build_yos_only_decrements(inputs, constants, term_df, ret_df)
+    method = constants.decrements_method
+    builder = _DECREMENT_BUILDERS.get(method)
+    if builder is None:
+        raise ValueError(
+            f"Plan {constants.plan_name!r}: unknown decrements.method "
+            f"{method!r}. Supported: {sorted(_DECREMENT_BUILDERS)}."
+        )
+    builder(inputs, constants, term_df, ret_df, decr_dir, class_name)
 
 
 def _resolve_age_group_breaks(constants: PlanConfig) -> list:
@@ -291,6 +288,8 @@ def _build_yos_only_decrements(
     constants: PlanConfig,
     term_df: pd.DataFrame,
     ret_df: pd.DataFrame,
+    decr_dir: Path,  # noqa: ARG001 — accepted for registry uniformity
+    class_name: str,  # noqa: ARG001 — accepted for registry uniformity
 ):
     """Convert stage 3 YOS-only termination rates to wide decrement format.
 
@@ -302,6 +301,9 @@ def _build_yos_only_decrements(
 
     Age group bands are read from ``modeling.age_groups`` in plan config
     via ``_resolve_age_group_breaks``.
+
+    ``decr_dir`` and ``class_name`` are accepted only so the decrement
+    registry can dispatch uniformly; this builder doesn't use them.
 
     Raises:
         ValueError: if any tier's declared ``retirement_rate_set``
@@ -370,7 +372,7 @@ def _build_years_from_nr_decrements(
     constants: PlanConfig,
     term_df: pd.DataFrame,
     ret_df: pd.DataFrame,
-    decr_dir: Path,
+    decr_dir: Path,  # noqa: ARG001 — accepted for registry uniformity
     class_name: str,
 ):
     """Build separation rate table using years-from-normal-retirement lookup.
@@ -486,6 +488,19 @@ def _build_years_from_nr_decrements(
     reduction_tables = load_reduction_tables(constants)
     if reduction_tables is not None:
         inputs["_reduction_tables"] = reduction_tables
+
+
+# ---------------------------------------------------------------------------
+# Decrement-method registry
+# ---------------------------------------------------------------------------
+
+# Maps the value of plan_config.json's ``decrements.method`` to a builder.
+# Each builder accepts a uniform 6-arg signature so ``_load_decrements``
+# can dispatch without knowing which method is in use.
+_DECREMENT_BUILDERS = {
+    "yos_only": _build_yos_only_decrements,
+    "years_from_nr": _build_years_from_nr_decrements,
+}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_pension_model/test_stage3_loader.py
+++ b/tests/test_pension_model/test_stage3_loader.py
@@ -292,4 +292,28 @@ def test_unknown_retirement_rate_set_raises(frs_config, tmp_path):
     })
 
     with pytest.raises(ValueError, match="bogus_set"):
-        _build_yos_only_decrements({}, bogus, term_df, ret_df)
+        _build_yos_only_decrements(
+            {}, bogus, term_df, ret_df, tmp_path, "regular"
+        )
+
+
+def test_unknown_decrements_method_raises(frs_config, tmp_path):
+    """A plan declaring an unknown decrements.method must raise a clear
+    error from the registry dispatch in _load_decrements.
+    """
+    from dataclasses import replace
+    from pension_model.core.data_loader import _load_decrements
+
+    raw = dict(frs_config.raw)
+    raw["decrements"] = {"method": "made_up_method"}
+    bogus = replace(frs_config, raw=raw)
+
+    # Use FRS's existing decrements directory; the dispatch fails before
+    # the CSVs are ever inspected for content.
+    decr_dir = (
+        Path(__file__).parent.parent.parent
+        / "plans" / "frs" / "data" / "decrements"
+    )
+
+    with pytest.raises(ValueError, match="made_up_method"):
+        _load_decrements({}, bogus, decr_dir, "regular")


### PR DESCRIPTION
Third PR of Phase B. Closes #125.

## What this changes

Replaces the runtime CSV sniffing dispatch with an explicit \`decrements.method\` config field declared in each plan's \`plan_config.json\`.

**Why two builders, not one.** The two paths represent genuinely different actuarial conventions used by different actuaries:

- \`yos_only\` (FRS, Milliman): termination depends on years of service and current age band.
- \`years_from_nr\` (TXTRS): termination depends on YOS for years 0-9, then on years-from-normal-retirement for years 10+.

Both are valid. Forcing one into the other in data prep would either lose information (collapsing TXTRS's late-career proximity-to-retirement structure) or fabricate it (synthesizing age-band rates TXTRS's AV doesn't provide). We keep both builders; B2 only fixes how the runtime decides which to run.

**The dispatch fix.** Three changes:
1. Top-level \`decrements\` block in plan_config.json with a required \`method\` field. FRS sets \`\"yos_only\"\`; TXTRS and TXTRS-AV set \`\"years_from_nr\"\`.
2. \`PlanConfig.decrements_method\` property reading from \`raw[\"decrements\"][\"method\"]\`. Raises a clear \`KeyError\` if absent.
3. \`_DECREMENT_BUILDERS\` registry in \`data_loader.py\` mapping method names to builder functions. \`_load_decrements\` reads \`constants.decrements_method\` and dispatches; unknown methods raise \`ValueError\` with the supported list.

**Builder signatures harmonized.** \`_build_yos_only_decrements\` gains \`decr_dir\` and \`class_name\` parameters (annotated \`noqa: ARG001\` for registry uniformity; currently unused). \`_build_years_from_nr_decrements\` already had them; its \`decr_dir\` parameter is also unused and now annotated to match. This lets the registry dispatch with one uniform call shape.

## New tests

- \`test_unknown_decrements_method_raises\` — a plan declaring \`decrements.method = \"made_up_method\"\` raises a clear \`ValueError\` from the registry dispatch.
- \`test_unknown_retirement_rate_set_raises\` — updated for the harmonized 6-arg signature.

## Validation

- \`make r-match\` — 8/8 truth-table cells pass at relative diff < 1e-10.
- \`make test\` — 326 passed (was 325 + 1 new test), 2 skipped (unrelated snapshot updaters).

## Out of scope

- Splitting \`_build_years_from_nr_decrements\` further. It still has internal tier-name string parsing (\`df[\"tier\"].str.contains(\"norm|early|reduced\")\`); that's B3.
- Per-tier method declarations. Today's plans all use one method per plan; per-tier can come later if a multi-method plan ever shows up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)