### PR TITLE
B2.5: declare retirement_rate_set on TXTRS and TXTRS-AV tiers

### DIFF
--- a/plans/txtrs-av/config/plan_config.json
+++ b/plans/txtrs-av/config/plan_config.json
@@ -135,7 +135,8 @@
           {"condition": {}, "formula": "table", "table_key": "reduced_others"}
         ]
       },
-      "cola_key": "tier_1_active"
+      "cola_key": "tier_1_active",
+      "retirement_rate_set": "all"
     },
     {
       "name": "pre_2007",
@@ -161,7 +162,8 @@
           {"condition": {}, "formula": "table", "table_key": "reduced_others"}
         ]
       },
-      "cola_key": "tier_2_active"
+      "cola_key": "tier_2_active",
+      "retirement_rate_set": "all"
     },
     {
       "name": "vested_2014",
@@ -189,7 +191,8 @@
           {"condition": {}, "formula": "table", "table_key": "reduced_others"}
         ]
       },
-      "cola_key": "tier_3_active"
+      "cola_key": "tier_3_active",
+      "retirement_rate_set": "all"
     },
     {
       "name": "current",
@@ -216,7 +219,8 @@
           {"condition": {}, "formula": "table", "table_key": "reduced_others"}
         ]
       },
-      "cola_key": "tier_4_active"
+      "cola_key": "tier_4_active",
+      "retirement_rate_set": "all"
     }
   ],
 

--- a/plans/txtrs/config/plan_config.json
+++ b/plans/txtrs/config/plan_config.json
@@ -149,7 +149,8 @@
           {"condition": {}, "formula": "table", "table_key": "reduced_others"}
         ]
       },
-      "cola_key": "tier_1_active"
+      "cola_key": "tier_1_active",
+      "retirement_rate_set": "all"
     },
     {
       "name": "intermediate",
@@ -177,7 +178,8 @@
           {"condition": {}, "formula": "table", "table_key": "reduced_others"}
         ]
       },
-      "cola_key": "tier_2_active"
+      "cola_key": "tier_2_active",
+      "retirement_rate_set": "all"
     },
     {
       "name": "current",
@@ -205,7 +207,8 @@
           {"condition": {}, "formula": "table", "table_key": "reduced_others"}
         ]
       },
-      "cola_key": "tier_3_active"
+      "cola_key": "tier_3_active",
+      "retirement_rate_set": "all"
     }
   ],
 


### PR DESCRIPTION
Cleanup follow-up to #124 (B1.5). Closes #127.

## What this changes

Adds explicit \`\"retirement_rate_set\": \"all\"\` to every tier in TXTRS and TXTRS-AV plan_configs. Brings them in line with FRS, where every tier already declares the field.

- \`plans/txtrs/config/plan_config.json\` — 3 tiers (grandfathered, intermediate, current)
- \`plans/txtrs-av/config/plan_config.json\` — 4 tiers (grandfathered, pre_2007, vested_2014, current)

No code changes. No CSV changes. No new tests.

## Why

After B1.5, FRS declared \`retirement_rate_set\` on every tier (\`\"before_2011\"\` / \`\"2011_or_later\"\`) but TXTRS and TXTRS-AV declared nothing. Their tiers fell back to the default (the tier's own name) — which silently mismatched their CSV's single \`rate_set\` value of \`\"all\"\`.

Nothing was broken at runtime: those plans go through \`_build_years_from_nr_decrements\`, which never reads the field. B1.5's validation check only runs in \`_build_yos_only_decrements\`. But the dormant-but-incorrect default is exactly the kind of latent bug Phase B is supposed to be eliminating.

## Audit context

I ran a quick scan across all Phase A and Phase B added per-tier fields to confirm \`retirement_rate_set\` is the only FRS-only residual:

| Field | Phase | Default | Status |
|---|---|---|---|
| \`discount_rate_key\` | A3 | \`\"dr_current\"\` | ✓ correct for TXTRS/TXTRS-AV |
| design-ratio cutoff keys | A4 | n/a | ✓ all three plans updated |
| class groups | A5 | n/a | ✓ all three plans updated |
| vesting/FAS defaults | A6 | n/a | ✓ all three plans updated |
| \`retirement_rate_set\` | B1.5 | tier's own name | ✗ FRS-only — fixed in this PR |
| \`decrements.method\` | B2 | n/a (required) | ✓ all three plans updated |

## Validation

- \`make r-match\` — 8/8 truth-table cells pass at relative diff < 1e-10.
- \`make test\` — 326 passed, 2 skipped (unrelated snapshot updaters).

🤖 Generated with [Claude Code](https://claude.com/claude-code)