### PR TITLE
B3b: eliminate composite tier+status strings from live code

### DIFF
--- a/src/pension_model/config_resolver_common.py
+++ b/src/pension_model/config_resolver_common.py
@@ -233,11 +233,3 @@ def _reduce_condition_vec(
             or_mask |= _reduce_condition_vec(sub, dist_age, yos, entry_year, tier_name)
         mask &= or_mask
     return mask
-
-
-_STATUS_SUFFIX = {
-    NON_VESTED: "_non_vested",
-    VESTED: "_vested",
-    EARLY: "_early",
-    NORM: "_norm",
-}

--- a/src/pension_model/config_resolvers.py
+++ b/src/pension_model/config_resolvers.py
@@ -11,7 +11,6 @@ from pension_model.config_resolvers_vectorized import (
     resolve_cola_vec,
     resolve_reduce_factor_vec,
     resolve_tiers_vec,
-    resolve_tiers_vec_str,
 )
 
 
@@ -27,5 +26,4 @@ __all__ = [
     "resolve_cola_vec",
     "resolve_reduce_factor_vec",
     "resolve_tiers_vec",
-    "resolve_tiers_vec_str",
 ]

--- a/src/pension_model/config_resolvers_scalar.py
+++ b/src/pension_model/config_resolvers_scalar.py
@@ -26,7 +26,11 @@ def get_tier(
     age: int,
     yos: int,
     entry_age: int = 0,
-) -> str:
+) -> tuple[str, str]:
+    """Resolve the (tier_name, status) for one (class, entry_year, age, yos).
+
+    Status is one of ``"norm"``, ``"early"``, ``"vested"``, ``"non_vested"``.
+    """
     group = config.class_group(class_name)
 
     matched_tier = None
@@ -68,25 +72,26 @@ def get_tier(
     eligibility = _get_eligibility(matched_tier, group, config.tier_defs)
 
     if not eligibility:
-        return f"{tier_name}_non_vested"
+        return tier_name, "non_vested"
 
     if _matches_any(eligibility.get("normal", []), age, yos, entry_year, entry_age):
-        return f"{tier_name}_norm"
+        return tier_name, "norm"
 
     if _matches_any(eligibility.get("early", []), age, yos, entry_year, entry_age):
-        return f"{tier_name}_early"
+        return tier_name, "early"
 
     vesting_yos = eligibility["vesting_yos"]
     if yos >= vesting_yos:
-        return f"{tier_name}_vested"
+        return tier_name, "vested"
 
-    return f"{tier_name}_non_vested"
+    return tier_name, "non_vested"
 
 
 def get_ben_mult(
     config: PlanConfig,
     class_name: str,
-    tier: str,
+    tier_name: str,
+    status: str,
     dist_age: int,
     yos: int,
     dist_year: int = 0,
@@ -95,15 +100,13 @@ def get_ben_mult(
     if class_rules is None:
         return float("nan")
 
-    tier_base = tier.split("_")[0] + "_" + tier.split("_")[1] if "_" in tier else tier
-
     if "all_tiers" in class_rules:
         rules = class_rules["all_tiers"]
     else:
-        rules = class_rules.get(tier_base)
+        rules = class_rules.get(tier_name)
         if rules is None:
             for key in class_rules:
-                if key.endswith("_same_as") and key.replace("_same_as", "") == tier_base:
+                if key.endswith("_same_as") and key.replace("_same_as", "") == tier_name:
                     rules = class_rules.get(class_rules[key])
                     break
         if rules is None:
@@ -119,7 +122,7 @@ def get_ben_mult(
             for cond in entry["or"]:
                 if _matches_condition(cond, dist_age, yos):
                     return entry["mult"]
-        if "early" in tier and "early_fallback" in rules:
+        if status == "early" and "early_fallback" in rules:
             return rules["early_fallback"]
         return float("nan")
 
@@ -129,17 +132,17 @@ def get_ben_mult(
 def get_reduce_factor(
     config: PlanConfig,
     class_name: str,
-    tier: str,
+    tier_name: str,
+    status: str,
     dist_age: int,
     yos: int = 0,
     entry_year: int = 0,
 ) -> float:
-    if "norm" in tier:
+    if status == "norm":
         return 1.0
-    if "early" not in tier and "reduced" not in tier:
+    if status != "early":
         return float("nan")
 
-    tier_name = tier.rsplit("_", 1)[0] if "_" in tier else tier
     tier_def = next((td for td in config.tier_defs if td["name"] == tier_name), None)
     if tier_def is None:
         return float("nan")

--- a/src/pension_model/config_resolvers_vectorized.py
+++ b/src/pension_model/config_resolvers_vectorized.py
@@ -11,7 +11,6 @@ from pension_model.config_resolver_common import (
     NON_VESTED,
     NORM,
     VESTED,
-    _STATUS_SUFFIX,
     _entry_year_in_tier_vec,
     _get_eligibility,
     _is_grandfathered_vec,
@@ -183,21 +182,6 @@ def resolve_tiers_vec(
             ret_status[combo_mask] = sub_status
 
     return tier_id, ret_status
-
-
-def resolve_tiers_vec_str(
-    config: PlanConfig,
-    class_name: np.ndarray,
-    entry_year: np.ndarray,
-    age: np.ndarray,
-    yos: np.ndarray,
-    entry_age: Optional[np.ndarray] = None,
-) -> np.ndarray:
-    tier_id, ret_status = resolve_tiers_vec(config, class_name, entry_year, age, yos, entry_age)
-    result = np.empty(len(tier_id), dtype=object)
-    for i in range(len(tier_id)):
-        result[i] = config._tier_id_to_name[tier_id[i]] + _STATUS_SUFFIX[ret_status[i]]
-    return result
 
 
 def resolve_cola_vec(

--- a/src/pension_model/core/data_loader.py
+++ b/src/pension_model/core/data_loader.py
@@ -424,19 +424,23 @@ def _build_years_from_nr_decrements(
     df = pd.DataFrame(rows, columns=["entry_year", "term_age", "yos", "entry_age", "term_year"])
     df = df.sort_values(["entry_year", "entry_age", "term_age"]).reset_index(drop=True)
 
-    # Determine tier
-    tiers = np.empty(len(df), dtype=object)
+    # Resolve (tier_name, status) per row. Status drives the
+    # is_normal_retire / is_early_retire flags directly — no string
+    # parsing of a composite tier+status column.
+    tier_names = np.empty(len(df), dtype=object)
+    statuses = np.empty(len(df), dtype=object)
     for i in range(len(df)):
-        tiers[i] = get_tier(
+        tier_names[i], statuses[i] = get_tier(
             constants, class_name,
             int(df.iloc[i]["entry_year"]), int(df.iloc[i]["term_age"]),
             int(df.iloc[i]["yos"]),
             entry_age=int(df.iloc[i]["entry_age"]),
         )
-    df["tier"] = tiers
+    df["tier"] = tier_names
+    df["status"] = statuses
 
-    df["is_normal_retire"] = df["tier"].str.contains("norm")
-    df["is_early_retire"] = df["tier"].str.contains("early|reduced")
+    df["is_normal_retire"] = df["status"] == "norm"
+    df["is_early_retire"] = df["status"] == "early"
 
     # Find years from normal retirement
     first_normal = df[df["is_normal_retire"]].groupby(

--- a/src/pension_model/plan_config.py
+++ b/src/pension_model/plan_config.py
@@ -21,7 +21,6 @@ from pension_model.config_resolvers import (
     resolve_cola_vec,
     resolve_reduce_factor_vec,
     resolve_tiers_vec,
-    resolve_tiers_vec_str,
 )
 from pension_model.config_schema import EARLY, NON_VESTED, NORM, VESTED, PlanConfig
 
@@ -43,5 +42,4 @@ __all__ = [
     "resolve_cola_vec",
     "resolve_reduce_factor_vec",
     "resolve_tiers_vec",
-    "resolve_tiers_vec_str",
 ]

--- a/tests/test_pension_model/_vectorized_resolver_test_support.py
+++ b/tests/test_pension_model/_vectorized_resolver_test_support.py
@@ -2,6 +2,38 @@
 
 import numpy as np
 
+from pension_model.config_schema import EARLY, NON_VESTED, NORM, VESTED
+
+
+# Map ret_status integer codes to the same status strings emitted by
+# scalar get_tier. Used to compare scalar (tier_name, status) tuples
+# against vectorized (tier_id, ret_status) results.
+_STATUS_INT_TO_STR = {
+    NON_VESTED: "non_vested",
+    VESTED: "vested",
+    EARLY: "early",
+    NORM: "norm",
+}
+
+
+def vec_tier_components(config, cn, ey, age, yos, entry_age=None):
+    """Return parallel (tier_names, statuses) arrays from the vectorized resolver.
+
+    Replacement for the deleted ``resolve_tiers_vec_str`` — produces the
+    same component pair the scalar ``get_tier`` returns, sourced from
+    ``resolve_tiers_vec``'s integer codes via lookup tables.
+    """
+    from pension_model.plan_config import resolve_tiers_vec
+
+    tier_id, ret_status = resolve_tiers_vec(config, cn, ey, age, yos, entry_age)
+    tier_names = np.array(
+        [config._tier_id_to_name[t] for t in tier_id], dtype=object
+    )
+    statuses = np.array(
+        [_STATUS_INT_TO_STR[s] for s in ret_status], dtype=object
+    )
+    return tier_names, statuses
+
 
 def build_frs_grid():
     """Dense grid of inputs covering FRS tier boundaries and class variations."""
@@ -48,11 +80,11 @@ def rows_to_arrays(rows):
     return cn, ey, age, yos
 
 
-def scalar_cola(config, tier_str, entry_year, yos):
+def scalar_cola(config, tier_name, entry_year, yos):
     """Reproduce the scalar COLA logic used by the annuity builder."""
     cola_cutoff = config.cola_proration_cutoff_year
     for td in config.tier_defs:
-        if td["name"] in tier_str:
+        if td["name"] == tier_name:
             cola_key = td.get("cola_key", "tier_1_active")
             raw_cola = config.cola.get(cola_key, 0.0)
             if (cola_key == "tier_1_active"

--- a/tests/test_pension_model/test_vectorized_resolvers_frs.py
+++ b/tests/test_pension_model/test_vectorized_resolvers_frs.py
@@ -15,13 +15,13 @@ from pension_model.plan_config import (
     resolve_cola_vec,
     resolve_reduce_factor_vec,
     resolve_tiers_vec,
-    resolve_tiers_vec_str,
 )
 
 from ._vectorized_resolver_test_support import (
     build_frs_grid,
     rows_to_arrays,
     scalar_cola,
+    vec_tier_components,
 )
 
 
@@ -30,17 +30,22 @@ def test_resolve_tiers_vec_matches_scalar_frs():
     rows = build_frs_grid()
     cn, ey, age, yos = rows_to_arrays(rows)
 
-    expected = np.array([
-        get_tier(config, rows[i][0], int(ey[i]), int(age[i]), int(yos[i]))
-        for i in range(len(rows))
-    ], dtype=object)
+    expected_names = np.empty(len(rows), dtype=object)
+    expected_statuses = np.empty(len(rows), dtype=object)
+    for i in range(len(rows)):
+        expected_names[i], expected_statuses[i] = get_tier(
+            config, rows[i][0], int(ey[i]), int(age[i]), int(yos[i])
+        )
 
-    actual = resolve_tiers_vec_str(config, cn, ey, age, yos)
+    actual_names, actual_statuses = vec_tier_components(config, cn, ey, age, yos)
 
-    mismatches = np.where(expected != actual)[0]
+    mismatches = np.where(
+        (expected_names != actual_names) | (expected_statuses != actual_statuses)
+    )[0]
     if len(mismatches) > 0:
         diffs = [
-            (rows[i], expected[i], actual[i])
+            (rows[i], (expected_names[i], expected_statuses[i]),
+             (actual_names[i], actual_statuses[i]))
             for i in mismatches[:10]
         ]
         pytest.fail(
@@ -70,12 +75,16 @@ def test_resolve_tiers_vec_entry_age_override_frs():
     yos = np.array([10, 10], dtype=np.int64)
     ea_override = np.array([25, 0], dtype=np.int64)
 
-    actual = resolve_tiers_vec_str(config, cn, ey, age, yos, entry_age=ea_override)
-    expected = np.array([
+    actual_names, actual_statuses = vec_tier_components(
+        config, cn, ey, age, yos, entry_age=ea_override
+    )
+    expected = [
         get_tier(config, "regular", 2000, 40, 10, entry_age=25),
         get_tier(config, "regular", 2000, 40, 10, entry_age=30),
-    ], dtype=object)
-    assert np.array_equal(actual, expected)
+    ]
+    for i, (exp_name, exp_status) in enumerate(expected):
+        assert actual_names[i] == exp_name
+        assert actual_statuses[i] == exp_status
 
 
 def test_resolve_cola_vec_matches_scalar_frs():
@@ -83,11 +92,11 @@ def test_resolve_cola_vec_matches_scalar_frs():
     rows = build_frs_grid()
     cn, ey, age, yos = rows_to_arrays(rows)
 
-    tiers_str = resolve_tiers_vec_str(config, cn, ey, age, yos)
+    tier_names, _ = vec_tier_components(config, cn, ey, age, yos)
     tier_id, _ = resolve_tiers_vec(config, cn, ey, age, yos)
 
     expected = np.array([
-        scalar_cola(config, tiers_str[i], int(ey[i]), int(yos[i]))
+        scalar_cola(config, tier_names[i], int(ey[i]), int(yos[i]))
         for i in range(len(rows))
     ], dtype=np.float64)
 
@@ -102,13 +111,13 @@ def test_resolve_ben_mult_vec_matches_scalar_frs():
     rows = build_frs_grid()
     cn, ey, age, yos = rows_to_arrays(rows)
 
-    tiers_str = resolve_tiers_vec_str(config, cn, ey, age, yos)
+    tier_names, statuses = vec_tier_components(config, cn, ey, age, yos)
     tier_id, ret_status = resolve_tiers_vec(config, cn, ey, age, yos)
     dist_year = ey + yos
 
     expected = np.array([
-        get_ben_mult(config, rows[i][0], tiers_str[i], int(age[i]), int(yos[i]),
-                     int(dist_year[i]))
+        get_ben_mult(config, rows[i][0], tier_names[i], statuses[i],
+                     int(age[i]), int(yos[i]), int(dist_year[i]))
         for i in range(len(rows))
     ], dtype=np.float64)
 
@@ -140,12 +149,12 @@ def test_resolve_reduce_factor_vec_matches_scalar_frs():
     rows = build_frs_grid()
     cn, ey, age, yos = rows_to_arrays(rows)
 
-    tiers = resolve_tiers_vec_str(config, cn, ey, age, yos)
+    tier_names, statuses = vec_tier_components(config, cn, ey, age, yos)
     tier_id, ret_status = resolve_tiers_vec(config, cn, ey, age, yos)
 
     expected = np.array([
-        get_reduce_factor(config, rows[i][0], tiers[i], int(age[i]),
-                          int(yos[i]), int(ey[i]))
+        get_reduce_factor(config, rows[i][0], tier_names[i], statuses[i],
+                          int(age[i]), int(yos[i]), int(ey[i]))
         for i in range(len(rows))
     ], dtype=np.float64)
 
@@ -157,7 +166,7 @@ def test_resolve_reduce_factor_vec_matches_scalar_frs():
     mismatches = np.where(~(nan_match & val_match))[0]
     if len(mismatches) > 0:
         diffs = [
-            (rows[i], tiers[i], expected[i], actual[i])
+            (rows[i], (tier_names[i], statuses[i]), expected[i], actual[i])
             for i in mismatches[:10]
         ]
         pytest.fail(

--- a/tests/test_pension_model/test_vectorized_resolvers_txtrs.py
+++ b/tests/test_pension_model/test_vectorized_resolvers_txtrs.py
@@ -14,13 +14,13 @@ from pension_model.plan_config import (
     resolve_cola_vec,
     resolve_reduce_factor_vec,
     resolve_tiers_vec,
-    resolve_tiers_vec_str,
 )
 
 from ._vectorized_resolver_test_support import (
     build_txtrs_grid,
     rows_to_arrays,
     scalar_cola,
+    vec_tier_components,
 )
 
 
@@ -29,17 +29,22 @@ def test_resolve_tiers_vec_matches_scalar_txtrs():
     rows = build_txtrs_grid()
     cn, ey, age, yos = rows_to_arrays(rows)
 
-    expected = np.array([
-        get_tier(config, rows[i][0], int(ey[i]), int(age[i]), int(yos[i]))
-        for i in range(len(rows))
-    ], dtype=object)
+    expected_names = np.empty(len(rows), dtype=object)
+    expected_statuses = np.empty(len(rows), dtype=object)
+    for i in range(len(rows)):
+        expected_names[i], expected_statuses[i] = get_tier(
+            config, rows[i][0], int(ey[i]), int(age[i]), int(yos[i])
+        )
 
-    actual = resolve_tiers_vec_str(config, cn, ey, age, yos)
+    actual_names, actual_statuses = vec_tier_components(config, cn, ey, age, yos)
 
-    mismatches = np.where(expected != actual)[0]
+    mismatches = np.where(
+        (expected_names != actual_names) | (expected_statuses != actual_statuses)
+    )[0]
     if len(mismatches) > 0:
         diffs = [
-            (rows[i], expected[i], actual[i])
+            (rows[i], (expected_names[i], expected_statuses[i]),
+             (actual_names[i], actual_statuses[i]))
             for i in mismatches[:10]
         ]
         pytest.fail(
@@ -52,11 +57,11 @@ def test_resolve_cola_vec_matches_scalar_txtrs():
     rows = build_txtrs_grid()
     cn, ey, age, yos = rows_to_arrays(rows)
 
-    tiers_str = resolve_tiers_vec_str(config, cn, ey, age, yos)
+    tier_names, _ = vec_tier_components(config, cn, ey, age, yos)
     tier_id, _ = resolve_tiers_vec(config, cn, ey, age, yos)
 
     expected = np.array([
-        scalar_cola(config, tiers_str[i], int(ey[i]), int(yos[i]))
+        scalar_cola(config, tier_names[i], int(ey[i]), int(yos[i]))
         for i in range(len(rows))
     ], dtype=np.float64)
 
@@ -71,13 +76,13 @@ def test_resolve_ben_mult_vec_matches_scalar_txtrs():
     rows = build_txtrs_grid()
     cn, ey, age, yos = rows_to_arrays(rows)
 
-    tiers_str = resolve_tiers_vec_str(config, cn, ey, age, yos)
+    tier_names, statuses = vec_tier_components(config, cn, ey, age, yos)
     tier_id, ret_status = resolve_tiers_vec(config, cn, ey, age, yos)
     dist_year = ey + yos
 
     expected = np.array([
-        get_ben_mult(config, rows[i][0], tiers_str[i], int(age[i]), int(yos[i]),
-                     int(dist_year[i]))
+        get_ben_mult(config, rows[i][0], tier_names[i], statuses[i],
+                     int(age[i]), int(yos[i]), int(dist_year[i]))
         for i in range(len(rows))
     ], dtype=np.float64)
 
@@ -96,12 +101,12 @@ def test_resolve_reduce_factor_vec_matches_scalar_txtrs():
     rows = build_txtrs_grid()
     cn, ey, age, yos = rows_to_arrays(rows)
 
-    tiers = resolve_tiers_vec_str(config, cn, ey, age, yos)
+    tier_names, statuses = vec_tier_components(config, cn, ey, age, yos)
     tier_id, ret_status = resolve_tiers_vec(config, cn, ey, age, yos)
 
     expected = np.array([
-        get_reduce_factor(config, rows[i][0], tiers[i], int(age[i]),
-                          int(yos[i]), int(ey[i]))
+        get_reduce_factor(config, rows[i][0], tier_names[i], statuses[i],
+                          int(age[i]), int(yos[i]), int(ey[i]))
         for i in range(len(rows))
     ], dtype=np.float64)
 
@@ -113,7 +118,7 @@ def test_resolve_reduce_factor_vec_matches_scalar_txtrs():
     mismatches = np.where(~(nan_match & val_match))[0]
     if len(mismatches) > 0:
         diffs = [
-            (rows[i], tiers[i], expected[i], actual[i])
+            (rows[i], (tier_names[i], statuses[i]), expected[i], actual[i])
             for i in mismatches[:10]
         ]
         pytest.fail(


### PR DESCRIPTION
Final PR of B3 (\"generalize tier-name parsing\"). Closes #131.

After B3a (#130) and the cleanup PR (#133) deleted dead consumers, only three live parser sites remained — all in \`config_resolvers_scalar.py\`, plus their consumer in \`_build_years_from_nr_decrements\`.

## What this changes

### Scalar resolvers (\`config_resolvers_scalar.py\`)

**\`get_tier\` returns \`(tier_name, status)\` tuple** instead of \`f\"{tier_name}_{status}\"\`. Status is one of \`\"norm\"\` / \`\"early\"\` / \`\"vested\"\` / \`\"non_vested\"\` — the same values that were previously suffixes.

**\`get_ben_mult(config, class_name, tier_name, status, ...)\`** drops the line-98 \`tier.split(\"_\")\` parse; replaces \`\"early\" in tier\` with \`status == \"early\"\` for the early_fallback check.

**\`get_reduce_factor(config, class_name, tier_name, status, ...)\`** drops three parsing sites:
- \`\"norm\" in tier\` → \`status == \"norm\"\`
- \`\"early\" not in tier and \"reduced\" not in tier\` → \`status != \"early\"\` (the \`\"reduced\"\` branch was dead — never emitted by \`get_tier\`)
- \`tier.rsplit(\"_\", 1)[0]\` → \`tier_name\` parameter

### Loader (\`data_loader.py:_build_years_from_nr_decrements\`)

Captures \`tier_name\` and \`status\` in separate columns (\`df[\"tier\"]\` and \`df[\"status\"]\`) instead of overloading \`df[\"tier\"]\` with the composite. Replaces:
- \`df[\"tier\"].str.contains(\"norm\")\` → \`df[\"status\"] == \"norm\"\`
- \`df[\"tier\"].str.contains(\"early|reduced\")\` → \`df[\"status\"] == \"early\"\`

### Vectorized cleanup

- Deleted \`resolve_tiers_vec_str\` (test-only; existed solely to emit composite strings to feed the tuple-shaped scalar helpers — obsolete after the scalar refactor).
- Deleted \`_STATUS_SUFFIX\` constant (only consumer was \`resolve_tiers_vec_str\`).
- Removed both names from \`__all__\` in \`config_resolvers.py\` and \`plan_config.py\`.

### Tests

- New helper \`vec_tier_components(config, ...)\` in \`_vectorized_resolver_test_support.py\` returns parallel \`(tier_names, statuses)\` arrays from the vectorized resolver via \`_tier_id_to_name\` and a small int→status-string dict. Replaces \`resolve_tiers_vec_str\`.
- \`scalar_cola\` now takes \`tier_name\` directly (was substring-matching on the composite).
- 8 tests across \`test_vectorized_resolvers_frs.py\` and \`test_vectorized_resolvers_txtrs.py\` updated to use the new tuple-returning scalar helpers.

## Bit-identity

Logic unchanged. The composite string was the only input to the parsers; the parsers reconstructed exactly the same parts that \`get_tier\` already had. Removing the build-then-parse round-trip can't change which arithmetic operations run. Each row in \`_build_years_from_nr_decrements\` flips the same \`is_normal_retire\` / \`is_early_retire\` flags as before — just from \`status == \"norm\"\` instead of \`str.contains(\"norm\")\`.

## Diff

| File | Change |
|---|---|
| \`config_resolvers_scalar.py\` | \`get_tier\` returns tuple; 2 helpers updated |
| \`config_resolvers_vectorized.py\` | Deleted \`resolve_tiers_vec_str\` |
| \`config_resolver_common.py\` | Deleted \`_STATUS_SUFFIX\` |
| \`config_resolvers.py\`, \`plan_config.py\` | Removed deleted names |
| \`core/data_loader.py\` | Captures \`tier_name\` + \`status\` separately |
| \`_vectorized_resolver_test_support.py\` | Added \`vec_tier_components\`; \`scalar_cola\` takes \`tier_name\` |
| \`test_vectorized_resolvers_frs.py\` | 8 tests updated |
| \`test_vectorized_resolvers_txtrs.py\` | 4 tests updated |

**9 files, +115 / -90.**

## Validation

- \`make r-match\` — 8/8 truth-table cells pass at relative diff < 1e-10.
- \`make test\` — 326 passed, 2 skipped (unrelated snapshot updaters). All 12 vectorized-resolver tests pass with the new helper-based ground-truth pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)