### PR TITLE
B6a: read corridor constants from plan_config instead of hardcoding

### DIFF
--- a/src/pension_model/core/_funding_helpers.py
+++ b/src/pension_model/core/_funding_helpers.py
@@ -253,20 +253,33 @@ def _populate_calibrated_nc_rates(f, liab, nc_cal, n_years):
         f.loc[1:, "nc_rate_cb_new"] = nc_new_cb[:-1]
 
 
-def _ava_corridor_smoothing(ava_prev, net_cf, mva, dr):
-    """Five-year corridor AVA smoothing (recognize 1/5 of gain/loss).
+def _ava_corridor_smoothing(
+    ava_prev,
+    net_cf,
+    mva,
+    dr,
+    recognition_fraction,
+    corridor_low,
+    corridor_high,
+):
+    """Corridor AVA smoothing with config-driven recognition and bounds.
 
     Used by the corridor (FRS-style) funding path *at the plan-aggregate
     level*. The smoothed AVA is the prior AVA plus expected mid-year
-    investment income, plus 1/5 of the gap to MVA, then bounded to the
-    [80%, 120%] corridor around MVA::
+    investment income, plus ``recognition_fraction`` of the gap to MVA,
+    then bounded to the ``[corridor_low * mva, corridor_high * mva]``
+    corridor::
 
         exp_inv_earnings_ava = ava_prev * dr + net_cf * dr / 2
         exp_ava              = ava_prev + net_cf + exp_inv_earnings_ava
-        ava_unbounded        = exp_ava + (mva - exp_ava) * 0.2
-        ava                  = clip(ava_unbounded, 0.8 * mva, 1.2 * mva)
+        ava_unbounded        = exp_ava + (mva - exp_ava) * recognition_fraction
+        ava                  = clip(ava_unbounded, corridor_low * mva, corridor_high * mva)
         alloc_inv_earnings_ava = ava - ava_prev - net_cf
         ava_base             = ava_prev + net_cf / 2
+
+    For FRS the parameters are 0.2, 0.8, 1.2 (one-fifth recognition,
+    [80%, 120%] corridor) — declared in ``plan_config.json`` under
+    ``funding.ava_smoothing``.
 
     Returned values match the column names written by the original
     inline FRS smoothing block (legacy and new layers each get their
@@ -277,10 +290,10 @@ def _ava_corridor_smoothing(ava_prev, net_cf, mva, dr):
     exp_ava = ava_prev + net_cf + exp_inv_earnings_ava
     ava = max(
         min(
-            exp_ava + (mva - exp_ava) * 0.2,
-            mva * 1.2,
+            exp_ava + (mva - exp_ava) * recognition_fraction,
+            mva * corridor_high,
         ),
-        mva * 0.8,
+        mva * corridor_low,
     )
     alloc_inv_earnings_ava = ava - ava_prev - net_cf
     ava_base = ava_prev + net_cf / 2

--- a/src/pension_model/core/_funding_setup.py
+++ b/src/pension_model/core/_funding_setup.py
@@ -76,9 +76,19 @@ def resolve_funding_context(
     has_cb = "cb" in constants.benefit_types
     has_dc = "payroll_dc_legacy" in funding_inputs["init_funding"].columns
 
-    method = (fund.ava_smoothing or {}).get("method")
+    smoothing_cfg = fund.ava_smoothing or {}
+    method = smoothing_cfg.get("method")
     if method == "corridor":
-        ava_strategy = CorridorSmoothing()
+        # ``gain_loss_recognition`` is the historical name for the
+        # corridor's recognition fraction (the share of the gap to MVA
+        # recognized each year). The name is misleading — it has
+        # nothing to do with the gain/loss smoothing strategy — but
+        # renaming it touches plan_config.json; deferred.
+        ava_strategy = CorridorSmoothing(
+            recognition_fraction=smoothing_cfg.get("gain_loss_recognition", 0.2),
+            corridor_low=smoothing_cfg.get("corridor_low", 0.8),
+            corridor_high=smoothing_cfg.get("corridor_high", 1.2),
+        )
     elif method == "gain_loss":
         ava_strategy = GainLossSmoothing()
     else:

--- a/src/pension_model/core/_funding_strategies.py
+++ b/src/pension_model/core/_funding_strategies.py
@@ -132,12 +132,18 @@ class AvaSmoothingStrategy(Protocol):
 
 
 class CorridorSmoothing:
-    """Five-year corridor smoothing at the plan-aggregate level.
+    """Corridor smoothing at the plan-aggregate level.
 
-    Smooths each leg's AVA toward MVA at 1/5 per year, bounded to
-    ``[0.8 * mva, 1.2 * mva]``. After smoothing the aggregate, allocates
-    the realized earnings to each class in proportion to that class's
-    pre-smoothing ``ava_base`` (= ``ava_prev + net_cf / 2``).
+    Each year, smooths AVA toward MVA by ``recognition_fraction`` of the
+    gap, bounded to ``[corridor_low * mva, corridor_high * mva]``. After
+    smoothing the aggregate, allocates the realized earnings to each
+    class in proportion to that class's pre-smoothing ``ava_base``
+    (= ``ava_prev + net_cf / 2``).
+
+    The three constants are declared in ``plan_config.json`` under
+    ``funding.ava_smoothing`` and threaded in by ``resolve_funding_context``.
+    Defaults match FRS (0.2 recognition, [0.8, 1.2] corridor) so a plan
+    can omit them.
     """
 
     aggregation_level: ClassVar[Literal["plan", "class"]] = "plan"
@@ -157,6 +163,16 @@ class CorridorSmoothing:
     # Corridor does not emit the gainloss-only output columns.
     emits_liability_gain_loss_sum: ClassVar[bool] = False
 
+    def __init__(
+        self,
+        recognition_fraction: float = 0.2,
+        corridor_low: float = 0.8,
+        corridor_high: float = 1.2,
+    ):
+        self.recognition_fraction = recognition_fraction
+        self.corridor_low = corridor_low
+        self.corridor_high = corridor_high
+
     def smooth(
         self,
         ava_prev: float,
@@ -165,7 +181,15 @@ class CorridorSmoothing:
         dr: float,
         state: dict,  # noqa: ARG002 — corridor has no extra state
     ) -> dict:
-        return _ava_corridor_smoothing(ava_prev, net_cf, mva, dr)
+        return _ava_corridor_smoothing(
+            ava_prev,
+            net_cf,
+            mva,
+            dr,
+            self.recognition_fraction,
+            self.corridor_low,
+            self.corridor_high,
+        )
 
     def allocate_to_classes(
         self,


### PR DESCRIPTION
First half of B6 (\"smoothing/cascade config\"). Closes #135.

## What this changes

Three corridor-smoothing constants were hardcoded in \`_ava_corridor_smoothing\` despite FRS's \`plan_config.json\` already declaring them. After this PR, the function reads from config; the hardcode is gone.

| Constant | Old (hardcoded) | New (config-read) |
|---|---|---|
| Recognition fraction (1/5 of gap-to-MVA each year) | \`0.2\` literal in \`_funding_helpers.py:280\` | \`fund.ava_smoothing.gain_loss_recognition\` (default 0.2) |
| Corridor upper bound | \`mva * 1.2\` literal | \`fund.ava_smoothing.corridor_high\` (default 1.2) |
| Corridor lower bound | \`mva * 0.8\` literal | \`fund.ava_smoothing.corridor_low\` (default 0.8) |

Plumbing:

- **\`_ava_corridor_smoothing\`** (\`_funding_helpers.py\`) takes the three params; uses them in the formula.
- **\`CorridorSmoothing\`** (\`_funding_strategies.py\`) gains an \`__init__\` that stores the three values; \`smooth()\` forwards to the helper. Defaults match today's hardcode so a plan can omit any of them.
- **\`resolve_funding_context\`** (\`_funding_setup.py\`) reads the three keys from \`fund.ava_smoothing\` and passes them to the constructor.

## Why no plan_config changes

FRS already declared all three keys with values 0.20, 0.80, 1.20 — exactly today's hardcode. TXTRS uses gain/loss smoothing (different code path, not touched here). Pure Python routing change: same numbers fed via config rather than literals.

## Why \`gain_loss_recognition\` keeps its misleading name

The key name is misleading — it's the *corridor* recognition fraction, nothing to do with gain/loss smoothing. Renaming to \`recognition_fraction\` is cleaner but adds plan_config churn; deferred to a separate cosmetic PR.

## Out of scope (B6b)

\`_ava_gain_loss_smoothing\` hardcodes both the cascade structure (4 deferral slots: \`defer_y1\`...\`defer_y4\`) and the weights (\`0.5\`, \`2/3\`, \`3/4\`, \`4/5\`). Generalizing to N years requires renaming funding-frame columns, which touches output CSVs and tests. Higher blast radius — separate PR if/when needed.

## Diff

| File | Change |
|---|---|
| \`_funding_helpers.py\` | \`_ava_corridor_smoothing\` accepts 3 new params |
| \`_funding_strategies.py\` | \`CorridorSmoothing\` gains \`__init__\` |
| \`_funding_setup.py\` | reads keys from config; passes to constructor |

**3 files, +65 / -18.**

## Validation

- \`make r-match\` — 8/8 truth-table cells pass at relative diff < 1e-10.
- \`make test\` — 326 passed, 2 skipped (unrelated snapshot updaters).

Bit-identity holds: same numbers, same arithmetic, just routed via config rather than literals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)