### PR TITLE
B4a: declare-only funding legs in plan_config

### DIFF
--- a/plans/frs/config/plan_config.json
+++ b/plans/frs/config/plan_config.json
@@ -48,7 +48,11 @@
       "corridor_low": 0.80,
       "corridor_high": 1.20,
       "gain_loss_recognition": 0.20
-    }
+    },
+    "legs": [
+      {"name": "legacy", "entry_year_max_param": "new_year"},
+      {"name": "new", "entry_year_min_param": "new_year"}
+    ]
   },
 
   "decrements": {

--- a/plans/txtrs-av/config/plan_config.json
+++ b/plans/txtrs-av/config/plan_config.json
@@ -72,7 +72,11 @@
           ]
         }
       ]
-    }
+    },
+    "legs": [
+      {"name": "legacy", "entry_year_max_param": "new_year"},
+      {"name": "new", "entry_year_min_param": "new_year"}
+    ]
   },
 
   "decrements": {

--- a/plans/txtrs/config/plan_config.json
+++ b/plans/txtrs/config/plan_config.json
@@ -93,7 +93,11 @@
           ]
         }
       ]
-    }
+    },
+    "legs": [
+      {"name": "legacy", "entry_year_max_param": "new_year"},
+      {"name": "new", "entry_year_min_param": "new_year"}
+    ]
   },
 
   "decrements": {

--- a/src/pension_model/config_loading.py
+++ b/src/pension_model/config_loading.py
@@ -197,6 +197,11 @@ def load_plan_config(
         _tier_id_to_retire_rate_set=tier_id_to_retire_rate_set,
     )
 
+    # Fatal: legs must be non-overlapping and cover the full
+    # entry-year range. Raises ValueError on misconfiguration.
+    from pension_model.config_validation import validate_funding_legs
+    validate_funding_legs(config)
+
     for warning in config.validate():
         log.info("[%s config] %s", config.plan_name, warning)
 

--- a/src/pension_model/config_schema.py
+++ b/src/pension_model/config_schema.py
@@ -143,6 +143,35 @@ class PlanConfig:
         return self.raw.get("funding", {}).get("amo_period_current")
 
     @property
+    def funding_legs(self) -> Tuple[Tuple[str, Optional[int], Optional[int]], ...]:
+        """Resolved funding legs as ``((name, lo, hi), ...)``.
+
+        ``lo`` is inclusive, ``hi`` is exclusive — same convention as
+        the tier resolver (``entry_year_min`` / ``entry_year_max``).
+        ``entry_year_min_param`` / ``entry_year_max_param`` strings of
+        ``\"new_year\"`` resolve to ``self.new_year``.
+
+        Defaults to today's two-leg ``legacy`` / ``new`` split keyed off
+        ``new_year`` if the plan_config doesn't declare ``funding.legs``.
+        """
+        legs_raw = self.raw.get("funding", {}).get("legs")
+        if not legs_raw:
+            legs_raw = [
+                {"name": "legacy", "entry_year_max_param": "new_year"},
+                {"name": "new", "entry_year_min_param": "new_year"},
+            ]
+        resolved = []
+        for leg in legs_raw:
+            lo = leg.get("entry_year_min")
+            if leg.get("entry_year_min_param") == "new_year":
+                lo = self.new_year
+            hi = leg.get("entry_year_max")
+            if leg.get("entry_year_max_param") == "new_year":
+                hi = self.new_year
+            resolved.append((leg["name"], lo, hi))
+        return tuple(resolved)
+
+    @property
     def decrements_method(self) -> str:
         decr = self.raw.get("decrements")
         if not decr or "method" not in decr:

--- a/src/pension_model/config_validation.py
+++ b/src/pension_model/config_validation.py
@@ -3,6 +3,51 @@
 from pathlib import Path
 
 
+def validate_funding_legs(config) -> None:
+    """Fatal check: funding legs are non-overlapping and cover the full
+    entry-year range of the model.
+
+    Currently also enforces exactly two legs — the simulation's
+    funding-frame columns are hardcoded to two leg names (today
+    ``legacy`` / ``new``). Generalization to N legs is tracked in
+    Phase C9 (#137).
+
+    Raises:
+        ValueError: if leg count is not 2, if any two legs overlap, or
+        if any entry year in ``[min_entry_year, max_entry_year)`` is
+        not covered by exactly one leg.
+    """
+    legs = config.funding_legs
+    if len(legs) != 2:
+        raise ValueError(
+            f"Plan {config.plan_name!r}: funding.legs must declare "
+            f"exactly two legs (today's column-name shape requires it). "
+            f"Got {len(legs)}: {[n for n, _, _ in legs]}. "
+            f"N-leg generalization tracked in #137."
+        )
+
+    lo_bound = config.min_entry_year
+    hi_bound = config.max_entry_year + 1  # max_entry_year is inclusive in usage
+
+    for ey in range(lo_bound, hi_bound):
+        matches = [
+            name for name, lo, hi in legs
+            if (lo is None or ey >= lo) and (hi is None or ey < hi)
+        ]
+        if len(matches) == 0:
+            raise ValueError(
+                f"Plan {config.plan_name!r}: entry_year {ey} is not "
+                f"covered by any funding leg. Legs: "
+                f"{[(n, lo, hi) for n, lo, hi in legs]}."
+            )
+        if len(matches) > 1:
+            raise ValueError(
+                f"Plan {config.plan_name!r}: entry_year {ey} is covered "
+                f"by multiple funding legs {matches}. Legs must not "
+                f"overlap. Legs: {[(n, lo, hi) for n, lo, hi in legs]}."
+            )
+
+
 def validate_config(config) -> list[str]:
     """Return non-fatal config warnings for a loaded plan."""
     warnings: list[str] = []

--- a/src/pension_model/core/pipeline_projected.py
+++ b/src/pension_model/core/pipeline_projected.py
@@ -15,15 +15,28 @@ def _get_bt_columns(bt: str) -> dict:
     return {"pvfb": None, "pvfnc": None, "nc": None}
 
 
-def _allocate_members(wf, benefit_types, design_ratios, new_year, design_cutoff_year=2018):
-    """Allocate workforce members to benefit type buckets (legacy/new)."""
+def _allocate_members(wf, benefit_types, design_ratios, legs, design_cutoff_year=2018):
+    """Allocate workforce members to benefit type buckets, one column
+    per (benefit_type, leg).
+
+    ``legs`` is the resolved leg list ``((name, lo, hi), ...)`` from
+    ``PlanConfig.funding_legs``. Today this is exactly two legs
+    (today's column-name shape requires it; see #137 for the
+    generalization). The first leg uses the ``before_cutoff`` /
+    ``after_cutoff`` design-ratio split (controlled by
+    ``design_cutoff_year``); the second leg uses the ``new`` ratio.
+    """
+    legacy_name, _, legacy_hi = legs[0]
+    new_name, new_lo, _ = legs[1]
+    cutoff = new_lo if new_lo is not None else legacy_hi
+
     ey = wf["entry_year"]
     n = wf["n_active"]
     for bt in benefit_types:
         before, after, new = design_ratios[bt]
-        wf[f"n_{bt}_legacy"] = np.where(
-            ey < new_year, np.where(ey < design_cutoff_year, n * before, n * after), 0.0)
-        wf[f"n_{bt}_new"] = np.where(ey < new_year, 0.0, n * new)
+        wf[f"n_{bt}_{legacy_name}"] = np.where(
+            ey < cutoff, np.where(ey < design_cutoff_year, n * before, n * after), 0.0)
+        wf[f"n_{bt}_{new_name}"] = np.where(ey < cutoff, 0.0, n * new)
     return wf
 
 
@@ -43,16 +56,23 @@ def _filter_lookup_to_runtime(lookup: pd.DataFrame, wf: pd.DataFrame, columns: l
     return lookup.loc[mask]
 
 
-def _allocate_term(wf, pop_col, design_ratios, benefit_types, new_year, design_cutoff_year=2018):
-    """Allocate term/refund/retire workforce to benefit type buckets."""
+def _allocate_term(wf, pop_col, design_ratios, benefit_types, legs, design_cutoff_year=2018):
+    """Allocate term/refund/retire workforce to benefit type buckets.
+
+    See :func:`_allocate_members` for the leg / design-ratio mapping.
+    """
+    legacy_name, _, legacy_hi = legs[0]
+    new_name, new_lo, _ = legs[1]
+    cutoff = new_lo if new_lo is not None else legacy_hi
+
     ey = wf["entry_year"]
     n = wf[pop_col]
     base = pop_col[2:] if pop_col.startswith("n_") else pop_col
     for bt in benefit_types:
         before, after, new = design_ratios[bt]
-        wf[f"n_{base}_{bt}_legacy"] = np.where(
-            ey < new_year, np.where(ey < design_cutoff_year, n * before, n * after), 0.0)
-        wf[f"n_{base}_{bt}_new"] = np.where(ey < new_year, 0.0, n * new)
+        wf[f"n_{base}_{bt}_{legacy_name}"] = np.where(
+            ey < cutoff, np.where(ey < design_cutoff_year, n * before, n * after), 0.0)
+        wf[f"n_{base}_{bt}_{new_name}"] = np.where(ey < cutoff, 0.0, n * new)
     return wf
 
 
@@ -60,8 +80,7 @@ def compute_active_liability(wf_active: pd.DataFrame, active_benefit_lookup: pd.
                              class_name: str, constants) -> pd.DataFrame:
     """Compute active member liability by year."""
     r = constants.ranges
-    new_year = r.new_year
-    design_cutoff = constants.plan_design_cutoff_year or new_year
+    design_cutoff = constants.plan_design_cutoff_year or r.new_year
 
     design_ratios = constants.get_design_ratios(class_name)
     benefit_types = list(constants.benefit_types)
@@ -76,7 +95,7 @@ def compute_active_liability(wf_active: pd.DataFrame, active_benefit_lookup: pd.
         how="left",
     )
     wf = wf.fillna(0)
-    wf = _allocate_members(wf, benefit_types, design_ratios, new_year, design_cutoff)
+    wf = _allocate_members(wf, benefit_types, design_ratios, constants.funding_legs, design_cutoff)
     salary = wf["salary"]
     wf["total_payroll_est"] = salary * wf["n_active"]
     wf["total_n_active"] = wf["n_active"]
@@ -152,7 +171,7 @@ def compute_term_liability(wf_term: pd.DataFrame, term_liability_lookup: pd.Data
     )
 
     wf["pvfb_db_term"] = wf["pvfb_db_at_term_age"] / wf["cum_mort_dr"]
-    wf = _allocate_term(wf, "n_term", design_ratios, benefit_types, r.new_year, design_cutoff)
+    wf = _allocate_term(wf, "n_term", design_ratios, benefit_types, constants.funding_legs, design_cutoff)
     sum_cols = []
     for bt in benefit_types:
         if bt == "dc":
@@ -191,7 +210,7 @@ def compute_refund_liability(wf_refund: pd.DataFrame, refund_lookup: pd.DataFram
         how="left",
     )
 
-    wf = _allocate_term(wf, "n_refund", design_ratios, benefit_types, r.new_year, design_cutoff)
+    wf = _allocate_term(wf, "n_refund", design_ratios, benefit_types, constants.funding_legs, design_cutoff)
     sum_cols = []
     for bt in benefit_types:
         if bt == "dc":
@@ -250,7 +269,7 @@ def compute_retire_liability(wf_retire: pd.DataFrame, retire_benefit_lookup: pd.
         wf["cb_benefit_final"] = wf["cb_benefit"] * (1 + wf["cola"]) ** (wf["year"] - wf["retire_year"])
         wf["pvfb_cb_retire"] = wf["cb_benefit_final"] * (wf["ann_factor"] - 1)
 
-    wf = _allocate_term(wf, "n_retire", design_ratios, benefit_types, r.new_year, design_cutoff)
+    wf = _allocate_term(wf, "n_retire", design_ratios, benefit_types, constants.funding_legs, design_cutoff)
     sum_cols = []
     for bt in benefit_types:
         if bt == "dc":

--- a/tests/test_pension_model/test_stage3_loader.py
+++ b/tests/test_pension_model/test_stage3_loader.py
@@ -317,3 +317,42 @@ def test_unknown_decrements_method_raises(frs_config, tmp_path):
 
     with pytest.raises(ValueError, match="made_up_method"):
         _load_decrements({}, bogus, decr_dir, "regular")
+
+
+def test_overlapping_funding_legs_raises(frs_config):
+    """Funding legs whose entry-year ranges overlap raise a clear
+    ValueError listing the overlapping leg names.
+    """
+    from dataclasses import replace
+    from pension_model.config_validation import validate_funding_legs
+
+    # Override raw so funding_legs resolves to two overlapping legs.
+    raw = dict(frs_config.raw)
+    raw["funding"] = dict(raw["funding"])
+    raw["funding"]["legs"] = [
+        {"name": "legacy", "entry_year_max": 2030},
+        {"name": "new", "entry_year_min": 2020},  # overlap on 2020-2029
+    ]
+    bogus = replace(frs_config, raw=raw)
+
+    with pytest.raises(ValueError, match="overlap"):
+        validate_funding_legs(bogus)
+
+
+def test_gappy_funding_legs_raises(frs_config):
+    """Funding legs that don't cover the full entry-year range raise a
+    clear ValueError naming the uncovered year.
+    """
+    from dataclasses import replace
+    from pension_model.config_validation import validate_funding_legs
+
+    raw = dict(frs_config.raw)
+    raw["funding"] = dict(raw["funding"])
+    raw["funding"]["legs"] = [
+        {"name": "legacy", "entry_year_max": 2010},
+        {"name": "new", "entry_year_min": 2020},  # gap 2010..2019
+    ]
+    bogus = replace(frs_config, raw=raw)
+
+    with pytest.raises(ValueError, match="not covered"):
+        validate_funding_legs(bogus)


### PR DESCRIPTION
Last item of Phase B. Closes #138. Design check-in in \`scratch/B4_design_checkin.md\`. Bigger N-leg / parametric-column work promoted to Phase C9 (#137).

## What this changes

The 2-leg \`legacy\` / \`new\` funding split was implicit in code: \`pipeline_projected.py\` hardcoded the column names and used the single \`ranges.new_year\` cutoff to bucket members. After this PR the legs are declared explicitly in \`plan_config.json\` under \`funding.legs[]\`. Today's behavior is preserved bit-for-bit; the schema change just gives the legs a config home.

**Schema.** \`funding.legs[]\` is an array of objects with \`name\` plus \`entry_year_min\` / \`entry_year_max\` (or \`*_param: \"new_year\"\` to resolve from \`ranges.new_year\`). Same min/max convention as the tier resolver — min inclusive, max exclusive.

**FRS / TXTRS / TXTRS-AV plan_configs:**

\`\`\`json
\"legs\": [
  {\"name\": \"legacy\", \"entry_year_max_param\": \"new_year\"},
  {\"name\": \"new\",    \"entry_year_min_param\": \"new_year\"}
]
\`\`\`

All three keep the literal names \`legacy\` and \`new\` so R baselines and snapshot tests are unchanged.

**Code:**

- **\`PlanConfig.funding_legs\`** new property returning resolved \`((name, lo, hi), ...)\` tuples. Defaults to today's structure if \`funding.legs\` is missing.
- **\`validate_funding_legs\`** fatal load-time check. Enforces exactly two legs (today's column-name shape requires it; relaxation is C9), no overlap, full coverage of the entry-year range. Called from \`config_loading\` after the PlanConfig is built.
- **\`pipeline_projected._allocate_members\` / \`_allocate_term\`** read leg names + cutoff from \`constants.funding_legs\` instead of taking \`new_year\` directly. Two-leg shape preserved; the first leg uses the before/after design-ratio split, the second uses the new ratio.

## Why this is small

The point of B4a is to make the leg structure declarative — *not* to generalize. The 2-leg constraint is enforced at load time. Funding-strategy code that hardcodes \`payroll_db_legacy\` / \`payroll_db_new\` references is not touched (those names match today's leg names). A future plan that wants different leg names or counts won't work yet — that's the C9 generalization.

## What stays the same

- The 2-leg structure. C9 will replace this with per-tier layers.
- All column names — \`legacy\` and \`new\` literals throughout the funding model.
- Funding strategy code (no changes).
- Snapshot tests, R baselines, output CSVs — unchanged.
- The secondary \`design_cutoff_year\` (FRS 2018) inside the legacy leg stays as a ratio sub-table, not a leg.

## New unit tests

- \`test_overlapping_funding_legs_raises\` — legs whose ranges overlap raise \`ValueError\` matching \`\"overlap\"\`.
- \`test_gappy_funding_legs_raises\` — legs that don't cover the entry-year range raise \`ValueError\` matching \`\"not covered\"\`.

## Validation

- \`make r-match\` — 8/8 truth-table cells pass at relative diff < 1e-10.
- \`make test\` — 328 passed (was 326 + 2 new), 2 skipped (unrelated snapshot updaters).

Bit-identity holds: the legs resolve to today's exact \`new_year\` cutoff and the literal column names \`legacy\` / \`new\`.

## Out of scope (Phase C9, #137)

- N-leg generalization with parametric column names.
- Per-tier funding layers replacing the leg concept entirely.
- Scenario-added tiers (a real and recurring policy-analysis use case noted by the user).

🤖 Generated with [Claude Code](https://claude.com/claude-code)