### PR TITLE
Cleanup: lint warnings + rename gain_loss_recognition to recognition_fraction

### DIFF
--- a/plans/frs/config/plan_config.json
+++ b/plans/frs/config/plan_config.json
@@ -47,7 +47,7 @@
       "method": "corridor",
       "corridor_low": 0.80,
       "corridor_high": 1.20,
-      "gain_loss_recognition": 0.20
+      "recognition_fraction": 0.20
     },
     "legs": [
       {"name": "legacy", "entry_year_max_param": "new_year"},

--- a/src/pension_model/cli.py
+++ b/src/pension_model/cli.py
@@ -47,8 +47,8 @@ def _fmt_smoothing(cfg):
     if method == "corridor":
         lo = sm.get("corridor_low", 0.8)
         hi = sm.get("corridor_high", 1.2)
-        recog = sm.get("gain_loss_recognition", 0.2)
-        return f"corridor ({lo:.0%}-{hi:.0%} of MVA), {recog:.0%}/yr gain-loss recognition"
+        recog = sm.get("recognition_fraction", 0.2)
+        return f"corridor ({lo:.0%}-{hi:.0%} of MVA), {recog:.0%}/yr recognition"
     elif method == "gain_loss":
         period = sm.get("recognition_period", 4)
         return f"{period}-year gain-loss recognition"

--- a/src/pension_model/config_validation.py
+++ b/src/pension_model/config_validation.py
@@ -1,7 +1,5 @@
 """Validation helpers for loaded plan configs."""
 
-from pathlib import Path
-
 
 def validate_funding_legs(config) -> None:
     """Fatal check: funding legs are non-overlapping and cover the full

--- a/src/pension_model/core/_funding_setup.py
+++ b/src/pension_model/core/_funding_setup.py
@@ -79,13 +79,8 @@ def resolve_funding_context(
     smoothing_cfg = fund.ava_smoothing or {}
     method = smoothing_cfg.get("method")
     if method == "corridor":
-        # ``gain_loss_recognition`` is the historical name for the
-        # corridor's recognition fraction (the share of the gap to MVA
-        # recognized each year). The name is misleading — it has
-        # nothing to do with the gain/loss smoothing strategy — but
-        # renaming it touches plan_config.json; deferred.
         ava_strategy = CorridorSmoothing(
-            recognition_fraction=smoothing_cfg.get("gain_loss_recognition", 0.2),
+            recognition_fraction=smoothing_cfg.get("recognition_fraction", 0.2),
             corridor_low=smoothing_cfg.get("corridor_low", 0.8),
             corridor_high=smoothing_cfg.get("corridor_high", 1.2),
         )

--- a/src/pension_model/core/pipeline_projected.py
+++ b/src/pension_model/core/pipeline_projected.py
@@ -126,7 +126,6 @@ def compute_active_liability(wf_active: pd.DataFrame, active_benefit_lookup: pd.
         if cols["nc"] is None or cols["nc"] not in wf.columns:
             continue
 
-        nc_col = cols["nc"]
         for period in ["legacy", "new"]:
             pay_col = f"payroll_{bt}_{period}_est"
             if pay_col not in result.columns:

--- a/tests/test_pension_model/test_stage3_loader.py
+++ b/tests/test_pension_model/test_stage3_loader.py
@@ -297,7 +297,7 @@ def test_unknown_retirement_rate_set_raises(frs_config, tmp_path):
         )
 
 
-def test_unknown_decrements_method_raises(frs_config, tmp_path):
+def test_unknown_decrements_method_raises(frs_config):
     """A plan declaring an unknown decrements.method must raise a clear
     error from the registry dispatch in _load_decrements.
     """


### PR DESCRIPTION
Tiny cleanup PR. Closes #140.

## Lint fixes (3 Pyrefly warnings)

| File | Issue |
|---|---|
| \`tests/test_pension_model/test_stage3_loader.py:300\` | \`tmp_path\` fixture parameter unused in \`test_unknown_decrements_method_raises\` (the test uses \`Path(__file__).parent\` directly). Dropped. |
| \`src/pension_model/core/pipeline_projected.py:129\` | \`nc_col = cols[\"nc\"]\` assigned but never read. Deleted. |
| \`src/pension_model/config_validation.py:3\` | \`from pathlib import Path\` unused — no function in this module uses Path directly; data-file paths are derived via \`config.resolve_data_dir()\`. Deleted. |

## Rename \`gain_loss_recognition\` → \`recognition_fraction\`

B6a (#135) plumbed three corridor-smoothing constants from \`plan_config.json\` through \`CorridorSmoothing\` into \`_ava_corridor_smoothing\`. One key — \`gain_loss_recognition\` — was misleadingly named: it's the *corridor* recognition fraction, has nothing to do with the gain/loss smoothing strategy.

Renamed everywhere:
- \`plans/frs/config/plan_config.json\` — FRS is the only plan that uses corridor smoothing, hence the only plan with this key.
- \`src/pension_model/core/_funding_setup.py\` — single read site. The note about the misleading historical name (added in B6a) is removed since the name is now accurate.
- \`src/pension_model/cli.py\` — display string in \`_fmt_smoothing\` updated to read the renamed key.

TXTRS and TXTRS-AV use gain/loss smoothing and don't have this key, so they're not touched.

## Validation

- \`make r-match\` — 8/8 truth-table cells pass at relative diff < 1e-10.
- \`make test\` — 328 passed, 2 skipped (unrelated snapshot updaters).

**6 files, +5 / -13.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)