### PR TITLE
A3 follow-up: extend tier discount-rate selection from binary to N rates

### DIFF
--- a/src/pension_model/core/benefit_tables.py
+++ b/src/pension_model/core/benefit_tables.py
@@ -1294,6 +1294,22 @@ def _resolve_sep_type_vec(ret_status: np.ndarray) -> np.ndarray:
     return _SEP_TYPE_LABELS[_resolve_sep_kind_vec(ret_status)]
 
 
+def _resolve_econ_rate(econ, key: str, plan_name: str) -> float:
+    """Resolve a tier's ``discount_rate_key`` to a value on the
+    economic namespace. Raises ``ValueError`` with the unknown key
+    listed if the lookup fails — silent fallback to ``dr_current``
+    is no longer permitted.
+    """
+    if not hasattr(econ, key):
+        raise ValueError(
+            f"Plan {plan_name!r}: tier discount_rate_key {key!r} is "
+            f"not a known economic-namespace attribute. Pick one of: "
+            f"dr_current, dr_new, dr_old, model_return, baseline_dr_current, "
+            f"baseline_model_return, payroll_growth."
+        )
+    return getattr(econ, key)
+
+
 def build_benefit_val_table(
     salary_benefit_table: pd.DataFrame,
     benefit_table: pd.DataFrame,
@@ -1367,7 +1383,7 @@ def build_benefit_val_table(
     ret_status_arr = sbt["ret_status"].to_numpy(dtype=np.int8, copy=False)
     sep_kind_arr = _resolve_sep_kind_vec(ret_status_arr)
     dr_by_tier_id = np.array(
-        [econ.dr_new if k == "dr_new" else econ.dr_current
+        [_resolve_econ_rate(econ, k, constants.plan_name)
          for k in constants._tier_id_to_dr_key],
         dtype=np.float64,
     )

--- a/tests/test_pension_model/test_stage3_loader.py
+++ b/tests/test_pension_model/test_stage3_loader.py
@@ -356,3 +356,15 @@ def test_gappy_funding_legs_raises(frs_config):
 
     with pytest.raises(ValueError, match="not covered"):
         validate_funding_legs(bogus)
+
+
+def test_unknown_tier_discount_rate_key_raises(frs_config):
+    """A tier declaring a discount_rate_key not present on the
+    economic namespace raises ValueError naming the unknown key.
+    Catches typos and silent fallback to dr_current.
+    """
+    from pension_model.core.benefit_tables import _resolve_econ_rate
+
+    econ = frs_config.economic
+    with pytest.raises(ValueError, match="bogus_rate"):
+        _resolve_econ_rate(econ, "bogus_rate", frs_config.plan_name)


### PR DESCRIPTION
Closes #142. Tiny generalization of the per-tier discount-rate lookup added in A3 (#103).

## What this changes

A3 added a per-tier \`discount_rate_key\` field but kept the lookup binary:

\`\`\`python
dr_by_tier_id = np.array(
    [econ.dr_new if k == \"dr_new\" else econ.dr_current
     for k in constants._tier_id_to_dr_key],
    dtype=np.float64,
)
\`\`\`

Any key string other than \`\"dr_new\"\` silently used \`econ.dr_current\`. A plan declaring \`\"dr_old\"\` or a typo'd key would get the wrong rate without warning.

After this PR, the lookup is \`getattr(econ, key)\` via a small helper that raises \`ValueError\` listing the unknown key and the supported rate names:

\`\`\`python
def _resolve_econ_rate(econ, key, plan_name):
    if not hasattr(econ, key):
        raise ValueError(
            f\"Plan {plan_name!r}: tier discount_rate_key {key!r} is \"
            f\"not a known economic-namespace attribute. Pick one of: \"
            f\"dr_current, dr_new, dr_old, model_return, ...\"
        )
    return getattr(econ, key)
\`\`\`

A plan can now declare any rate name on the \`economic\` namespace as a tier's \`discount_rate_key\`.

## Bit-identity

- FRS tier_3: \`\"dr_new\"\` → \`getattr(econ, \"dr_new\")\` = same float as \`econ.dr_new\`.
- FRS tier_1, tier_2 default to \`\"dr_current\"\` → \`getattr(econ, \"dr_current\")\` = same float.
- TXTRS all tiers default to \`\"dr_current\"\` → same.

## New unit test

\`test_unknown_tier_discount_rate_key_raises\` — calls \`_resolve_econ_rate\` with a bogus key and asserts the \`ValueError\` mentions the unknown key.

## Validation

- \`make r-match\` — 8/8 truth-table cells pass at relative diff < 1e-10.
- \`make test\` — 329 passed (was 328 + 1 new), 2 skipped (unrelated snapshot updaters).

**2 files, +29 / -1.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)