### PR TITLE
A6 follow-up: replace literal NRA=65 fallbacks with explicit errors

### DIFF
--- a/src/pension_model/config_resolvers_scalar.py
+++ b/src/pension_model/config_resolvers_scalar.py
@@ -161,7 +161,18 @@ def get_reduce_factor(
     if "nra" in reduction:
         nra_map = reduction["nra"]
         rate = reduction["rate_per_year"]
-        nra = nra_map.get(class_name, nra_map.get("default", 65))
+        if class_name in nra_map:
+            nra = nra_map[class_name]
+        elif "default" in nra_map:
+            nra = nra_map["default"]
+        else:
+            raise ValueError(
+                f"Plan {config.plan_name!r}: NRA map for tier "
+                f"{tier_name!r} has no entry for class {class_name!r} "
+                f"and no 'default' fallback. Add either an explicit "
+                f"per-class NRA or a 'default' key to "
+                f"early_retire_reduction.nra."
+            )
         return 1.0 - rate * (nra - dist_age)
 
     if "rules" in reduction:
@@ -172,7 +183,14 @@ def get_reduce_factor(
             formula = rule.get("formula", "linear")
             if formula == "linear":
                 rate = rule["rate_per_year"]
-                nra = rule.get("nra", 65)
+                if "nra" not in rule:
+                    raise ValueError(
+                        f"Plan {config.plan_name!r}: tier {tier_name!r} "
+                        f"has a linear early-retire reduction rule "
+                        f"without an 'nra' field. Every linear rule "
+                        f"must declare its NRA."
+                    )
+                nra = rule["nra"]
                 return max(0.0, 1.0 - rate * (nra - dist_age))
             if formula == "table":
                 table_key = rule.get("table_key", "")

--- a/src/pension_model/config_resolvers_vectorized.py
+++ b/src/pension_model/config_resolvers_vectorized.py
@@ -325,7 +325,19 @@ def resolve_reduce_factor_vec(
         if "nra" in reduction:
             nra_map = reduction["nra"]
             rate = reduction["rate_per_year"]
-            nra = nra_map.get(class_name_value, nra_map.get("default", 65))
+            if class_name_value in nra_map:
+                nra = nra_map[class_name_value]
+            elif "default" in nra_map:
+                nra = nra_map["default"]
+            else:
+                tier_name = config._tier_id_to_name[tier_index]
+                raise ValueError(
+                    f"Plan {config.plan_name!r}: NRA map for tier "
+                    f"{tier_name!r} has no entry for class "
+                    f"{class_name_value!r} and no 'default' fallback. "
+                    f"Add either an explicit per-class NRA or a "
+                    f"'default' key to early_retire_reduction.nra."
+                )
             result[idx_arr] = 1.0 - rate * (nra - sub_age)
             continue
 
@@ -347,7 +359,14 @@ def resolve_reduce_factor_vec(
                 formula = rule.get("formula", "linear")
                 if formula == "linear":
                     rate = rule["rate_per_year"]
-                    nra = rule.get("nra", 65)
+                    if "nra" not in rule:
+                        raise ValueError(
+                            f"Plan {config.plan_name!r}: tier "
+                            f"{tier_name!r} has a linear early-retire "
+                            f"reduction rule without an 'nra' field. "
+                            f"Every linear rule must declare its NRA."
+                        )
+                    nra = rule["nra"]
                     sub_vals[cond_mask] = np.maximum(0.0, 1.0 - rate * (nra - sub_age[cond_mask]))
                     assigned |= cond_mask
                 elif formula == "table":

--- a/tests/test_pension_model/test_stage3_loader.py
+++ b/tests/test_pension_model/test_stage3_loader.py
@@ -368,3 +368,66 @@ def test_unknown_tier_discount_rate_key_raises(frs_config):
     econ = frs_config.economic
     with pytest.raises(ValueError, match="bogus_rate"):
         _resolve_econ_rate(econ, "bogus_rate", frs_config.plan_name)
+
+
+def test_missing_per_class_nra_raises(frs_config):
+    """A per-class NRA map missing the requested class and the
+    'default' fallback raises a clear ValueError. Catches forgetting
+    to declare an NRA for one of the plan's classes.
+    """
+    from dataclasses import replace
+    from pension_model.config_resolvers import get_reduce_factor
+
+    # FRS tier_1 uses a per-class NRA map. Build a tier_defs tuple with
+    # tier_1's 'default' entry stripped — only 'special' is left.
+    new_tier_defs = []
+    for td in frs_config.tier_defs:
+        if td["name"] == "tier_1":
+            td2 = {**td, "early_retire_reduction": {**td["early_retire_reduction"]}}
+            td2["early_retire_reduction"]["nra"] = {"special": 55}  # no 'default'
+            new_tier_defs.append(td2)
+        else:
+            new_tier_defs.append(td)
+    bogus = replace(frs_config, tier_defs=tuple(new_tier_defs))
+
+    # 'regular' isn't in the map and no default — should raise.
+    with pytest.raises(ValueError, match="no 'default'"):
+        get_reduce_factor(
+            bogus, "regular", "tier_1", "early", dist_age=58, yos=10, entry_year=1990
+        )
+
+
+def test_missing_rule_nra_raises(frs_config):
+    """A linear early-retire reduction rule without an 'nra' field
+    raises a clear ValueError. Catches forgetting the NRA on a rule.
+    """
+    from dataclasses import replace
+    from pension_model.config_resolvers import get_reduce_factor
+
+    # Inject a tier with a linear rule that omits 'nra'.
+    bogus_tier = {
+        "name": "tier_bogus",
+        "entry_year_min": 0,
+        "entry_year_max": 9999,
+        "fas_years": 5,
+        "cola_key": "tier_1_active",
+        "retirement_rate_set": "before_2011",
+        "eligibility": {
+            "default": {
+                "normal": [{"min_age": 65}],
+                "early": [{"min_age": 55}],
+                "vesting_yos": 5,
+            }
+        },
+        "early_retire_reduction": {
+            "rules": [
+                {"condition": {}, "formula": "linear", "rate_per_year": 0.05},  # no 'nra'
+            ]
+        },
+    }
+    bogus = replace(frs_config, tier_defs=(bogus_tier,))
+
+    with pytest.raises(ValueError, match="without an 'nra' field"):
+        get_reduce_factor(
+            bogus, "regular", "tier_bogus", "early", dist_age=58, yos=10, entry_year=1990
+        )


### PR DESCRIPTION
Closes #144. Closes the literal-65 NRA fallback residual that A6 (#110) deferred for schema thinking.

## What this changes

Four fallback sites where a missing NRA silently produced 65:

| Site | Pattern |
|---|---|
| \`config_resolvers_scalar.py:164\` | \`nra_map.get(class_name, nra_map.get(\"default\", 65))\` |
| \`config_resolvers_scalar.py:175\` | \`rule.get(\"nra\", 65)\` |
| \`config_resolvers_vectorized.py:328\` | per-class map (vectorized) |
| \`config_resolvers_vectorized.py:350\` | rule-level (vectorized) |

Each is replaced with an explicit \`ValueError\` that names the tier and the missing field. Two patterns:

**Per-class map:**
\`\`\`python
if class_name in nra_map:
    nra = nra_map[class_name]
elif \"default\" in nra_map:
    nra = nra_map[\"default\"]
else:
    raise ValueError(...)  # names tier + class
\`\`\`

**Rule-level:**
\`\`\`python
if \"nra\" not in rule:
    raise ValueError(...)  # names tier
nra = rule[\"nra\"]
\`\`\`

## Why this is bit-identical

Audit: every linear rule in FRS, TXTRS, and TXTRS-AV declares an \`nra\`; every per-class \`nra\` map either lists every class or has a \`default\`. The literal \`65\` fallback never fired for any current plan. After this PR, a misconfigured plan fails loudly instead of silently getting 65.

## New unit tests

- \`test_missing_per_class_nra_raises\` — strip the \`default\` entry from FRS tier_1's NRA map, ask for the \`regular\` class, expect a clear \`ValueError\`.
- \`test_missing_rule_nra_raises\` — inject a linear reduction rule without an \`nra\` field, expect a clear \`ValueError\`.

## Validation

- \`make r-match\` — 8/8 truth-table cells pass at relative diff < 1e-10.
- \`make test\` — 331 passed (was 329 + 2 new), 2 skipped (unrelated snapshot updaters).

**3 files, +104 / -4.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)