### PR TITLE
B5 follow-up: explicit funding.contribution_strategy field

### DIFF
--- a/plans/frs/config/plan_config.json
+++ b/plans/frs/config/plan_config.json
@@ -36,6 +36,7 @@
   "funding": {
     "has_drop": true,
     "drop_reference_class": "regular",
+    "contribution_strategy": "actuarial",
     "policy": "statutory",
     "amo_method": "level_pct",
     "amo_period_new": 20,

--- a/plans/txtrs-av/config/plan_config.json
+++ b/plans/txtrs-av/config/plan_config.json
@@ -34,6 +34,7 @@
   },
 
   "funding": {
+    "contribution_strategy": "statutory",
     "policy": "statutory",
     "amo_method": "level_pct",
     "amo_period_new": 30,

--- a/plans/txtrs/config/plan_config.json
+++ b/plans/txtrs/config/plan_config.json
@@ -51,6 +51,7 @@
   },
 
   "funding": {
+    "contribution_strategy": "statutory",
     "policy": "statutory",
     "amo_method": "level_pct",
     "amo_period_new": 30,

--- a/src/pension_model/config_compat.py
+++ b/src/pension_model/config_compat.py
@@ -50,6 +50,7 @@ def build_benefit_namespace(config) -> SimpleNamespace:
 def build_funding_namespace(config) -> SimpleNamespace:
     return SimpleNamespace(
         funding_policy=config.funding_policy,
+        contribution_strategy=config.contribution_strategy,
         amo_method=config.amo_method,
         amo_period_new=config.amo_period_new,
         amo_pay_growth=config.amo_pay_growth,

--- a/src/pension_model/config_loading.py
+++ b/src/pension_model/config_loading.py
@@ -167,6 +167,7 @@ def load_plan_config(
         cola=ben.get("cola", {}),
         cash_balance=ben.get("cash_balance"),
         funding_policy=fun["policy"],
+        contribution_strategy=fun["contribution_strategy"],
         amo_method=fun["amo_method"],
         amo_period_new=fun["amo_period_new"],
         amo_pay_growth=fun.get("amo_pay_growth", eco["payroll_growth"]),

--- a/src/pension_model/config_schema.py
+++ b/src/pension_model/config_schema.py
@@ -43,6 +43,7 @@ class PlanConfig:
     benefit_types: Tuple[str, ...]
     cola: dict
     funding_policy: str
+    contribution_strategy: str
     amo_method: str
     amo_period_new: int
     amo_pay_growth: float

--- a/src/pension_model/core/_funding_setup.py
+++ b/src/pension_model/core/_funding_setup.py
@@ -104,8 +104,17 @@ def resolve_funding_context(
         or ava_strategy.aggregation_level == "plan"
     )
 
+    cont_strategy_name = fund.contribution_strategy
     stat_rates = constants.statutory_rates
-    if stat_rates:
+    if cont_strategy_name == "statutory":
+        if not stat_rates:
+            raise ValueError(
+                f"Plan {constants.plan_name!r}: "
+                f"funding.contribution_strategy is 'statutory' but "
+                f"funding.statutory_rates is missing. The statutory "
+                f"strategy requires a statutory_rates block declaring "
+                f"ee_rate_schedule and er_rate_components."
+            )
         ee_schedule = stat_rates.get(
             "ee_rate_schedule",
             [{"from_year": 0, "rate": constants.benefit.db_ee_cont_rate}],
@@ -115,9 +124,15 @@ def resolve_funding_context(
             ee_schedule=ee_schedule,
             components=resolve_er_rate_components(stat_rates),
         )
-    else:
+    elif cont_strategy_name == "actuarial":
         cont_strategy = ActuarialContributions(
             db_ee_cont_rate=constants.benefit.db_ee_cont_rate,
+        )
+    else:
+        raise ValueError(
+            f"Plan {constants.plan_name!r}: "
+            f"funding.contribution_strategy = {cont_strategy_name!r} "
+            f"is not supported. Pick one of: 'actuarial', 'statutory'."
         )
 
     return FundingContext(

--- a/tests/test_pension_model/test_stage3_loader.py
+++ b/tests/test_pension_model/test_stage3_loader.py
@@ -397,6 +397,39 @@ def test_missing_per_class_nra_raises(frs_config):
         )
 
 
+def test_unknown_contribution_strategy_raises(frs_config):
+    """A plan declaring funding.contribution_strategy = 'made_up' raises
+    a clear ValueError from resolve_funding_context.
+    """
+    from dataclasses import replace
+    from pension_model.core._funding_setup import resolve_funding_context
+
+    bogus = replace(frs_config, contribution_strategy="made_up_strategy")
+    funding_inputs = {
+        "init_funding": __import__("pandas").DataFrame({"class": ["regular"]}),
+    }
+
+    with pytest.raises(ValueError, match="made_up_strategy"):
+        resolve_funding_context(bogus, funding_inputs)
+
+
+def test_statutory_strategy_requires_rates_block(frs_config):
+    """Declaring funding.contribution_strategy = 'statutory' without a
+    funding.statutory_rates block raises a clear ValueError.
+    """
+    from dataclasses import replace
+    from pension_model.core._funding_setup import resolve_funding_context
+
+    bogus = replace(frs_config, contribution_strategy="statutory")
+    # FRS doesn't have statutory_rates; bogus inherits that absence.
+    funding_inputs = {
+        "init_funding": __import__("pandas").DataFrame({"class": ["regular"]}),
+    }
+
+    with pytest.raises(ValueError, match="statutory_rates"):
+        resolve_funding_context(bogus, funding_inputs)
+
+
 def test_missing_rule_nra_raises(frs_config):
     """A linear early-retire reduction rule without an 'nra' field
     raises a clear ValueError. Catches forgetting the NRA on a rule.


### PR DESCRIPTION
Closes #146. Closes the contribution-strategy dispatch residual that B5 (#119) called out: today's choice between \`StatutoryContributions\` and \`ActuarialContributions\` is dispatched on *presence* of the \`funding.statutory_rates\` block rather than via an explicit field.

## What this changes

**Schema.** Adds required \`funding.contribution_strategy\` field. Values: \`\"statutory\"\` or \`\"actuarial\"\`.

| Plan | New value | Matches today's behavior because... |
|---|---|---|
| FRS | \`\"actuarial\"\` | no \`statutory_rates\` block → \`ActuarialContributions\` |
| TXTRS | \`\"statutory\"\` | has \`statutory_rates\` block → \`StatutoryContributions\` |
| TXTRS-AV | \`\"statutory\"\` | same as TXTRS |

**PlanConfig.** New \`contribution_strategy: str\` dataclass field. Populated in \`config_loading\` from \`fun[\"contribution_strategy\"]\`; missing field raises \`KeyError\` at load. \`build_funding_namespace\` exposes it via the funding namespace.

**Loader (\`resolve_funding_context\`).** Explicit field read replaces presence-of-block dispatch. Two new error paths:
- \`\"statutory\"\` declared but \`statutory_rates\` block missing → \`ValueError\`.
- Unknown strategy value → \`ValueError\` listing supported set.

## Bit-identity

- FRS: presence-based dispatch picked actuarial; explicit field picks actuarial. Same instance.
- TXTRS / TXTRS-AV: presence-based dispatch picked statutory; explicit field picks statutory. Same instance.

## New unit tests

- \`test_unknown_contribution_strategy_raises\` — declaring \`\"made_up_strategy\"\` raises \`ValueError\` with the unknown name in the message.
- \`test_statutory_strategy_requires_rates_block\` — declaring \`\"statutory\"\` without the \`statutory_rates\` block raises \`ValueError\` referencing \`statutory_rates\`.

## Validation

- \`make r-match\` — 8/8 truth-table cells pass at relative diff < 1e-10.
- \`make test\` — 333 passed (was 331 + 2 new), 2 skipped (unrelated snapshot updaters).

**8 files, +56 / -2.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)