### PR TITLE
Pydantic schema migration — PR 2: Funding model

### DIFF
--- a/src/pension_model/cli.py
+++ b/src/pension_model/cli.py
@@ -41,19 +41,16 @@ def _fmt_pct(val):
 
 
 def _fmt_smoothing(cfg):
-    """Describe asset smoothing from config dict."""
+    """Describe asset smoothing from typed config."""
     sm = cfg.ava_smoothing
-    method = sm.get("method", "unknown")
-    if method == "corridor":
-        lo = sm.get("corridor_low", 0.8)
-        hi = sm.get("corridor_high", 1.2)
-        recog = sm.get("recognition_fraction", 0.2)
-        return f"corridor ({lo:.0%}-{hi:.0%} of MVA), {recog:.0%}/yr recognition"
-    elif method == "gain_loss":
-        period = sm.get("recognition_period", 4)
-        return f"{period}-year gain-loss recognition"
-    else:
-        return method
+    if sm.method == "corridor":
+        return (
+            f"corridor ({sm.corridor_low:.0%}-{sm.corridor_high:.0%} "
+            f"of MVA), {sm.recognition_fraction:.0%}/yr recognition"
+        )
+    if sm.method == "gain_loss":
+        return f"{sm.recognition_period}-year gain-loss recognition"
+    return sm.method
 
 
 # ---------------------------------------------------------------------------
@@ -172,7 +169,7 @@ def print_parameters(constants):
     print(f"    Investment return:      {ec.model_return:.1%}")
     print(f"    Payroll growth:         {ec.payroll_growth:.2%}")
     print(f"    COLA (retirees):        {bn.cola_current_retire:.0%}")
-    print(f"    Funding policy:         {fn.funding_policy}")
+    print(f"    Funding policy:         {fn.policy}")
     print(f"    Amortization:           {fn.amo_method}, {fn.amo_period_new}-year period")
     print(f"    Asset smoothing:        {_fmt_smoothing(fn)}")
     print(f"    Projection horizon:     {rn.model_period} years from {rn.start_year} valuation (through {rn.start_year + rn.model_period})")

--- a/src/pension_model/config_compat.py
+++ b/src/pension_model/config_compat.py
@@ -21,20 +21,6 @@ def build_benefit_namespace(config) -> SimpleNamespace:
     )
 
 
-def build_funding_namespace(config) -> SimpleNamespace:
-    return SimpleNamespace(
-        funding_policy=config.funding_policy,
-        contribution_strategy=config.contribution_strategy,
-        amo_method=config.amo_method,
-        amo_period_new=config.amo_period_new,
-        amo_pay_growth=config.amo_pay_growth,
-        funding_lag=config.funding_lag,
-        amo_period_term=config.amo_period_term,
-        amo_term_growth=config.amo_term_growth,
-        ava_smoothing=config.ava_smoothing,
-    )
-
-
 def build_class_data_namespace(config) -> dict:
     result = {}
     for class_name, valuation in config.valuation_inputs.items():

--- a/src/pension_model/config_loading.py
+++ b/src/pension_model/config_loading.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Dict, Optional
 
 from pension_model.config_schema import PlanConfig
-from pension_model.schemas import Decrements, Economic, Modeling, Ranges
+from pension_model.schemas import Decrements, Economic, Funding, Modeling, Ranges
 
 
 log = logging.getLogger(__name__)
@@ -112,6 +112,19 @@ def _build_economic_model(
     })
 
 
+def _build_funding_model(fun_raw: dict, eco_raw: dict) -> Funding:
+    """Validate and build the Funding schema model.
+
+    Pre-fills ``amo_pay_growth`` from ``economic.payroll_growth`` if
+    the funding block omits it — preserves the pre-pydantic loader's
+    defensive default. All other required fields must be declared
+    explicitly (the schema enforces).
+    """
+    fun_with_defaults = dict(fun_raw)
+    fun_with_defaults.setdefault("amo_pay_growth", eco_raw["payroll_growth"])
+    return Funding.model_validate(fun_with_defaults)
+
+
 def _build_decrements_model(raw: dict, *, plan_name: str) -> Decrements:
     """Validate and build the Decrements schema model.
 
@@ -190,6 +203,7 @@ def load_plan_config(
     ranges_model = Ranges.model_validate(rng)
     decrements_model = _build_decrements_model(raw, plan_name=raw["plan_name"])
     modeling_model = Modeling.model_validate(raw.get("modeling", {}))
+    funding_model = _build_funding_model(fun, eco)
 
     config = PlanConfig(
         plan_name=raw["plan_name"],
@@ -203,15 +217,6 @@ def load_plan_config(
         benefit_types=tuple(ben.get("benefit_types", ["db"])),
         cola=ben.get("cola", {}),
         cash_balance=ben.get("cash_balance"),
-        funding_policy=fun["policy"],
-        contribution_strategy=fun["contribution_strategy"],
-        amo_method=fun["amo_method"],
-        amo_period_new=fun["amo_period_new"],
-        amo_pay_growth=fun.get("amo_pay_growth", eco["payroll_growth"]),
-        funding_lag=fun.get("funding_lag", 1),
-        amo_period_term=fun.get("amo_period_term", 50),
-        amo_term_growth=fun.get("amo_term_growth", 0.03),
-        ava_smoothing=fun.get("ava_smoothing", {}),
         classes=tuple(raw["classes"]),
         class_groups=raw.get("class_groups", {}),
         tier_defs=tuple(raw.get("tiers", [])),
@@ -222,6 +227,7 @@ def load_plan_config(
         ranges=ranges_model,
         decrements=decrements_model,
         modeling=modeling_model,
+        funding=funding_model,
         calibration=calibration,
         _class_to_group=class_to_group,
         _tier_name_to_id=tier_name_to_id,

--- a/src/pension_model/config_schema.py
+++ b/src/pension_model/config_schema.py
@@ -8,10 +8,9 @@ from typing import Dict, List, Optional, Tuple
 from pension_model.config_compat import (
     build_benefit_namespace,
     build_class_data_namespace,
-    build_funding_namespace,
 )
 from pension_model.config_validation import validate_config, validate_data_files
-from pension_model.schemas import Decrements, Economic, Modeling, Ranges
+from pension_model.schemas import Decrements, Economic, Funding, Modeling, Ranges
 
 
 NON_VESTED = 0
@@ -32,15 +31,6 @@ class PlanConfig:
     fas_years_default: int
     benefit_types: Tuple[str, ...]
     cola: dict
-    funding_policy: str
-    contribution_strategy: str
-    amo_method: str
-    amo_period_new: int
-    amo_pay_growth: float
-    funding_lag: int
-    amo_period_term: int
-    amo_term_growth: float
-    ava_smoothing: dict
     classes: Tuple[str, ...]
     class_groups: Dict[str, List[str]]
     tier_defs: Tuple[dict, ...]
@@ -51,6 +41,7 @@ class PlanConfig:
     ranges: Ranges
     decrements: Decrements
     modeling: Modeling
+    funding: Funding
     calibration: Dict[str, dict] = field(default_factory=dict)
     cash_balance: Optional[dict] = None
     reduce_tables: Optional[Dict[str, object]] = None
@@ -188,19 +179,59 @@ class PlanConfig:
 
     @property
     def has_drop(self) -> bool:
-        return self.raw.get("funding", {}).get("has_drop", False)
+        return self.funding.has_drop
 
     @property
     def drop_reference_class(self) -> Optional[str]:
-        return self.raw.get("funding", {}).get("drop_reference_class")
+        return self.funding.drop_reference_class
 
     @property
-    def statutory_rates(self) -> Optional[dict]:
-        return self.raw.get("funding", {}).get("statutory_rates")
+    def statutory_rates(self):
+        """Typed StatutoryRates model, or None if not declared."""
+        return self.funding.statutory_rates
 
     @property
     def amo_period_current(self) -> Optional[int]:
-        return self.raw.get("funding", {}).get("amo_period_current")
+        return self.funding.amo_period_current
+
+    @property
+    def funding_policy(self) -> str:
+        return self.funding.policy
+
+    @property
+    def contribution_strategy(self) -> str:
+        return self.funding.contribution_strategy
+
+    @property
+    def amo_method(self) -> str:
+        return self.funding.amo_method
+
+    @property
+    def amo_period_new(self) -> int:
+        return self.funding.amo_period_new
+
+    @property
+    def amo_pay_growth(self) -> float:
+        return self.funding.amo_pay_growth
+
+    @property
+    def funding_lag(self) -> int:
+        return self.funding.funding_lag
+
+    @property
+    def amo_period_term(self) -> int:
+        return self.funding.amo_period_term
+
+    @property
+    def amo_term_growth(self) -> float:
+        return self.funding.amo_term_growth
+
+    @property
+    def ava_smoothing(self):
+        """Typed AVA smoothing spec (CorridorAvaSmoothing or
+        GainLossAvaSmoothing).
+        """
+        return self.funding.ava_smoothing
 
     @property
     def funding_legs(self) -> Tuple[Tuple[str, Optional[int], Optional[int]], ...]:
@@ -209,26 +240,17 @@ class PlanConfig:
         ``lo`` is inclusive, ``hi`` is exclusive — same convention as
         the tier resolver (``entry_year_min`` / ``entry_year_max``).
         ``entry_year_min_param`` / ``entry_year_max_param`` strings of
-        ``\"new_year\"`` resolve to ``self.new_year``.
-
-        Defaults to today's two-leg ``legacy`` / ``new`` split keyed off
-        ``new_year`` if the plan_config doesn't declare ``funding.legs``.
+        ``"new_year"`` resolve to ``self.new_year``.
         """
-        legs_raw = self.raw.get("funding", {}).get("legs")
-        if not legs_raw:
-            legs_raw = [
-                {"name": "legacy", "entry_year_max_param": "new_year"},
-                {"name": "new", "entry_year_min_param": "new_year"},
-            ]
         resolved = []
-        for leg in legs_raw:
-            lo = leg.get("entry_year_min")
-            if leg.get("entry_year_min_param") == "new_year":
+        for leg in self.funding.legs:
+            lo = leg.entry_year_min
+            if leg.entry_year_min_param == "new_year":
                 lo = self.new_year
-            hi = leg.get("entry_year_max")
-            if leg.get("entry_year_max_param") == "new_year":
+            hi = leg.entry_year_max
+            if leg.entry_year_max_param == "new_year":
                 hi = self.new_year
-            resolved.append((leg["name"], lo, hi))
+            resolved.append((leg.name, lo, hi))
         return tuple(resolved)
 
     @property
@@ -262,10 +284,6 @@ class PlanConfig:
     @property
     def benefit(self) -> SimpleNamespace:
         return build_benefit_namespace(self)
-
-    @property
-    def funding(self) -> SimpleNamespace:
-        return build_funding_namespace(self)
 
     @property
     def class_data(self) -> dict:

--- a/src/pension_model/core/_funding_setup.py
+++ b/src/pension_model/core/_funding_setup.py
@@ -76,21 +76,18 @@ def resolve_funding_context(
     has_cb = "cb" in constants.benefit_types
     has_dc = "payroll_dc_legacy" in funding_inputs["init_funding"].columns
 
-    smoothing_cfg = fund.ava_smoothing or {}
-    method = smoothing_cfg.get("method")
-    if method == "corridor":
+    # ``fund.ava_smoothing`` is now a typed discriminated union;
+    # method validity was checked at config-load time. Dispatch on
+    # the concrete type.
+    smoothing_cfg = fund.ava_smoothing
+    if smoothing_cfg.method == "corridor":
         ava_strategy = CorridorSmoothing(
-            recognition_fraction=smoothing_cfg.get("recognition_fraction", 0.2),
-            corridor_low=smoothing_cfg.get("corridor_low", 0.8),
-            corridor_high=smoothing_cfg.get("corridor_high", 1.2),
+            recognition_fraction=smoothing_cfg.recognition_fraction,
+            corridor_low=smoothing_cfg.corridor_low,
+            corridor_high=smoothing_cfg.corridor_high,
         )
-    elif method == "gain_loss":
+    else:  # method == "gain_loss" — schema enforces no other values
         ava_strategy = GainLossSmoothing()
-    else:
-        raise ValueError(
-            f"Unknown funding.ava_smoothing.method: {method!r}. "
-            f"Supported: 'corridor', 'gain_loss'."
-        )
 
     # The plan-aggregate frame is built up inside the year-loop when
     # either (a) there's more than one class and we want a plan-level
@@ -104,35 +101,24 @@ def resolve_funding_context(
         or ava_strategy.aggregation_level == "plan"
     )
 
-    cont_strategy_name = fund.contribution_strategy
-    stat_rates = constants.statutory_rates
-    if cont_strategy_name == "statutory":
-        if not stat_rates:
-            raise ValueError(
-                f"Plan {constants.plan_name!r}: "
-                f"funding.contribution_strategy is 'statutory' but "
-                f"funding.statutory_rates is missing. The statutory "
-                f"strategy requires a statutory_rates block declaring "
-                f"ee_rate_schedule and er_rate_components."
-            )
-        ee_schedule = stat_rates.get(
-            "ee_rate_schedule",
-            [{"from_year": 0, "rate": constants.benefit.db_ee_cont_rate}],
-        )
+    # ``fund.contribution_strategy`` validity is enforced by the
+    # Funding schema (Literal["statutory", "actuarial"]); the
+    # required-when-statutory check on ``statutory_rates`` is also
+    # schema-level, so by here the typed model is consistent.
+    if fund.contribution_strategy == "statutory":
+        stat_rates = fund.statutory_rates
+        ee_schedule = [
+            {"from_year": e.from_year, "rate": e.rate}
+            for e in stat_rates.ee_rate_schedule
+        ]
         cont_strategy = StatutoryContributions(
-            funding_policy=fund.funding_policy,
+            funding_policy=fund.policy,
             ee_schedule=ee_schedule,
             components=resolve_er_rate_components(stat_rates),
         )
-    elif cont_strategy_name == "actuarial":
+    else:  # "actuarial" — schema enforces no other values
         cont_strategy = ActuarialContributions(
             db_ee_cont_rate=constants.benefit.db_ee_cont_rate,
-        )
-    else:
-        raise ValueError(
-            f"Plan {constants.plan_name!r}: "
-            f"funding.contribution_strategy = {cont_strategy_name!r} "
-            f"is not supported. Pick one of: 'actuarial', 'statutory'."
         )
 
     return FundingContext(
@@ -157,7 +143,7 @@ def resolve_funding_context(
         builds_aggregate_in_loop=builds_aggregate_in_loop,
         has_cb=has_cb,
         has_dc=has_dc,
-        funding_policy=fund.funding_policy,
+        funding_policy=fund.policy,
         init_funding=funding_inputs["init_funding"],
         amort_layers=funding_inputs.get("amort_layers"),
         ret_scen=_build_return_stream_for_funding(constants, ava_strategy),
@@ -187,16 +173,18 @@ def _build_return_stream_for_funding(
     return stream
 
 
-def resolve_er_rate_components(stat_rates: dict) -> list:
-    """Build statutory employer-rate components from config."""
-    components = stat_rates.get("er_rate_components")
-    if components is None:
-        raise ValueError(
-            "funding.statutory_rates.er_rate_components is required when "
-            "using the statutory contribution strategy. See an existing "
-            "plan's plan_config.json for an example schema."
-        )
-    return [RateComponent.from_config(c) for c in components]
+def resolve_er_rate_components(stat_rates) -> list:
+    """Build statutory employer-rate components from the typed
+    StatutoryRates spec.
+
+    Each schema-side ``RateComponentSpec`` is converted to the
+    strategy-side ``RateComponent`` via ``model_dump()`` — the field
+    shapes match by design.
+    """
+    return [
+        RateComponent.from_config(c.model_dump())
+        for c in stat_rates.er_rate_components
+    ]
 
 
 def setup_funding_frames(ctx: FundingContext) -> dict:

--- a/src/pension_model/schemas/__init__.py
+++ b/src/pension_model/schemas/__init__.py
@@ -20,15 +20,35 @@ yet. See ``scratch/pydantic_migration_plan.md`` for the order.
 from pension_model.schemas.base import StrictModel
 from pension_model.schemas.decrements import Decrements
 from pension_model.schemas.economic import Economic
+from pension_model.schemas.funding import (
+    AvaSmoothing,
+    CorridorAvaSmoothing,
+    Funding,
+    GainLossAvaSmoothing,
+    LegDef,
+    RampSpec,
+    RateComponentSpec,
+    RateScheduleEntry,
+    StatutoryRates,
+)
 from pension_model.schemas.modeling import AgeGroup, Modeling
 from pension_model.schemas.ranges import Ranges
 
 
 __all__ = [
     "AgeGroup",
+    "AvaSmoothing",
+    "CorridorAvaSmoothing",
     "Decrements",
     "Economic",
+    "Funding",
+    "GainLossAvaSmoothing",
+    "LegDef",
     "Modeling",
+    "RampSpec",
     "Ranges",
+    "RateComponentSpec",
+    "RateScheduleEntry",
+    "StatutoryRates",
     "StrictModel",
 ]

--- a/src/pension_model/schemas/funding.py
+++ b/src/pension_model/schemas/funding.py
@@ -1,0 +1,179 @@
+"""Schema for the ``funding`` block of plan_config.json."""
+
+from __future__ import annotations
+
+from typing import Annotated, Literal, Optional, Union
+
+from pydantic import Field, model_validator
+
+from pension_model.schemas.base import StrictModel
+
+
+# ---------------------------------------------------------------------------
+# AVA smoothing — method-discriminated union
+# ---------------------------------------------------------------------------
+
+
+class CorridorAvaSmoothing(StrictModel):
+    """Corridor smoothing parameters.
+
+    Each year, smooths AVA toward MVA by ``recognition_fraction`` of
+    the gap, bounded to ``[corridor_low * mva, corridor_high * mva]``.
+    """
+
+    method: Literal["corridor"]
+    corridor_low: float = 0.8
+    corridor_high: float = 1.2
+    recognition_fraction: float = 0.2
+
+
+class GainLossAvaSmoothing(StrictModel):
+    """Gain/loss deferral cascade parameters.
+
+    Each year's asset gain/loss is deferred and recognized over
+    ``recognition_period`` years.
+    """
+
+    method: Literal["gain_loss"]
+    recognition_period: int
+
+
+# Discriminated union by ``method``. Pydantic dispatches to the right
+# concrete model based on the method tag.
+AvaSmoothing = Annotated[
+    Union[CorridorAvaSmoothing, GainLossAvaSmoothing],
+    Field(discriminator="method"),
+]
+
+
+# ---------------------------------------------------------------------------
+# Statutory rate components
+# ---------------------------------------------------------------------------
+
+
+class RateScheduleEntry(StrictModel):
+    """One step in a year-keyed step-function rate schedule."""
+
+    from_year: int
+    rate: float
+
+
+class RampSpec(StrictModel):
+    """Linear ramp parameters for an employer-rate component."""
+
+    rate_per_year: float
+    end_year: int
+
+
+class RateComponentSpec(StrictModel):
+    """One term in the statutory employer-rate cascade.
+
+    Each component contributes ``rate(year) * payroll_share`` to the
+    effective employer rate. Rate is specified as either a step
+    schedule or a linear ramp — exactly one must be present.
+    """
+
+    name: str
+    payroll_share: float = 1.0
+    schedule: Optional[list[RateScheduleEntry]] = None
+    initial_rate: Optional[float] = None
+    ramp: Optional[RampSpec] = None
+    start_year: Optional[int] = None
+
+    @model_validator(mode="after")
+    def _check_rate_form(self) -> "RateComponentSpec":
+        has_schedule = self.schedule is not None
+        has_ramp = self.ramp is not None
+        if not has_schedule and not has_ramp:
+            raise ValueError(
+                f"RateComponentSpec {self.name!r}: must specify either "
+                f"'schedule' (step function) or 'ramp' (with "
+                f"'initial_rate'). Neither was provided."
+            )
+        if has_schedule and has_ramp:
+            raise ValueError(
+                f"RateComponentSpec {self.name!r}: 'schedule' and 'ramp' "
+                f"are mutually exclusive. Pick one."
+            )
+        return self
+
+
+class StatutoryRates(StrictModel):
+    """Statutory contribution-rate definitions.
+
+    Required when ``Funding.contribution_strategy == \"statutory\"``.
+    """
+
+    ee_rate_schedule: list[RateScheduleEntry]
+    er_rate_components: list[RateComponentSpec]
+
+
+# ---------------------------------------------------------------------------
+# Funding legs
+# ---------------------------------------------------------------------------
+
+
+class LegDef(StrictModel):
+    """One funding leg.
+
+    Either or both of ``entry_year_min`` and ``entry_year_max`` may be
+    omitted to mean open-ended. ``*_param`` strings of ``"new_year"``
+    resolve to ``Ranges.new_year`` at access time (today the only
+    supported parametric reference).
+    """
+
+    name: str
+    entry_year_min: Optional[int] = None
+    entry_year_max: Optional[int] = None
+    entry_year_min_param: Optional[Literal["new_year"]] = None
+    entry_year_max_param: Optional[Literal["new_year"]] = None
+
+
+def _default_legs() -> list[LegDef]:
+    """Default 2-leg layout (legacy/new) keyed off ``new_year``.
+
+    Used when ``Funding.legs`` is omitted, preserving today's
+    pre-explicit-legs behavior.
+    """
+    return [
+        LegDef(name="legacy", entry_year_max_param="new_year"),
+        LegDef(name="new", entry_year_min_param="new_year"),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Top-level Funding model
+# ---------------------------------------------------------------------------
+
+
+class Funding(StrictModel):
+    """Funding-model parameters."""
+
+    contribution_strategy: Literal["statutory", "actuarial"]
+    policy: str = Field(description="Funding policy. Today: 'statutory' or 'adc'.")
+    amo_method: str
+    amo_period_new: int
+    amo_pay_growth: float
+    funding_lag: int = 1
+
+    amo_period_current: Optional[int] = None
+    amo_period_term: int = 50
+    amo_term_growth: float = 0.03
+
+    has_drop: bool = False
+    drop_reference_class: Optional[str] = None
+
+    ava_smoothing: AvaSmoothing
+    statutory_rates: Optional[StatutoryRates] = None
+    legs: list[LegDef] = Field(default_factory=_default_legs)
+
+    @model_validator(mode="after")
+    def _check_statutory_rates_present(self) -> "Funding":
+        if self.contribution_strategy == "statutory" and self.statutory_rates is None:
+            raise ValueError(
+                "funding.contribution_strategy is 'statutory' but "
+                "funding.statutory_rates is missing. The statutory "
+                "strategy requires a statutory_rates block declaring "
+                "ee_rate_schedule and er_rate_components."
+            )
+        return self

--- a/tests/test_pension_model/test_schemas.py
+++ b/tests/test_pension_model/test_schemas.py
@@ -13,10 +13,19 @@ from pydantic import ValidationError
 
 from pension_model.schemas import (
     AgeGroup,
+    AvaSmoothing,
+    CorridorAvaSmoothing,
     Decrements,
     Economic,
+    Funding,
+    GainLossAvaSmoothing,
+    LegDef,
     Modeling,
+    RampSpec,
     Ranges,
+    RateComponentSpec,
+    RateScheduleEntry,
+    StatutoryRates,
 )
 
 
@@ -176,3 +185,156 @@ class TestModeling:
     def test_extra_top_level_field_raises(self):
         with pytest.raises(ValidationError, match="bogus"):
             Modeling.model_validate({"bogus": True})
+
+
+# ---------------------------------------------------------------------------
+# AvaSmoothing (discriminated union)
+# ---------------------------------------------------------------------------
+
+
+class TestAvaSmoothing:
+    def test_corridor_method_dispatches_to_corridor_model(self):
+        sm = CorridorAvaSmoothing.model_validate({"method": "corridor"})
+        assert sm.corridor_low == 0.8
+        assert sm.corridor_high == 1.2
+        assert sm.recognition_fraction == 0.2
+
+    def test_corridor_with_explicit_values(self):
+        sm = CorridorAvaSmoothing.model_validate({
+            "method": "corridor",
+            "corridor_low": 0.7,
+            "corridor_high": 1.3,
+            "recognition_fraction": 0.25,
+        })
+        assert sm.corridor_low == 0.7
+        assert sm.recognition_fraction == 0.25
+
+    def test_gain_loss_method(self):
+        sm = GainLossAvaSmoothing.model_validate({
+            "method": "gain_loss",
+            "recognition_period": 4,
+        })
+        assert sm.recognition_period == 4
+
+    def test_gain_loss_missing_recognition_period_raises(self):
+        with pytest.raises(ValidationError, match="recognition_period"):
+            GainLossAvaSmoothing.model_validate({"method": "gain_loss"})
+
+
+# ---------------------------------------------------------------------------
+# RateComponentSpec (mutual-exclusion validator)
+# ---------------------------------------------------------------------------
+
+
+class TestRateComponentSpec:
+    def test_schedule_form_loads(self):
+        c = RateComponentSpec.model_validate({
+            "name": "base",
+            "payroll_share": 1.0,
+            "schedule": [{"from_year": 0, "rate": 0.08}],
+        })
+        assert c.schedule is not None
+        assert c.ramp is None
+
+    def test_ramp_form_loads(self):
+        c = RateComponentSpec.model_validate({
+            "name": "surcharge",
+            "payroll_share": 0.5,
+            "initial_rate": 0.0,
+            "ramp": {"rate_per_year": 0.001, "end_year": 2030},
+        })
+        assert c.ramp is not None
+        assert c.schedule is None
+
+    def test_neither_schedule_nor_ramp_raises(self):
+        with pytest.raises(ValidationError, match="must specify either"):
+            RateComponentSpec.model_validate({
+                "name": "no_rate",
+            })
+
+    def test_both_schedule_and_ramp_raises(self):
+        with pytest.raises(ValidationError, match="mutually exclusive"):
+            RateComponentSpec.model_validate({
+                "name": "both",
+                "schedule": [{"from_year": 0, "rate": 0.08}],
+                "ramp": {"rate_per_year": 0.001, "end_year": 2030},
+            })
+
+
+# ---------------------------------------------------------------------------
+# Funding (top-level + cross-field validator)
+# ---------------------------------------------------------------------------
+
+
+class TestFunding:
+    def _valid_actuarial(self, **overrides):
+        base = {
+            "contribution_strategy": "actuarial",
+            "policy": "statutory",
+            "amo_method": "level_pct",
+            "amo_period_new": 20,
+            "amo_pay_growth": 0.0325,
+            "ava_smoothing": {"method": "corridor"},
+        }
+        base.update(overrides)
+        return base
+
+    def _valid_statutory(self, **overrides):
+        base = self._valid_actuarial()
+        base.update({
+            "contribution_strategy": "statutory",
+            "ava_smoothing": {"method": "gain_loss", "recognition_period": 4},
+            "statutory_rates": {
+                "ee_rate_schedule": [{"from_year": 0, "rate": 0.08}],
+                "er_rate_components": [
+                    {
+                        "name": "base",
+                        "schedule": [{"from_year": 0, "rate": 0.08}],
+                    },
+                ],
+            },
+        })
+        base.update(overrides)
+        return base
+
+    def test_actuarial_loads(self):
+        f = Funding.model_validate(self._valid_actuarial())
+        assert f.contribution_strategy == "actuarial"
+        assert isinstance(f.ava_smoothing, CorridorAvaSmoothing)
+
+    def test_statutory_loads(self):
+        f = Funding.model_validate(self._valid_statutory())
+        assert f.contribution_strategy == "statutory"
+        assert isinstance(f.ava_smoothing, GainLossAvaSmoothing)
+        assert f.statutory_rates is not None
+
+    def test_statutory_without_rates_block_raises(self):
+        bad = self._valid_actuarial()
+        bad["contribution_strategy"] = "statutory"
+        with pytest.raises(ValidationError, match="statutory_rates is missing"):
+            Funding.model_validate(bad)
+
+    def test_unknown_contribution_strategy_raises(self):
+        bad = self._valid_actuarial()
+        bad["contribution_strategy"] = "made_up"
+        with pytest.raises(ValidationError, match="made_up"):
+            Funding.model_validate(bad)
+
+    def test_default_legs(self):
+        f = Funding.model_validate(self._valid_actuarial())
+        assert len(f.legs) == 2
+        assert f.legs[0].name == "legacy"
+        assert f.legs[0].entry_year_max_param == "new_year"
+        assert f.legs[1].name == "new"
+        assert f.legs[1].entry_year_min_param == "new_year"
+
+    def test_explicit_legs_override_default(self):
+        f = Funding.model_validate(self._valid_actuarial(legs=[
+            {"name": "before_2011", "entry_year_max": 2011},
+            {"name": "from_2011", "entry_year_min": 2011},
+        ]))
+        assert [leg.name for leg in f.legs] == ["before_2011", "from_2011"]
+
+    def test_extra_field_raises(self):
+        with pytest.raises(ValidationError, match="bogus_field"):
+            Funding.model_validate(self._valid_actuarial(bogus_field=1))

--- a/tests/test_pension_model/test_stage3_loader.py
+++ b/tests/test_pension_model/test_stage3_loader.py
@@ -316,15 +316,15 @@ def test_overlapping_funding_legs_raises(frs_config):
     """
     from dataclasses import replace
     from pension_model.config_validation import validate_funding_legs
+    from pension_model.schemas import LegDef
 
-    # Override raw so funding_legs resolves to two overlapping legs.
-    raw = dict(frs_config.raw)
-    raw["funding"] = dict(raw["funding"])
-    raw["funding"]["legs"] = [
-        {"name": "legacy", "entry_year_max": 2030},
-        {"name": "new", "entry_year_min": 2020},  # overlap on 2020-2029
-    ]
-    bogus = replace(frs_config, raw=raw)
+    new_funding = frs_config.funding.model_copy(update={
+        "legs": [
+            LegDef(name="legacy", entry_year_max=2030),
+            LegDef(name="new", entry_year_min=2020),  # overlap 2020-2029
+        ],
+    })
+    bogus = replace(frs_config, funding=new_funding)
 
     with pytest.raises(ValueError, match="overlap"):
         validate_funding_legs(bogus)
@@ -336,14 +336,15 @@ def test_gappy_funding_legs_raises(frs_config):
     """
     from dataclasses import replace
     from pension_model.config_validation import validate_funding_legs
+    from pension_model.schemas import LegDef
 
-    raw = dict(frs_config.raw)
-    raw["funding"] = dict(raw["funding"])
-    raw["funding"]["legs"] = [
-        {"name": "legacy", "entry_year_max": 2010},
-        {"name": "new", "entry_year_min": 2020},  # gap 2010..2019
-    ]
-    bogus = replace(frs_config, raw=raw)
+    new_funding = frs_config.funding.model_copy(update={
+        "legs": [
+            LegDef(name="legacy", entry_year_max=2010),
+            LegDef(name="new", entry_year_min=2020),  # gap 2010-2019
+        ],
+    })
+    bogus = replace(frs_config, funding=new_funding)
 
     with pytest.raises(ValueError, match="not covered"):
         validate_funding_legs(bogus)
@@ -392,33 +393,35 @@ def test_unknown_contribution_strategy_raises(frs_config):
     """A plan declaring funding.contribution_strategy = 'made_up' raises
     a clear ValueError from resolve_funding_context.
     """
-    from dataclasses import replace
-    from pension_model.core._funding_setup import resolve_funding_context
+    from pydantic import ValidationError
+    from pension_model.schemas import Funding
 
-    bogus = replace(frs_config, contribution_strategy="made_up_strategy")
-    funding_inputs = {
-        "init_funding": __import__("pandas").DataFrame({"class": ["regular"]}),
-    }
+    # Build a Funding payload with an unsupported contribution_strategy.
+    # Validation fires at schema-parse time via Literal type.
+    bad_payload = dict(frs_config.funding.model_dump())
+    bad_payload["contribution_strategy"] = "made_up_strategy"
 
-    with pytest.raises(ValueError, match="made_up_strategy"):
-        resolve_funding_context(bogus, funding_inputs)
+    with pytest.raises(ValidationError, match="made_up_strategy"):
+        Funding.model_validate(bad_payload)
 
 
 def test_statutory_strategy_requires_rates_block(frs_config):
     """Declaring funding.contribution_strategy = 'statutory' without a
-    funding.statutory_rates block raises a clear ValueError.
+    funding.statutory_rates block raises at schema-parse time via the
+    Funding model_validator.
     """
-    from dataclasses import replace
-    from pension_model.core._funding_setup import resolve_funding_context
+    from pydantic import ValidationError
+    from pension_model.schemas import Funding
 
-    bogus = replace(frs_config, contribution_strategy="statutory")
-    # FRS doesn't have statutory_rates; bogus inherits that absence.
-    funding_inputs = {
-        "init_funding": __import__("pandas").DataFrame({"class": ["regular"]}),
-    }
+    # FRS today is "actuarial" with no statutory_rates. Build a payload
+    # that flips contribution_strategy to "statutory" but keeps
+    # statutory_rates absent.
+    bad_payload = dict(frs_config.funding.model_dump())
+    bad_payload["contribution_strategy"] = "statutory"
+    bad_payload["statutory_rates"] = None
 
-    with pytest.raises(ValueError, match="statutory_rates"):
-        resolve_funding_context(bogus, funding_inputs)
+    with pytest.raises(ValidationError, match="statutory_rates"):
+        Funding.model_validate(bad_payload)
 
 
 def test_missing_rule_nra_raises(frs_config):


### PR DESCRIPTION
Second PR of the pydantic schema migration. Plan: \`scratch/pydantic_migration_plan.md\`. Closes #150. Builds on #149.

Migrates the \`funding\` block of plan_config.json to typed pydantic models. Largest of the medium-tier PRs because the funding block has nested sub-models with method-discriminated unions and mutually-exclusive variants.

## What's new in \`schemas/funding.py\`

| Model | Purpose |
|---|---|
| \`CorridorAvaSmoothing\` | Plan with corridor smoothing — \`corridor_low\`, \`corridor_high\`, \`recognition_fraction\` (with sensible defaults). |
| \`GainLossAvaSmoothing\` | Plan with N-year gain/loss cascade — \`recognition_period\`. |
| \`AvaSmoothing\` | \`Annotated[Union[...], Field(discriminator=\"method\")]\` — pydantic auto-dispatches based on the method tag. |
| \`RateScheduleEntry\` | One \`{from_year, rate}\` step. |
| \`RampSpec\` | \`{rate_per_year, end_year}\` for linear-ramp rate components. |
| \`RateComponentSpec\` | One term in the statutory employer-rate cascade. Validator enforces \`schedule\` and \`ramp\` are mutually exclusive (and exactly one required). |
| \`StatutoryRates\` | \`ee_rate_schedule\` + \`er_rate_components\`. |
| \`LegDef\` | One funding leg. \`*_param: \"new_year\"\` resolves at access time. |
| \`Funding\` | Top-level. Validator enforces \`statutory_rates\` is present when \`contribution_strategy == \"statutory\"\`. |

## Validation moves

| Before | After |
|---|---|
| \`if not stat_rates: raise ValueError(...)\` in \`_funding_setup.py\` | Validator on \`Funding\` model — fires at config load. |
| \`smoothing_cfg.get(\"method\")\` string compare for dispatch | \`isinstance(smoothing_cfg, CorridorAvaSmoothing)\` or \`smoothing_cfg.method == \"corridor\"\`. |
| \`if cont_strategy_name not in (\"statutory\", \"actuarial\"): raise\` | \`Literal[\"statutory\", \"actuarial\"]\` type — invalid values rejected at schema-parse time. |
| Implicit (no validation) — a \`RateComponentSpec\` with both schedule and ramp would fall through silently. | \`model_validator\` rejects with clear message. |

## PlanConfig migration

- New \`funding: Funding\` field stored on PlanConfig.
- 9 legacy scalar fields → \`@property\` delegators: \`funding_policy\` (maps to \`fund.policy\` in JSON), \`contribution_strategy\`, \`amo_method\`, \`amo_period_new\`, \`amo_pay_growth\`, \`funding_lag\`, \`amo_period_term\`, \`amo_term_growth\`, \`ava_smoothing\`.
- Existing \`@property\` accessors (\`has_drop\`, \`drop_reference_class\`, \`statutory_rates\`, \`amo_period_current\`, \`funding_legs\`) read from the typed model.
- The \`@property funding\` returning \`SimpleNamespace\` replaced by the stored typed field.

## Consumer fixes

- **\`_funding_setup.resolve_funding_context\`** — typed dispatch on \`fund.ava_smoothing\`, the runtime statutory-rates check is gone (handled by schema), \`ee_rate_schedule\` converted from typed entries to dicts at the strategy boundary.
- **\`_funding_setup.resolve_er_rate_components\`** — takes typed \`StatutoryRates\`; converts \`RateComponentSpec\` → strategy-side \`RateComponent\` via \`model_dump()\` (field shapes match by design).
- **\`cli._fmt_smoothing\`** — typed attribute access.
- **\`cli\` summary print** — \`fn.policy\` instead of \`fn.funding_policy\` (the typed model uses the JSON key directly).
- **4 leg/strategy tests** updated to use \`funding.model_copy(update=...)\` and schema-level validation.

## Loader

- New \`_build_funding_model\` helper. Pre-fills \`amo_pay_growth\` from \`economic.payroll_growth\` if omitted — preserves pre-pydantic loader's defensive default.
- \`PlanConfig()\` construction drops 9 redundant kwargs.

## Validation

- \`make r-match\` — 8/8 truth-table cells pass at relative diff < 1e-10.
- \`make test\` — 369 passed (was 354 + 15 new), 2 skipped.

## Diff

9 files, +511 / -152. Most of the new lines are declarative model definitions and tests.

## Out of scope

PRs 3-8 of the migration. Plan in \`scratch/pydantic_migration_plan.md\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)