### PR TITLE
Pydantic schema migration — PR 3: Benefit model

### DIFF
--- a/src/pension_model/cli.py
+++ b/src/pension_model/cli.py
@@ -168,7 +168,7 @@ def print_parameters(constants):
     print(f"    Discount rate:          {ec.dr_current:.1%}")
     print(f"    Investment return:      {ec.model_return:.1%}")
     print(f"    Payroll growth:         {ec.payroll_growth:.2%}")
-    print(f"    COLA (retirees):        {bn.cola_current_retire:.0%}")
+    print(f"    COLA (retirees):        {bn.cola.current_retire:.0%}")
     print(f"    Funding policy:         {fn.policy}")
     print(f"    Amortization:           {fn.amo_method}, {fn.amo_period_new}-year period")
     print(f"    Asset smoothing:        {_fmt_smoothing(fn)}")

--- a/src/pension_model/config_compat.py
+++ b/src/pension_model/config_compat.py
@@ -1,24 +1,11 @@
 """Compatibility adapters layered on top of ``PlanConfig``.
 
-Some sections (``benefit``, ``funding``, per-class data) still use
-``SimpleNamespace`` builders. The migration to typed pydantic models
-is in progress — see ``scratch/pydantic_migration_plan.md``.
+Per-class data still uses a ``SimpleNamespace`` builder; the migration
+to typed pydantic models is in progress — see
+``scratch/pydantic_migration_plan.md``.
 """
 
 from types import SimpleNamespace
-
-
-def build_benefit_namespace(config) -> SimpleNamespace:
-    cola = config.cola
-    return SimpleNamespace(
-        db_ee_cont_rate=config.db_ee_cont_rate,
-        db_ee_interest_rate=config.db_ee_interest_rate,
-        cal_factor=config.cal_factor,
-        retire_refund_ratio=config.retire_refund_ratio,
-        cola_current_retire=cola.get("current_retire", 0.0),
-        cola_current_retire_one=cola.get("current_retire_one_time", 0.0),
-        one_time_cola=cola.get("one_time_cola", False),
-    )
 
 
 def build_class_data_namespace(config) -> dict:

--- a/src/pension_model/config_loading.py
+++ b/src/pension_model/config_loading.py
@@ -10,7 +10,14 @@ from pathlib import Path
 from typing import Dict, Optional
 
 from pension_model.config_schema import PlanConfig
-from pension_model.schemas import Decrements, Economic, Funding, Modeling, Ranges
+from pension_model.schemas import (
+    Benefit,
+    Decrements,
+    Economic,
+    Funding,
+    Modeling,
+    Ranges,
+)
 
 
 log = logging.getLogger(__name__)
@@ -204,19 +211,12 @@ def load_plan_config(
     decrements_model = _build_decrements_model(raw, plan_name=raw["plan_name"])
     modeling_model = Modeling.model_validate(raw.get("modeling", {}))
     funding_model = _build_funding_model(fun, eco)
+    benefit_model = Benefit.model_validate(ben)
 
     config = PlanConfig(
         plan_name=raw["plan_name"],
         plan_description=raw.get("plan_description", ""),
         raw=raw,
-        db_ee_cont_rate=ben["db_ee_cont_rate"],
-        db_ee_interest_rate=ben.get("db_ee_interest_rate", 0.0),
-        cal_factor=ben.get("cal_factor", 1.0),
-        retire_refund_ratio=ben.get("retire_refund_ratio", 1.0),
-        fas_years_default=ben["fas_years_default"],
-        benefit_types=tuple(ben.get("benefit_types", ["db"])),
-        cola=ben.get("cola", {}),
-        cash_balance=ben.get("cash_balance"),
         classes=tuple(raw["classes"]),
         class_groups=raw.get("class_groups", {}),
         tier_defs=tuple(raw.get("tiers", [])),
@@ -228,6 +228,7 @@ def load_plan_config(
         decrements=decrements_model,
         modeling=modeling_model,
         funding=funding_model,
+        benefit=benefit_model,
         calibration=calibration,
         _class_to_group=class_to_group,
         _tier_name_to_id=tier_name_to_id,

--- a/src/pension_model/config_resolvers_vectorized.py
+++ b/src/pension_model/config_resolvers_vectorized.py
@@ -201,10 +201,10 @@ def resolve_cola_vec(
         if not mask.any():
             continue
         cola_key = tier_def["cola_key"]
-        raw_cola = config.cola.get(cola_key, 0.0)
+        raw_cola = getattr(config.cola, cola_key, 0.0)
         should_prorate = (
             tier_def.get("prorate_cola", False)
-            and not config.cola.get(cola_key + "_constant", False)
+            and not getattr(config.cola, cola_key + "_constant", False)
             and cola_cutoff is not None
             and raw_cola > 0
         )

--- a/src/pension_model/config_schema.py
+++ b/src/pension_model/config_schema.py
@@ -6,11 +6,17 @@ from types import SimpleNamespace
 from typing import Dict, List, Optional, Tuple
 
 from pension_model.config_compat import (
-    build_benefit_namespace,
     build_class_data_namespace,
 )
 from pension_model.config_validation import validate_config, validate_data_files
-from pension_model.schemas import Decrements, Economic, Funding, Modeling, Ranges
+from pension_model.schemas import (
+    Benefit,
+    Decrements,
+    Economic,
+    Funding,
+    Modeling,
+    Ranges,
+)
 
 
 NON_VESTED = 0
@@ -24,13 +30,6 @@ class PlanConfig:
     plan_name: str
     plan_description: str
     raw: dict
-    db_ee_cont_rate: float
-    db_ee_interest_rate: float
-    cal_factor: float
-    retire_refund_ratio: float
-    fas_years_default: int
-    benefit_types: Tuple[str, ...]
-    cola: dict
     classes: Tuple[str, ...]
     class_groups: Dict[str, List[str]]
     tier_defs: Tuple[dict, ...]
@@ -42,8 +41,8 @@ class PlanConfig:
     decrements: Decrements
     modeling: Modeling
     funding: Funding
+    benefit: Benefit
     calibration: Dict[str, dict] = field(default_factory=dict)
-    cash_balance: Optional[dict] = None
     reduce_tables: Optional[Dict[str, object]] = None
     _class_to_group: Dict[str, str] = field(default_factory=dict)
     _tier_name_to_id: Dict[str, int] = field(default_factory=dict)
@@ -125,6 +124,42 @@ class PlanConfig:
         return self.ranges.max_yos
 
     @property
+    def db_ee_cont_rate(self) -> float:
+        return self.benefit.db_ee_cont_rate
+
+    @property
+    def db_ee_interest_rate(self) -> float:
+        return self.benefit.db_ee_interest_rate
+
+    @property
+    def cal_factor(self) -> float:
+        return self.benefit.cal_factor
+
+    @property
+    def retire_refund_ratio(self) -> float:
+        return self.benefit.retire_refund_ratio
+
+    @property
+    def fas_years_default(self) -> int:
+        return self.benefit.fas_years_default
+
+    @property
+    def benefit_types(self) -> Tuple[str, ...]:
+        return tuple(self.benefit.benefit_types)
+
+    @property
+    def cola(self):
+        """Typed Cola model. Use ``getattr(cola, key, default)`` for
+        per-tier active-rate keys (admitted as ``extra=\"allow\"``).
+        """
+        return self.benefit.cola
+
+    @property
+    def cash_balance(self):
+        """Typed CashBalance model, or None if not declared."""
+        return self.benefit.cash_balance
+
+    @property
     def scenario_name(self) -> Optional[str]:
         return self.raw.get("_scenario_name")
 
@@ -151,7 +186,7 @@ class PlanConfig:
 
     @property
     def cola_proration_cutoff_year(self) -> Optional[int]:
-        return self.cola.get("proration_cutoff_year")
+        return self.cola.proration_cutoff_year
 
     @property
     def plan_design_cutoff_year(self) -> Optional[int]:
@@ -280,10 +315,6 @@ class PlanConfig:
     @property
     def max_year(self) -> int:
         return self.ranges.max_year
-
-    @property
-    def benefit(self) -> SimpleNamespace:
-        return build_benefit_namespace(self)
 
     @property
     def class_data(self) -> dict:

--- a/src/pension_model/core/benefit_tables.py
+++ b/src/pension_model/core/benefit_tables.py
@@ -384,9 +384,9 @@ def build_salary_benefit_table(
     has_cb = "cb" in constants.benefit_types
     cb_cfg = constants.cash_balance if has_cb else None
     if cb_cfg is not None and actual_icr_series is not None:
-        ee_credit = cb_cfg["ee_pay_credit"]
-        er_credit = cb_cfg["er_pay_credit"]
-        cb_vesting = cb_cfg["vesting_yos"]
+        ee_credit = cb_cfg.ee_pay_credit
+        er_credit = cb_cfg.er_pay_credit
+        cb_vesting = cb_cfg.vesting_yos
 
         df["cb_ee_cont"] = ee_credit * df["salary"]
         df["cb_er_cont"] = er_credit * df["salary"]
@@ -799,7 +799,7 @@ def build_ann_factor_table(
     if expected_icr_by_class:
         cb_cfg = constants.cash_balance
         if cb_cfg is not None:
-            acr = cb_cfg.get("annuity_conversion_rate", 0.04)
+            acr = cb_cfg.annuity_conversion_rate
             expected_icr_by_code = np.full(len(class_labels), -1.0, dtype=np.float64)
             for cn, expected_icr in expected_icr_by_class.items():
                 expected_icr_by_code[class_to_code[cn]] = expected_icr
@@ -982,7 +982,7 @@ def build_benefit_table(
         cb_vesting = 5
         cb_cfg = constants.cash_balance
         if cb_cfg is not None:
-            cb_vesting = cb_cfg["vesting_yos"]
+            cb_vesting = cb_cfg.vesting_yos
         is_vested = (df["yos"] >= cb_vesting).astype(float)
         df["pv_cb_benefit"] = (
             is_vested * df["cb_benefit"] * df["ann_factor_term"]
@@ -1354,7 +1354,7 @@ def build_benefit_val_table(
     if has_cb:
         cb_cfg = constants.cash_balance
         if cb_cfg is not None:
-            cb_vesting = cb_cfg["vesting_yos"]
+            cb_vesting = cb_cfg.vesting_yos
 
     # Start from salary_benefit_table
     sbt = salary_benefit_table.copy()

--- a/src/pension_model/core/data_loader.py
+++ b/src/pension_model/core/data_loader.py
@@ -135,7 +135,7 @@ def load_plan_data(
             constants.ranges.start_year,
             constants.ranges.model_period,
             constants.economic.dr_current,
-            constants.benefit.cola_current_retire,
+            constants.benefit.cola.current_retire,
         )
         afr = ann_factor_retire_cache.get(ann_factor_key)
     else:
@@ -143,7 +143,7 @@ def load_plan_data(
     if afr is None:
         afr = build_ann_factor_retire_table(
             cm, class_name, constants.ranges.start_year, constants.ranges.model_period,
-            constants.economic.dr_current, constants.benefit.cola_current_retire,
+            constants.economic.dr_current, constants.benefit.cola.current_retire,
         )
         if ann_factor_retire_cache is not None:
             ann_factor_retire_cache[ann_factor_key] = afr

--- a/src/pension_model/core/pipeline.py
+++ b/src/pension_model/core/pipeline.py
@@ -127,21 +127,21 @@ def _compute_cb_icr_series(inputs: dict, constants: PlanConfig) -> tuple[float, 
     cash_balance = constants.cash_balance
     expected_icr = compute_expected_icr(
         constants.model_return,
-        cash_balance.get("return_volatility", 0.12),
-        cash_balance["icr_smooth_period"],
-        cash_balance["icr_floor"],
-        cash_balance["icr_cap"],
-        cash_balance["icr_upside_share"],
+        cash_balance.return_volatility,
+        cash_balance.icr_smooth_period,
+        cash_balance.icr_floor,
+        cash_balance.icr_cap,
+        cash_balance.icr_upside_share,
     )
     years = range(constants.min_entry_year, constants.max_year + 1)
     actual_icr_series = compute_actual_icr_series(
         years,
         constants.start_year,
         inputs["_return_scenario"],
-        cash_balance["icr_smooth_period"],
-        cash_balance["icr_floor"],
-        cash_balance["icr_cap"],
-        cash_balance["icr_upside_share"],
+        cash_balance.icr_smooth_period,
+        cash_balance.icr_floor,
+        cash_balance.icr_cap,
+        cash_balance.icr_upside_share,
     )
     return expected_icr, actual_icr_series
 

--- a/src/pension_model/schemas/__init__.py
+++ b/src/pension_model/schemas/__init__.py
@@ -18,6 +18,12 @@ yet. See ``scratch/pydantic_migration_plan.md`` for the order.
 """
 
 from pension_model.schemas.base import StrictModel
+from pension_model.schemas.benefit import (
+    Benefit,
+    CashBalance,
+    Cola,
+    DcSpec,
+)
 from pension_model.schemas.decrements import Decrements
 from pension_model.schemas.economic import Economic
 from pension_model.schemas.funding import (
@@ -38,7 +44,11 @@ from pension_model.schemas.ranges import Ranges
 __all__ = [
     "AgeGroup",
     "AvaSmoothing",
+    "Benefit",
+    "CashBalance",
+    "Cola",
     "CorridorAvaSmoothing",
+    "DcSpec",
     "Decrements",
     "Economic",
     "Funding",

--- a/src/pension_model/schemas/benefit.py
+++ b/src/pension_model/schemas/benefit.py
@@ -1,0 +1,93 @@
+"""Schema for the ``benefit`` block of plan_config.json."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from pydantic import ConfigDict, Field
+
+from pension_model.schemas.base import StrictModel
+
+
+class Cola(StrictModel):
+    """Cost-of-living adjustment assumptions.
+
+    Has two layers of fields:
+
+    * **Typed fixed fields** for retiree-side and proration:
+      ``current_retire``, ``current_retire_one_time``, ``one_time_cola``,
+      ``proration_cutoff_year``.
+
+    * **Dynamic per-tier active rates** (e.g. ``tier_1_active``,
+      ``tier_2_active_constant``) — admitted via ``extra="allow"``
+      because the keys depend on the plan's tier names. Read these
+      via ``getattr(cola, key, default)`` from caller code.
+
+    A future cleanup PR may move per-tier rates into a typed sub-dict
+    so the whole model can be strict; for now the loose form
+    preserves the existing JSON shape.
+    """
+
+    # The override loosens StrictModel's extra="forbid" to admit
+    # tier-keyed extras. Strict on type coercion still applies to
+    # the typed fields below.
+    model_config = ConfigDict(extra="allow", frozen=True)
+
+    current_retire: float = 0.0
+    current_retire_one_time: float = 0.0
+    one_time_cola: bool = False
+    proration_cutoff_year: Optional[int] = None
+
+
+class CashBalance(StrictModel):
+    """Cash-balance plan parameters (TXTRS-style)."""
+
+    ee_pay_credit: float
+    er_pay_credit: float
+    vesting_yos: int
+    icr_smooth_period: int
+    icr_floor: float
+    icr_cap: float
+    icr_upside_share: float
+    annuity_conversion_rate: float
+    return_volatility: float = 0.12
+
+
+class DcSpec(StrictModel):
+    """Defined-contribution sub-block (TXTRS-style)."""
+
+    ee_cont_rate: float
+    assumed_return: float
+    return_volatility: float = 0.12
+
+
+class Benefit(StrictModel):
+    """Plan-level benefit assumptions.
+
+    ``cal_factor`` and ``min_benefit_monthly`` are admitted but are
+    not yet used by every plan — the loader injects ``cal_factor``
+    from ``calibration.json`` if the plan has one, and
+    ``min_benefit_monthly`` is a TXTRS-only feature today.
+    """
+
+    db_ee_cont_rate: float
+    db_ee_interest_rate: float = 0.0
+    retire_refund_ratio: float = 1.0
+    fas_years_default: int
+    fas_years_grandfathered: Optional[int] = Field(
+        default=None,
+        description="Override fas_years for grandfathered tiers (TXTRS).",
+    )
+    min_benefit_monthly: Optional[float] = Field(
+        default=None,
+        description="Floor on monthly benefit at retirement (TXTRS).",
+    )
+    cal_factor: float = Field(
+        default=1.0,
+        description="Plan-wide calibration scalar applied to DB benefits. "
+        "Injected by the loader from calibration.json when present.",
+    )
+    benefit_types: list[str] = Field(default_factory=lambda: ["db"])
+    cola: Cola = Field(default_factory=Cola)
+    cash_balance: Optional[CashBalance] = None
+    dc: Optional[DcSpec] = None

--- a/tests/test_pension_model/_vectorized_resolver_test_support.py
+++ b/tests/test_pension_model/_vectorized_resolver_test_support.py
@@ -86,9 +86,9 @@ def scalar_cola(config, tier_name, entry_year, yos):
     for td in config.tier_defs:
         if td["name"] == tier_name:
             cola_key = td.get("cola_key", "tier_1_active")
-            raw_cola = config.cola.get(cola_key, 0.0)
+            raw_cola = getattr(config.cola, cola_key, 0.0)
             if (cola_key == "tier_1_active"
-                    and not config.cola.get("tier_1_active_constant", False)
+                    and not getattr(config.cola, "tier_1_active_constant", False)
                     and cola_cutoff is not None
                     and raw_cola > 0 and yos > 0):
                 yos_b4 = min(max(cola_cutoff - entry_year, 0), yos)

--- a/tests/test_pension_model/test_plan_config_txtrs.py
+++ b/tests/test_pension_model/test_plan_config_txtrs.py
@@ -15,4 +15,4 @@ def test_txtrs_loads():
     assert config.dr_current == 0.07
     assert config.db_ee_cont_rate == 0.0825
     assert config.cash_balance is not None
-    assert config.cash_balance["ee_pay_credit"] == 0.06
+    assert config.cash_balance.ee_pay_credit == 0.06

--- a/tests/test_pension_model/test_schemas.py
+++ b/tests/test_pension_model/test_schemas.py
@@ -14,7 +14,11 @@ from pydantic import ValidationError
 from pension_model.schemas import (
     AgeGroup,
     AvaSmoothing,
+    Benefit,
+    CashBalance,
+    Cola,
     CorridorAvaSmoothing,
+    DcSpec,
     Decrements,
     Economic,
     Funding,
@@ -338,3 +342,126 @@ class TestFunding:
     def test_extra_field_raises(self):
         with pytest.raises(ValidationError, match="bogus_field"):
             Funding.model_validate(self._valid_actuarial(bogus_field=1))
+
+
+# ---------------------------------------------------------------------------
+# Cola (extra=allow for per-tier dynamic keys)
+# ---------------------------------------------------------------------------
+
+
+class TestCola:
+    def test_empty_loads_with_defaults(self):
+        c = Cola.model_validate({})
+        assert c.current_retire == 0.0
+        assert c.proration_cutoff_year is None
+
+    def test_per_tier_keys_admitted_as_extras(self):
+        c = Cola.model_validate({
+            "current_retire": 0.03,
+            "tier_1_active": 0.03,
+            "tier_2_active": 0.0,
+            "tier_1_active_constant": False,
+        })
+        assert c.current_retire == 0.03
+        # Per-tier keys readable via getattr (not part of typed fields).
+        assert getattr(c, "tier_1_active") == 0.03
+        assert getattr(c, "tier_2_active") == 0.0
+        assert getattr(c, "tier_1_active_constant") is False
+        assert getattr(c, "missing_key", "fallback") == "fallback"
+
+
+# ---------------------------------------------------------------------------
+# CashBalance
+# ---------------------------------------------------------------------------
+
+
+class TestCashBalance:
+    def test_required_fields(self):
+        cb = CashBalance.model_validate({
+            "ee_pay_credit": 0.06,
+            "er_pay_credit": 0.09,
+            "vesting_yos": 5,
+            "icr_smooth_period": 5,
+            "icr_floor": 0.04,
+            "icr_cap": 0.07,
+            "icr_upside_share": 0.5,
+            "annuity_conversion_rate": 0.04,
+        })
+        assert cb.ee_pay_credit == 0.06
+        assert cb.return_volatility == 0.12  # default
+
+    def test_missing_required_raises(self):
+        with pytest.raises(ValidationError, match="vesting_yos"):
+            CashBalance.model_validate({
+                "ee_pay_credit": 0.06,
+                "er_pay_credit": 0.09,
+                "icr_smooth_period": 5,
+                "icr_floor": 0.04,
+                "icr_cap": 0.07,
+                "icr_upside_share": 0.5,
+                "annuity_conversion_rate": 0.04,
+            })
+
+    def test_extra_field_raises(self):
+        with pytest.raises(ValidationError, match="extra_thing"):
+            CashBalance.model_validate({
+                "ee_pay_credit": 0.06,
+                "er_pay_credit": 0.09,
+                "vesting_yos": 5,
+                "icr_smooth_period": 5,
+                "icr_floor": 0.04,
+                "icr_cap": 0.07,
+                "icr_upside_share": 0.5,
+                "annuity_conversion_rate": 0.04,
+                "extra_thing": True,
+            })
+
+
+# ---------------------------------------------------------------------------
+# Benefit (top-level + composition)
+# ---------------------------------------------------------------------------
+
+
+class TestBenefit:
+    def _valid(self, **overrides):
+        base = {
+            "db_ee_cont_rate": 0.03,
+            "fas_years_default": 5,
+            "benefit_types": ["db"],
+        }
+        base.update(overrides)
+        return base
+
+    def test_minimal_loads(self):
+        b = Benefit.model_validate(self._valid())
+        assert b.db_ee_cont_rate == 0.03
+        assert b.cola.current_retire == 0.0  # default Cola
+        assert b.cash_balance is None
+        assert b.dc is None
+
+    def test_with_cola_and_cb(self):
+        b = Benefit.model_validate(self._valid(
+            cola={"current_retire": 0.03, "tier_1_active": 0.03},
+            cash_balance={
+                "ee_pay_credit": 0.06,
+                "er_pay_credit": 0.09,
+                "vesting_yos": 5,
+                "icr_smooth_period": 5,
+                "icr_floor": 0.04,
+                "icr_cap": 0.07,
+                "icr_upside_share": 0.5,
+                "annuity_conversion_rate": 0.04,
+            },
+        ))
+        assert b.cola.current_retire == 0.03
+        assert getattr(b.cola, "tier_1_active") == 0.03
+        assert b.cash_balance is not None
+        assert b.cash_balance.ee_pay_credit == 0.06
+
+    def test_missing_required_raises(self):
+        with pytest.raises(ValidationError, match="db_ee_cont_rate"):
+            Benefit.model_validate({"fas_years_default": 5})
+
+    def test_extra_field_raises(self):
+        with pytest.raises(ValidationError, match="bogus"):
+            Benefit.model_validate(self._valid(bogus=1))


### PR DESCRIPTION
Third PR of the pydantic schema migration. Plan: \`scratch/pydantic_migration_plan.md\`. Closes #152. Builds on #149, #151.

Migrates the \`benefit\` block of plan_config.json to typed pydantic models. Introduces an interesting wrinkle in the COLA sub-model: per-tier active-rate keys (\`tier_1_active\`, \`tier_2_active\`, ...) are dynamic by tier name, so the \`Cola\` model uses \`extra=\"allow\"\` to admit them while still typing the well-known fixed keys.

## What's new in \`schemas/benefit.py\`

| Model | Purpose |
|---|---|
| \`Cola\` | Fixed fields typed; per-tier active-rate keys admitted via \`extra=\"allow\"\`, read via \`getattr(cola, key, default)\`. |
| \`CashBalance\` | TXTRS-style: pay credits, ICR smoothing, vesting, annuity conversion, return volatility. |
| \`DcSpec\` | Optional DC sub-block (TXTRS only). |
| \`Benefit\` | Top-level: discount-rate fields, FAS years, retire-refund ratio, benefit_types, plus sub-models. |

## Why \`Cola\` uses \`extra=\"allow\"\`

The cola dict has tier-name-keyed entries whose names depend on the plan's tier configuration. A typed model can't enumerate them in advance. \`extra=\"allow\"\` admits any extras while still type-checking the known fields. Consumers use \`getattr(cola, key, default)\` — works uniformly for both fixed fields and per-tier extras.

A future cleanup PR may move per-tier rates into a typed sub-dict so the whole model can be strict; for now the loose form preserves the existing JSON shape with no plan_config edits.

## PlanConfig migration

- New \`benefit: Benefit\` field stored on PlanConfig.
- 7 legacy scalar fields → \`@property\` delegators: \`db_ee_cont_rate\`, \`db_ee_interest_rate\`, \`cal_factor\`, \`retire_refund_ratio\`, \`fas_years_default\`, \`benefit_types\`, \`cola\`, \`cash_balance\`.
- The \`@property benefit\` returning \`SimpleNamespace\` replaced by the stored typed field.

## Consumer fixes (the bulk of this PR)

| Pattern | Where |
|---|---|
| \`cash_balance[\"key\"]\` → \`cash_balance.key\` (15 sites) | \`pipeline.py\`, \`benefit_tables.py\` |
| \`config.cola.get(key, default)\` → \`getattr(config.cola, key, default)\` | \`config_resolvers_vectorized\`, test support |
| \`bn.cola_current_retire\` → \`bn.cola.current_retire\` (old SimpleNamespace flattening goes away) | \`cli.py\`, \`data_loader.py\` |
| \`config.cash_balance[\"ee_pay_credit\"]\` → \`config.cash_balance.ee_pay_credit\` | \`test_plan_config_txtrs.py\` |

## Validation

- \`make r-match\` — 8/8 truth-table cells pass at relative diff < 1e-10.
- \`make test\` — 378 passed (was 369 + 9 new), 2 skipped.

## Diff

13 files, +312 / -63. Most additions are model definitions and tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)