### PR TITLE
Pydantic schema migration — PR 4: class-level bundle

### DIFF
--- a/src/pension_model/config_compat.py
+++ b/src/pension_model/config_compat.py
@@ -1,26 +1,6 @@
 """Compatibility adapters layered on top of ``PlanConfig``.
 
-Per-class data still uses a ``SimpleNamespace`` builder; the migration
-to typed pydantic models is in progress — see
-``scratch/pydantic_migration_plan.md``.
+After the pydantic schema migration this module is empty; kept as
+an import-stable home in case future helpers belong here. See
+``scratch/pydantic_migration_plan.md`` for the migration history.
 """
-
-from types import SimpleNamespace
-
-
-def build_class_data_namespace(config) -> dict:
-    result = {}
-    for class_name, valuation in config.valuation_inputs.items():
-        calibration = config.calibration.get(class_name, {})
-        result[class_name] = SimpleNamespace(
-            ben_payment=valuation["ben_payment"],
-            retiree_pop=valuation["retiree_pop"],
-            total_active_member=valuation["total_active_member"],
-            er_dc_cont_rate=valuation["er_dc_cont_rate"],
-            val_norm_cost=valuation["val_norm_cost"],
-            nc_cal=calibration.get("nc_cal", 1.0),
-            pvfb_term_current=calibration.get("pvfb_term_current", 0.0),
-        )
-    return result
-
-

--- a/src/pension_model/config_loading.py
+++ b/src/pension_model/config_loading.py
@@ -12,11 +12,15 @@ from typing import Dict, Optional
 from pension_model.config_schema import PlanConfig
 from pension_model.schemas import (
     Benefit,
+    Calibration,
+    ClassCalibration,
     Decrements,
     Economic,
     Funding,
     Modeling,
+    PlanDesign,
     Ranges,
+    ValuationInputs,
 )
 
 
@@ -47,11 +51,13 @@ def _load_calibration_data(
     calibration_path: Optional[Path],
     *,
     skip_class_calibration: bool,
-) -> tuple[dict, Optional[float]]:
+) -> tuple[Dict[str, ClassCalibration], Optional[float]]:
     """Load calibration payload from JSON when available.
 
     Returns:
         Tuple of ``(per_class_calibration, global_cal_factor_override)``.
+        The per-class dict is keyed by class name, with each value
+        a typed :class:`ClassCalibration`.
     """
     if calibration_path is None or not calibration_path.exists():
         return {}, None
@@ -59,8 +65,9 @@ def _load_calibration_data(
     with open(calibration_path) as f:
         cal_raw = json.load(f)
 
-    calibration = {} if skip_class_calibration else cal_raw.get("classes", {})
-    return calibration, cal_raw.get("cal_factor")
+    cal_model = Calibration.model_validate(cal_raw)
+    classes = {} if skip_class_calibration else cal_model.classes
+    return dict(classes), cal_model.cal_factor
 
 
 def _build_tier_metadata(
@@ -212,6 +219,11 @@ def load_plan_config(
     modeling_model = Modeling.model_validate(raw.get("modeling", {}))
     funding_model = _build_funding_model(fun, eco)
     benefit_model = Benefit.model_validate(ben)
+    plan_design_model = PlanDesign.model_validate(raw.get("plan_design", {}))
+    valuation_models = {
+        cn: ValuationInputs.model_validate(v)
+        for cn, v in raw.get("valuation_inputs", {}).items()
+    }
 
     config = PlanConfig(
         plan_name=raw["plan_name"],
@@ -221,8 +233,8 @@ def load_plan_config(
         class_groups=raw.get("class_groups", {}),
         tier_defs=tuple(raw.get("tiers", [])),
         benefit_mult_defs=raw.get("benefit_multipliers", {}),
-        plan_design_defs=raw.get("plan_design", {}),
-        valuation_inputs=raw.get("valuation_inputs", {}),
+        plan_design=plan_design_model,
+        valuation_inputs=valuation_models,
         economic=economic_model,
         ranges=ranges_model,
         decrements=decrements_model,

--- a/src/pension_model/config_schema.py
+++ b/src/pension_model/config_schema.py
@@ -2,20 +2,20 @@
 
 from dataclasses import dataclass, field
 from pathlib import Path
-from types import SimpleNamespace
 from typing import Dict, List, Optional, Tuple
 
-from pension_model.config_compat import (
-    build_class_data_namespace,
-)
 from pension_model.config_validation import validate_config, validate_data_files
 from pension_model.schemas import (
     Benefit,
+    ClassCalibration,
+    ClassData,
     Decrements,
     Economic,
     Funding,
     Modeling,
+    PlanDesign,
     Ranges,
+    ValuationInputs,
 )
 
 
@@ -34,15 +34,15 @@ class PlanConfig:
     class_groups: Dict[str, List[str]]
     tier_defs: Tuple[dict, ...]
     benefit_mult_defs: dict
-    plan_design_defs: dict
-    valuation_inputs: Dict[str, dict]
+    plan_design: PlanDesign
+    valuation_inputs: Dict[str, ValuationInputs]
     economic: Economic
     ranges: Ranges
     decrements: Decrements
     modeling: Modeling
     funding: Funding
     benefit: Benefit
-    calibration: Dict[str, dict] = field(default_factory=dict)
+    calibration: Dict[str, ClassCalibration] = field(default_factory=dict)
     reduce_tables: Optional[Dict[str, object]] = None
     _class_to_group: Dict[str, str] = field(default_factory=dict)
     _tier_name_to_id: Dict[str, int] = field(default_factory=dict)
@@ -190,7 +190,7 @@ class PlanConfig:
 
     @property
     def plan_design_cutoff_year(self) -> Optional[int]:
-        return self.raw.get("plan_design", {}).get("cutoff_year")
+        return self.plan_design.cutoff_year
 
     @property
     def salary_growth_col_map(self) -> Dict[str, str]:
@@ -317,25 +317,55 @@ class PlanConfig:
         return self.ranges.max_year
 
     @property
-    def class_data(self) -> dict:
-        return build_class_data_namespace(self)
+    def class_data(self) -> Dict[str, ClassData]:
+        """Per-class merged view of valuation_inputs + calibration.
+
+        Returns typed ``ClassData`` objects, one per class. Same
+        access pattern as the prior ``SimpleNamespace`` shape:
+        ``config.class_data[cn].nc_cal``, etc.
+        """
+        result = {}
+        for class_name, valuation in self.valuation_inputs.items():
+            cal = self.calibration.get(class_name)
+            result[class_name] = ClassData(
+                ben_payment=valuation.ben_payment,
+                retiree_pop=valuation.retiree_pop,
+                total_active_member=valuation.total_active_member,
+                er_dc_cont_rate=valuation.er_dc_cont_rate,
+                val_norm_cost=valuation.val_norm_cost,
+                nc_cal=cal.nc_cal if cal is not None else 1.0,
+                pvfb_term_current=cal.pvfb_term_current if cal is not None else 0.0,
+            )
+        return result
+
+    @property
+    def plan_design_defs(self) -> dict:
+        """Backward-compat: raw dict of group → ratios mappings.
+
+        Some legacy code (and the calibration runner) still iterates
+        the raw shape. Builds a dict from the typed ``plan_design``
+        each call.
+        """
+        return {
+            name: ratios.model_dump(exclude_none=True)
+            for name, ratios in self.plan_design.groups.items()
+        }
 
     def get_design_ratios(self, class_name: str) -> Dict[str, Tuple[float, float, float]]:
-        group = self.design_ratio_group_map.get(class_name, self.class_group(class_name))
-        ratios = self.plan_design_defs.get(group, self.plan_design_defs.get("default", {}))
+        from pension_model.schemas import PlanDesignRatios
+
+        group_name = self.design_ratio_group_map.get(class_name, self.class_group(class_name))
+        ratios = (
+            self.plan_design.group(group_name)
+            or self.plan_design.group("default")
+            or PlanDesignRatios()
+        )
         result = {}
         for bt in self.benefit_types:
             if bt == "db":
-                before = ratios.get("before_cutoff", 1.0)
-                after = ratios.get("after_cutoff", before)
-                new = ratios.get("new", ratios.get("new_db", 1.0))
-                result["db"] = (before, after, new)
+                result["db"] = ratios.db_triple()
             elif bt == "cb":
-                result["cb"] = (
-                    ratios.get("before_cb", 0.0),
-                    ratios.get("after_cb", 0.0),
-                    ratios.get("new_cb", 0.0),
-                )
+                result["cb"] = ratios.cb_triple()
             elif bt == "dc":
                 db_before, db_after, db_new = result.get("db", (1.0, 1.0, 1.0))
                 cb_before, cb_after, cb_new = result.get("cb", (0.0, 0.0, 0.0))
@@ -350,10 +380,13 @@ class PlanConfig:
         return self._class_to_group.get(class_name, "default")
 
     def get_class_inputs(self, class_name: str) -> dict:
-        base = dict(self.valuation_inputs.get(class_name, {}))
-        cal = self.calibration.get(class_name, {})
-        base["nc_cal"] = cal.get("nc_cal", 1.0)
-        base["pvfb_term_current"] = cal.get("pvfb_term_current", 0.0)
+        valuation = self.valuation_inputs.get(class_name)
+        if valuation is None:
+            return {"nc_cal": 1.0, "pvfb_term_current": 0.0}
+        base = valuation.model_dump(exclude_none=True)
+        cal = self.calibration.get(class_name)
+        base["nc_cal"] = cal.nc_cal if cal is not None else 1.0
+        base["pvfb_term_current"] = cal.pvfb_term_current if cal is not None else 0.0
         return base
 
     def validate(self) -> list:

--- a/src/pension_model/config_validation.py
+++ b/src/pension_model/config_validation.py
@@ -50,16 +50,11 @@ def validate_config(config) -> list[str]:
     """Return non-fatal config warnings for a loaded plan."""
     warnings: list[str] = []
 
-    for class_name, valuation in config.valuation_inputs.items():
-        if "ben_payment" not in valuation:
-            warnings.append(
-                f"class '{class_name}' is missing 'ben_payment' in valuation_inputs. "
-                f"This is the initial-year pension benefit payments to "
-                f"current retirees (used to seed the retiree liability projection)."
-            )
-
+    # ben_payment is required by ValuationInputs; the schema would
+    # have failed to load if it were missing. The check is kept here
+    # as a no-op for forward compat.
     for class_name, calibration in config.calibration.items():
-        nc_cal = calibration.get("nc_cal", 1.0)
+        nc_cal = calibration.nc_cal
         if nc_cal < 0.8 or nc_cal > 1.2:
             warnings.append(
                 f"class '{class_name}' has nc_cal={nc_cal:.3f} (outside 0.8-1.2 range). "
@@ -80,20 +75,25 @@ def validate_config(config) -> list[str]:
                 f"class '{class_name}' is listed in 'classes' but has no entry in valuation_inputs."
             )
 
+    # er_dc_cont_rate has a default of 0.0 in the schema. Only warn
+    # if the plan declares dc but the rate is zero (likely
+    # under-configured).
     if "dc" in config.benefit_types:
         for class_name in config.classes:
-            if "er_dc_cont_rate" not in config.valuation_inputs.get(class_name, {}):
+            valuation = config.valuation_inputs.get(class_name)
+            if valuation is not None and valuation.er_dc_cont_rate == 0.0:
                 warnings.append(
-                    f"class '{class_name}' is missing 'er_dc_cont_rate' in valuation_inputs "
+                    f"class '{class_name}' has er_dc_cont_rate=0.0 in valuation_inputs "
                     f"but benefit_types includes 'dc'."
                 )
 
     for class_name, valuation in config.valuation_inputs.items():
-        headcount_group = valuation.get("headcount_group")
+        headcount_group = valuation.headcount_group
         if headcount_group and len(headcount_group) > 1:
-            target = valuation["total_active_member"]
+            target = valuation.total_active_member
             for peer in headcount_group:
-                peer_target = config.valuation_inputs.get(peer, {}).get("total_active_member")
+                peer_val = config.valuation_inputs.get(peer)
+                peer_target = peer_val.total_active_member if peer_val is not None else None
                 if peer_target != target:
                     warnings.append(
                         f"headcount_group mismatch: '{class_name}' has total_active_member={target} "

--- a/src/pension_model/core/calibration.py
+++ b/src/pension_model/core/calibration.py
@@ -126,16 +126,18 @@ def build_targets_from_config(constants) -> Dict[str, CalibrationTargets]:
     targets = {}
     vi = constants.valuation_inputs
     for cn in constants.classes:
-        entry = vi.get(cn, {})
-        vnc = entry.get("val_norm_cost")
-        val_aal = entry.get("val_aal")
-        if vnc is None or val_aal is None:
+        entry = vi.get(cn)
+        if entry is None:
+            continue
+        if entry.val_norm_cost is None or entry.val_aal is None:
             continue
         targets[cn] = CalibrationTargets(
-            val_norm_cost=vnc,
-            val_aal=val_aal,
-            val_payroll=entry.get("val_payroll"),
-            val_benefit_payments=entry.get("outflow"),
+            val_norm_cost=entry.val_norm_cost,
+            val_aal=entry.val_aal,
+            val_payroll=entry.val_payroll,
+            # 'outflow' isn't part of the typed schema today; preserve
+            # the optional lookup pattern for future schema additions.
+            val_benefit_payments=getattr(entry, "outflow", None),
         )
     return targets
 

--- a/src/pension_model/core/data_loader.py
+++ b/src/pension_model/core/data_loader.py
@@ -561,9 +561,9 @@ def load_plan_inputs(constants: PlanConfig) -> tuple[PlanConfig, dict]:
     # Pre-compute per-class headcount adjustment ratios so the core
     # pipeline no longer needs to read demographic CSVs mid-computation.
     for cn in classes:
-        acfr = constants.valuation_inputs.get(cn, {})
+        acfr = constants.valuation_inputs.get(cn)
         target = constants.class_data[cn].total_active_member
-        hc_group = acfr.get("headcount_group")
+        hc_group = acfr.headcount_group if acfr is not None else None
         if hc_group and len(hc_group) > 1:
             raw_total = sum(raw_inputs_by_class[peer]["_raw_headcount_total"] for peer in hc_group)
         else:

--- a/src/pension_model/schemas/__init__.py
+++ b/src/pension_model/schemas/__init__.py
@@ -24,6 +24,7 @@ from pension_model.schemas.benefit import (
     Cola,
     DcSpec,
 )
+from pension_model.schemas.calibration import Calibration, ClassCalibration
 from pension_model.schemas.decrements import Decrements
 from pension_model.schemas.economic import Economic
 from pension_model.schemas.funding import (
@@ -38,14 +39,19 @@ from pension_model.schemas.funding import (
     StatutoryRates,
 )
 from pension_model.schemas.modeling import AgeGroup, Modeling
+from pension_model.schemas.plan_design import PlanDesign, PlanDesignRatios
 from pension_model.schemas.ranges import Ranges
+from pension_model.schemas.valuation_inputs import ClassData, ValuationInputs
 
 
 __all__ = [
     "AgeGroup",
     "AvaSmoothing",
     "Benefit",
+    "Calibration",
     "CashBalance",
+    "ClassCalibration",
+    "ClassData",
     "Cola",
     "CorridorAvaSmoothing",
     "DcSpec",
@@ -55,10 +61,13 @@ __all__ = [
     "GainLossAvaSmoothing",
     "LegDef",
     "Modeling",
+    "PlanDesign",
+    "PlanDesignRatios",
     "RampSpec",
     "Ranges",
     "RateComponentSpec",
     "RateScheduleEntry",
     "StatutoryRates",
     "StrictModel",
+    "ValuationInputs",
 ]

--- a/src/pension_model/schemas/calibration.py
+++ b/src/pension_model/schemas/calibration.py
@@ -1,0 +1,46 @@
+"""Schema for ``calibration.json`` (top-level + per-class)."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from pydantic import ConfigDict, Field
+
+from pension_model.schemas.base import StrictModel
+
+
+class ClassCalibration(StrictModel):
+    """Per-class calibration values."""
+
+    nc_cal: float = Field(
+        default=1.0,
+        description="Normal-cost calibration scalar. Multiplies the "
+        "model's NC rate to match AV. Values near 1.0 mean the model "
+        "is accurate for that class.",
+    )
+    pvfb_term_current: float = Field(
+        default=0.0,
+        description="PVFB on term-vested members at start year. "
+        "Seeds the term-vested AAL where the AV doesn't break out a "
+        "specific number.",
+    )
+
+
+class Calibration(StrictModel):
+    """Top-level calibration.json structure.
+
+    Free-text fields (``description``, ``source``, ``notes``) are
+    documentation and don't drive logic. ``cal_factor`` is injected
+    into ``Benefit.cal_factor`` by the loader. ``classes`` maps each
+    class name to its per-class calibration block.
+    """
+
+    # Allow free-form documentation fields plus future per-class
+    # entries the loader doesn't understand yet.
+    model_config = ConfigDict(extra="allow", frozen=True)
+
+    description: Optional[str] = None
+    source: Optional[str] = None
+    notes: Optional[str] = None
+    cal_factor: Optional[float] = None
+    classes: dict[str, ClassCalibration] = Field(default_factory=dict)

--- a/src/pension_model/schemas/plan_design.py
+++ b/src/pension_model/schemas/plan_design.py
@@ -1,0 +1,112 @@
+"""Schema for the ``plan_design`` block of plan_config.json."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from pydantic import ConfigDict, Field, model_validator
+
+from pension_model.schemas.base import StrictModel
+
+
+class PlanDesignRatios(StrictModel):
+    """Per-group benefit-type allocation ratios.
+
+    Each per-group block describes how members are split across
+    benefit types (DB / DC / CB), optionally with a before/after
+    cutoff for the DB share. Field names match the keys consumed by
+    ``PlanConfig.get_design_ratios``:
+
+    - ``before_cutoff`` / ``after_cutoff``: DB share for entry years
+      before/after the plan-design cutoff_year.
+    - ``new`` / ``new_db``: DB share for new hires (entry_year >=
+      ranges.new_year). ``new_db`` is the alias TXTRS uses.
+    - ``before_cb`` / ``after_cb`` / ``new_cb``: CB shares.
+
+    All fields optional; consumers default missing fields to 0.0 (CB)
+    or fall through to ``new_db`` (DB).
+    """
+
+    before_cutoff: Optional[float] = None
+    after_cutoff: Optional[float] = Field(
+        default=None,
+        description="Defaults to before_cutoff if omitted (no cutoff).",
+    )
+    new: Optional[float] = None
+    new_db: Optional[float] = None
+    before_cb: Optional[float] = None
+    after_cb: Optional[float] = None
+    new_cb: Optional[float] = None
+    new_dc: Optional[float] = None
+
+    def db_triple(self) -> tuple[float, float, float]:
+        """Return ``(before, after, new)`` DB ratios with defaults
+        applied: missing ``before_cutoff`` → 1.0, missing
+        ``after_cutoff`` → ``before_cutoff``, missing ``new`` →
+        ``new_db`` → 1.0.
+        """
+        before = self.before_cutoff if self.before_cutoff is not None else 1.0
+        after = self.after_cutoff if self.after_cutoff is not None else before
+        new = self.new if self.new is not None else (
+            self.new_db if self.new_db is not None else 1.0
+        )
+        return (before, after, new)
+
+    def cb_triple(self) -> tuple[float, float, float]:
+        """Return ``(before, after, new)`` CB ratios with missing
+        fields defaulting to 0.0.
+        """
+        return (
+            self.before_cb if self.before_cb is not None else 0.0,
+            self.after_cb if self.after_cb is not None else 0.0,
+            self.new_cb if self.new_cb is not None else 0.0,
+        )
+
+
+class PlanDesign(StrictModel):
+    """Top-level plan_design block.
+
+    Has a fixed ``cutoff_year`` plus a variable-shape map of group
+    name → :class:`PlanDesignRatios`. Group names depend on the
+    plan's class_groups configuration (FRS uses ``regular_group`` /
+    ``special_group``; TXTRS uses ``default``).
+
+    Groups arrive in JSON as top-level keys; an ``after``-mode
+    validator promotes each group's raw dict to a typed
+    ``PlanDesignRatios`` instance and exposes them via the
+    ``groups`` property.
+    """
+
+    # ``extra="allow"`` admits the per-group keys whose names depend
+    # on the plan. Validation of the per-group payloads happens in
+    # the after-validator below.
+    model_config = ConfigDict(extra="allow", frozen=True)
+
+    cutoff_year: Optional[int] = None
+
+    @model_validator(mode="after")
+    def _promote_groups_to_typed_ratios(self) -> "PlanDesign":
+        """Convert each extra (group) entry to ``PlanDesignRatios``."""
+        if not self.model_extra:
+            return self
+        promoted = {}
+        for name, raw in self.model_extra.items():
+            if isinstance(raw, PlanDesignRatios):
+                promoted[name] = raw
+            else:
+                promoted[name] = PlanDesignRatios.model_validate(raw)
+        # Re-set extras through the back door; pydantic stores extras
+        # in __pydantic_extra__ on frozen models.
+        object.__setattr__(self, "__pydantic_extra__", promoted)
+        return self
+
+    def group(self, name: str) -> Optional[PlanDesignRatios]:
+        """Look up a group's design ratios by name. Returns None if
+        absent (caller decides whether to fall back to ``default``).
+        """
+        return (self.model_extra or {}).get(name)
+
+    @property
+    def groups(self) -> dict[str, PlanDesignRatios]:
+        """All declared groups as a dict ``{name: PlanDesignRatios}``."""
+        return dict(self.model_extra or {})

--- a/src/pension_model/schemas/valuation_inputs.py
+++ b/src/pension_model/schemas/valuation_inputs.py
@@ -1,0 +1,64 @@
+"""Schema for the ``valuation_inputs`` block of plan_config.json,
+plus the merged ``class_data`` view used at runtime."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from pydantic import Field
+
+from pension_model.schemas.base import StrictModel
+
+
+class ValuationInputs(StrictModel):
+    """One class's actuarial-valuation snapshot.
+
+    Used to seed initial AAL / payroll / member counts and
+    benefit-payment streams. Each plan declares one entry per class
+    under ``valuation_inputs`` in plan_config.json.
+    """
+
+    ben_payment: float = Field(
+        description="Initial-year pension benefit payments to current "
+        "retirees. Seeds the retiree liability projection.",
+    )
+    retiree_pop: int
+    total_active_member: int
+    er_dc_cont_rate: float = Field(
+        default=0.0,
+        description="Employer DC contribution rate (used when "
+        "benefit_types includes 'dc').",
+    )
+    val_norm_cost: float
+    val_aal: Optional[float] = Field(
+        default=None,
+        description="AV-published actuarial accrued liability (used "
+        "for component-by-component calibration; optional).",
+    )
+    val_payroll: Optional[float] = Field(
+        default=None,
+        description="AV-published payroll for this class (FRS-only "
+        "today).",
+    )
+    headcount_group: Optional[list[str]] = Field(
+        default=None,
+        description="Classes whose headcount totals must agree (FRS "
+        "uses this to enforce eco/eso/judges share total_active_member).",
+    )
+
+
+class ClassData(StrictModel):
+    """Per-class merged view of valuation_inputs + calibration.
+
+    Replaces the ``SimpleNamespace`` from
+    ``config_compat.build_class_data_namespace``. Same access pattern
+    (e.g. ``config.class_data[cn].nc_cal``) but type-checked.
+    """
+
+    ben_payment: float
+    retiree_pop: int
+    total_active_member: int
+    er_dc_cont_rate: float
+    val_norm_cost: float
+    nc_cal: float = 1.0
+    pvfb_term_current: float = 0.0

--- a/tests/test_pension_model/test_calibration.py
+++ b/tests/test_pension_model/test_calibration.py
@@ -33,11 +33,14 @@ def calibration_results():
     # Load with calibration file to get cal_factor (a calibration parameter,
     # not plan design), but neutralize nc_cal and pvfb_term_current so the
     # calibration module re-derives them from scratch.
+    from pension_model.schemas import ClassCalibration
+
     constants = load_plan_config_by_name("frs")
-    # Reset per-class calibration values to neutral in the underlying dict
-    for cn in constants.calibration:
-        constants.calibration[cn]["nc_cal"] = 1.0
-        constants.calibration[cn]["pvfb_term_current"] = 0.0
+    # Reset per-class calibration values to neutral. The typed
+    # ClassCalibration is frozen, so swap the dict entries.
+    neutral = ClassCalibration(nc_cal=1.0, pvfb_term_current=0.0)
+    for cn in list(constants.calibration):
+        constants.calibration[cn] = neutral
     targets = build_targets_from_config(constants)
 
     liability = run_plan_pipeline(constants)

--- a/tests/test_pension_model/test_multi_class_gainloss.py
+++ b/tests/test_pension_model/test_multi_class_gainloss.py
@@ -38,8 +38,10 @@ def two_class_gainloss_outputs():
 
     sole_class = constants.classes[0]
     one_liab = liability[sole_class]
+    from pension_model.schemas import ClassCalibration
+
     one_vi = constants.valuation_inputs[sole_class]
-    one_cal = constants.calibration.get(sole_class, {})
+    one_cal = constants.calibration.get(sole_class) or ClassCalibration()
     init_row = funding_inputs["init_funding"].iloc[0].to_dict()
 
     new_constants = dataclasses.replace(

--- a/tests/test_pension_model/test_schemas.py
+++ b/tests/test_pension_model/test_schemas.py
@@ -15,7 +15,9 @@ from pension_model.schemas import (
     AgeGroup,
     AvaSmoothing,
     Benefit,
+    Calibration,
     CashBalance,
+    ClassCalibration,
     Cola,
     CorridorAvaSmoothing,
     DcSpec,
@@ -25,11 +27,14 @@ from pension_model.schemas import (
     GainLossAvaSmoothing,
     LegDef,
     Modeling,
+    PlanDesign,
+    PlanDesignRatios,
     RampSpec,
     Ranges,
     RateComponentSpec,
     RateScheduleEntry,
     StatutoryRates,
+    ValuationInputs,
 )
 
 
@@ -465,3 +470,119 @@ class TestBenefit:
     def test_extra_field_raises(self):
         with pytest.raises(ValidationError, match="bogus"):
             Benefit.model_validate(self._valid(bogus=1))
+
+
+# ---------------------------------------------------------------------------
+# ValuationInputs
+# ---------------------------------------------------------------------------
+
+
+class TestValuationInputs:
+    def _valid(self, **overrides):
+        base = {
+            "ben_payment": 1.0e9,
+            "retiree_pop": 1000,
+            "total_active_member": 5000,
+            "val_norm_cost": 0.10,
+        }
+        base.update(overrides)
+        return base
+
+    def test_minimal_loads(self):
+        v = ValuationInputs.model_validate(self._valid())
+        assert v.ben_payment == 1.0e9
+        assert v.er_dc_cont_rate == 0.0  # default
+        assert v.headcount_group is None
+
+    def test_with_headcount_group(self):
+        v = ValuationInputs.model_validate(
+            self._valid(headcount_group=["a", "b", "c"])
+        )
+        assert v.headcount_group == ["a", "b", "c"]
+
+    def test_missing_required_raises(self):
+        with pytest.raises(ValidationError, match="ben_payment"):
+            ValuationInputs.model_validate({
+                "retiree_pop": 1000,
+                "total_active_member": 5000,
+                "val_norm_cost": 0.10,
+            })
+
+    def test_extra_field_raises(self):
+        with pytest.raises(ValidationError, match="extra_thing"):
+            ValuationInputs.model_validate(self._valid(extra_thing=1))
+
+
+# ---------------------------------------------------------------------------
+# Calibration + ClassCalibration
+# ---------------------------------------------------------------------------
+
+
+class TestCalibration:
+    def test_classcalibration_defaults(self):
+        c = ClassCalibration.model_validate({})
+        assert c.nc_cal == 1.0
+        assert c.pvfb_term_current == 0.0
+
+    def test_calibration_loads_classes_dict(self):
+        c = Calibration.model_validate({
+            "cal_factor": 0.9,
+            "classes": {
+                "regular": {"nc_cal": 0.985, "pvfb_term_current": 6e9},
+                "special": {"nc_cal": 1.0, "pvfb_term_current": 0.0},
+            },
+        })
+        assert c.cal_factor == 0.9
+        assert isinstance(c.classes["regular"], ClassCalibration)
+        assert c.classes["regular"].nc_cal == 0.985
+
+    def test_documentation_fields_optional(self):
+        c = Calibration.model_validate({
+            "description": "FRS 2022 calibration",
+            "cal_factor": 0.9,
+        })
+        assert c.description == "FRS 2022 calibration"
+
+    def test_extra_admitted(self):
+        # Calibration uses extra="allow" so future fields don't break.
+        c = Calibration.model_validate({"future_field": "ok"})
+        assert "future_field" in (c.model_extra or {})
+
+
+# ---------------------------------------------------------------------------
+# PlanDesign + PlanDesignRatios
+# ---------------------------------------------------------------------------
+
+
+class TestPlanDesign:
+    def test_db_triple_with_full_fields(self):
+        r = PlanDesignRatios.model_validate({
+            "before_cutoff": 0.95,
+            "after_cutoff": 0.85,
+            "new": 0.75,
+        })
+        assert r.db_triple() == (0.95, 0.85, 0.75)
+
+    def test_db_triple_after_defaults_to_before(self):
+        r = PlanDesignRatios.model_validate({"before_cutoff": 0.75})
+        assert r.db_triple() == (0.75, 0.75, 1.0)
+
+    def test_db_triple_uses_new_db_when_new_absent(self):
+        r = PlanDesignRatios.model_validate({"before_cutoff": 1.0, "new_db": 0.5})
+        assert r.db_triple() == (1.0, 1.0, 0.5)
+
+    def test_cb_triple_defaults_to_zero(self):
+        r = PlanDesignRatios.model_validate({})
+        assert r.cb_triple() == (0.0, 0.0, 0.0)
+
+    def test_groups_promoted_to_typed_at_parse(self):
+        pd = PlanDesign.model_validate({
+            "cutoff_year": 2018,
+            "regular_group": {"before_cutoff": 0.75, "new": 0.25},
+            "special_group": {"before_cutoff": 0.95, "after_cutoff": 0.85, "new": 0.75},
+        })
+        assert pd.cutoff_year == 2018
+        assert isinstance(pd.group("regular_group"), PlanDesignRatios)
+        assert pd.group("regular_group").before_cutoff == 0.75
+        assert set(pd.groups) == {"regular_group", "special_group"}
+        assert pd.group("missing") is None


### PR DESCRIPTION
Fourth PR of the pydantic schema migration. Closes #154. Builds on #149, #151, #153.

Migrates the per-class data bundle: \`valuation_inputs\` (per-class plan_config block), \`calibration\` (top-level \`calibration.json\` plus per-class entries), and \`plan_design\` (per-group ratios + cutoff_year) — plus the merged \`class_data\` view that \`build_class_data_namespace\` produced.

## What's new

| Module | Models |
|---|---|
| \`schemas/valuation_inputs.py\` | \`ValuationInputs\` (per-class snapshot) and \`ClassData\` (merged valuation+calibration view) |
| \`schemas/calibration.py\` | \`ClassCalibration\` and \`Calibration\` (calibration.json top-level) |
| \`schemas/plan_design.py\` | \`PlanDesignRatios\` (per-group ratios) and \`PlanDesign\` (top-level with cutoff_year + dynamic group map) |

**\`PlanDesign\` shape note.** Group names depend on the plan's \`class_groups\` configuration (FRS uses \`regular_group\` / \`special_group\`; TXTRS uses \`default\`). The model uses \`extra=\"allow\"\` to admit them, and a \`model_validator(mode=\"after\")\` promotes each raw group dict to a typed \`PlanDesignRatios\` at parse time. Consumers access via \`plan_design.group(name)\` (returns Optional[PlanDesignRatios]) or \`plan_design.groups\` (full dict).

## PlanConfig migration

- \`valuation_inputs: Dict[str, dict]\` → \`Dict[str, ValuationInputs]\`.
- \`calibration: Dict[str, dict]\` → \`Dict[str, ClassCalibration]\`.
- \`plan_design_defs: dict\` → typed \`plan_design: PlanDesign\` (legacy \`plan_design_defs\` @property kept as dict-dump for backward compat).
- \`class_data\` @property builds \`Dict[str, ClassData]\` (typed) instead of \`Dict[str, SimpleNamespace]\`.
- \`get_design_ratios\` and \`get_class_inputs\` reworked to use typed access.
- \`PlanDesignRatios\` exposes \`db_triple()\` and \`cb_triple()\` helpers that apply today's defaulting rules cleanly.

## Loader

- \`_load_calibration_data\` parses \`calibration.json\` via the \`Calibration\` model and returns typed per-class data.
- \`load_plan_config\` builds typed valuation_inputs dict and PlanDesign model before constructing PlanConfig.

## Consumer fixes

- \`config_validation.validate_config\`: typed attribute access on valuation_inputs / calibration entries; \`er_dc_cont_rate\` check refined.
- \`core/data_loader.py\`: \`hc_group = acfr.headcount_group\` instead of \`acfr.get(\"headcount_group\")\`.
- \`core/calibration.py:build_targets_from_config\`: typed access on valuation_inputs entries.
- \`test_calibration\` fixture: \`ClassCalibration\` is frozen; reset by swapping dict entries with neutral instance.
- \`test_multi_class_gainloss\`: missing-class fallback uses \`ClassCalibration()\` instead of \`{}\`.

## config_compat.py is now empty

\`build_class_data_namespace\` deleted (replaced by the typed @property). Module kept as an import-stable home for any future helpers; \`SimpleNamespace\` import dropped from \`config_schema.py\` (resolves the lint warning from PR 3).

## Validation

- \`make r-match\` — 8/8 truth-table cells pass at relative diff < 1e-10.
- \`make test\` — 391 passed (was 378 + 13 new schema tests), 2 skipped.

## Diff

13 files, +466 / -82. Most additions are model definitions and tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)