### PR TITLE
Pydantic schema migration — PR 5: BenefitMultipliers

### DIFF
--- a/src/pension_model/config_loading.py
+++ b/src/pension_model/config_loading.py
@@ -12,6 +12,7 @@ from typing import Dict, Optional
 from pension_model.config_schema import PlanConfig
 from pension_model.schemas import (
     Benefit,
+    BenefitMultipliers,
     Calibration,
     ClassCalibration,
     Decrements,
@@ -224,6 +225,9 @@ def load_plan_config(
         cn: ValuationInputs.model_validate(v)
         for cn, v in raw.get("valuation_inputs", {}).items()
     }
+    benefit_mult_model = BenefitMultipliers.model_validate(
+        raw.get("benefit_multipliers", {})
+    )
 
     config = PlanConfig(
         plan_name=raw["plan_name"],
@@ -232,7 +236,7 @@ def load_plan_config(
         classes=tuple(raw["classes"]),
         class_groups=raw.get("class_groups", {}),
         tier_defs=tuple(raw.get("tiers", [])),
-        benefit_mult_defs=raw.get("benefit_multipliers", {}),
+        benefit_mult_defs=benefit_mult_model,
         plan_design=plan_design_model,
         valuation_inputs=valuation_models,
         economic=economic_model,

--- a/src/pension_model/config_resolvers_scalar.py
+++ b/src/pension_model/config_resolvers_scalar.py
@@ -96,34 +96,22 @@ def get_ben_mult(
     yos: int,
     dist_year: int = 0,
 ) -> float:
-    class_rules = config.benefit_mult_defs.get(class_name)
-    if class_rules is None:
+    rules = config.resolve_ben_mult(class_name, tier_name)
+    if rules is None:
         return float("nan")
 
-    if "all_tiers" in class_rules:
-        rules = class_rules["all_tiers"]
-    else:
-        rules = class_rules.get(tier_name)
-        if rules is None:
-            for key in class_rules:
-                if key.endswith("_same_as") and key.replace("_same_as", "") == tier_name:
-                    rules = class_rules.get(class_rules[key])
-                    break
-        if rules is None:
-            return float("nan")
+    if rules.flat is not None:
+        if rules.flat_before_year is not None and dist_year <= rules.flat_before_year.year:
+            return rules.flat_before_year.mult
+        return rules.flat
 
-    if "flat" in rules:
-        if "flat_before_year" in rules and dist_year <= rules["flat_before_year"]["year"]:
-            return rules["flat_before_year"]["mult"]
-        return rules["flat"]
-
-    if "graded" in rules:
-        for entry in rules["graded"]:
-            for cond in entry["or"]:
-                if _matches_condition(cond, dist_age, yos):
-                    return entry["mult"]
-        if status == "early" and "early_fallback" in rules:
-            return rules["early_fallback"]
+    if rules.graded is not None:
+        for entry in rules.graded:
+            for cond in entry.or_:
+                if _matches_condition(cond.model_dump(exclude_none=True), dist_age, yos):
+                    return entry.mult
+        if status == "early" and rules.early_fallback is not None:
+            return rules.early_fallback
         return float("nan")
 
     return float("nan")

--- a/src/pension_model/config_resolvers_vectorized.py
+++ b/src/pension_model/config_resolvers_vectorized.py
@@ -18,7 +18,6 @@ from pension_model.config_resolver_common import (
     _matches_any_vec,
     _matches_condition_vec,
     _reduce_condition_vec,
-    _resolve_ben_mult_rules,
     _resolve_tier_def,
 )
 
@@ -241,10 +240,9 @@ def resolve_ben_mult_vec(
     for class_name_value, tier_index, idx_arr in _iter_class_tier_groups(
         class_name, tier_id, n_tiers
     ):
-        class_rules = config.benefit_mult_defs.get(class_name_value)
-        if class_rules is None:
-            continue
-        rules = _resolve_ben_mult_rules(class_rules, config._tier_id_to_name[tier_index])
+        rules = config.resolve_ben_mult(
+            class_name_value, config._tier_id_to_name[tier_index]
+        )
         if rules is None:
             continue
 
@@ -252,28 +250,30 @@ def resolve_ben_mult_vec(
         sub_yos = yos[idx_arr]
         sub_year = dist_year[idx_arr]
 
-        if "flat" in rules:
-            vals = np.full(len(idx_arr), rules["flat"], dtype=np.float64)
-            if "flat_before_year" in rules:
-                before = rules["flat_before_year"]
-                vals = np.where(sub_year <= before["year"], before["mult"], vals)
+        if rules.flat is not None:
+            vals = np.full(len(idx_arr), rules.flat, dtype=np.float64)
+            if rules.flat_before_year is not None:
+                before = rules.flat_before_year
+                vals = np.where(sub_year <= before.year, before.mult, vals)
             result[idx_arr] = vals
             continue
 
-        if "graded" in rules:
+        if rules.graded is not None:
             sub_vals = np.full(len(idx_arr), np.nan, dtype=np.float64)
             assigned = np.zeros(len(idx_arr), dtype=bool)
-            for entry in rules["graded"]:
+            for entry in rules.graded:
                 entry_mask = np.zeros(len(idx_arr), dtype=bool)
-                for cond in entry["or"]:
-                    entry_mask |= _matches_condition_vec(cond, sub_age, sub_yos)
+                for cond in entry.or_:
+                    entry_mask |= _matches_condition_vec(
+                        cond.model_dump(exclude_none=True), sub_age, sub_yos
+                    )
                 new_assign = entry_mask & ~assigned
                 if new_assign.any():
-                    sub_vals[new_assign] = entry["mult"]
+                    sub_vals[new_assign] = entry.mult
                     assigned |= new_assign
-            if "early_fallback" in rules:
+            if rules.early_fallback is not None:
                 fallback_mask = ~assigned & (ret_status[idx_arr] == EARLY)
-                sub_vals[fallback_mask] = rules["early_fallback"]
+                sub_vals[fallback_mask] = rules.early_fallback
             result[idx_arr] = sub_vals
 
     return result

--- a/src/pension_model/config_schema.py
+++ b/src/pension_model/config_schema.py
@@ -7,12 +7,14 @@ from typing import Dict, List, Optional, Tuple
 from pension_model.config_validation import validate_config, validate_data_files
 from pension_model.schemas import (
     Benefit,
+    BenefitMultipliers,
     ClassCalibration,
     ClassData,
     Decrements,
     Economic,
     Funding,
     Modeling,
+    MultiplierRules,
     PlanDesign,
     Ranges,
     ValuationInputs,
@@ -33,7 +35,7 @@ class PlanConfig:
     classes: Tuple[str, ...]
     class_groups: Dict[str, List[str]]
     tier_defs: Tuple[dict, ...]
-    benefit_mult_defs: dict
+    benefit_mult_defs: BenefitMultipliers
     plan_design: PlanDesign
     valuation_inputs: Dict[str, ValuationInputs]
     economic: Economic
@@ -378,6 +380,17 @@ class PlanConfig:
 
     def class_group(self, class_name: str) -> str:
         return self._class_to_group.get(class_name, "default")
+
+    def resolve_ben_mult(
+        self, class_name: str, tier_name: str
+    ) -> Optional[MultiplierRules]:
+        """Look up the typed :class:`MultiplierRules` for a (class, tier).
+
+        Encapsulates the ``all_tiers`` / ``<tier>_same_as`` / direct
+        resolution so consumers don't have to thread the lookup logic
+        through dict access.
+        """
+        return self.benefit_mult_defs.resolve(class_name, tier_name)
 
     def get_class_inputs(self, class_name: str) -> dict:
         valuation = self.valuation_inputs.get(class_name)

--- a/src/pension_model/schemas/__init__.py
+++ b/src/pension_model/schemas/__init__.py
@@ -24,7 +24,15 @@ from pension_model.schemas.benefit import (
     Cola,
     DcSpec,
 )
+from pension_model.schemas.benefit_multipliers import (
+    BenefitMultipliers,
+    ClassMultipliers,
+    FlatBeforeYear,
+    GradedRule,
+    MultiplierRules,
+)
 from pension_model.schemas.calibration import Calibration, ClassCalibration
+from pension_model.schemas.conditions import Condition
 from pension_model.schemas.decrements import Decrements
 from pension_model.schemas.economic import Economic
 from pension_model.schemas.funding import (
@@ -48,19 +56,25 @@ __all__ = [
     "AgeGroup",
     "AvaSmoothing",
     "Benefit",
+    "BenefitMultipliers",
     "Calibration",
     "CashBalance",
     "ClassCalibration",
     "ClassData",
+    "ClassMultipliers",
     "Cola",
+    "Condition",
     "CorridorAvaSmoothing",
     "DcSpec",
     "Decrements",
     "Economic",
+    "FlatBeforeYear",
     "Funding",
     "GainLossAvaSmoothing",
+    "GradedRule",
     "LegDef",
     "Modeling",
+    "MultiplierRules",
     "PlanDesign",
     "PlanDesignRatios",
     "RampSpec",

--- a/src/pension_model/schemas/benefit_multipliers.py
+++ b/src/pension_model/schemas/benefit_multipliers.py
@@ -1,0 +1,177 @@
+"""Schema for the ``benefit_multipliers`` block of plan_config.json.
+
+Structure:
+
+* Top level: keyed by class name (``regular``, ``special``, ``all``, …).
+* Per-class: keyed by tier name (``tier_1``, ``tier_2``, …) or
+  ``all_tiers`` (single rules block applied to every tier of that
+  class). Plans can also declare a ``<tier_name>_same_as`` key whose
+  value is a string naming another tier — the alias resolves at
+  lookup time.
+* Per-tier (or ``all_tiers``): a :class:`MultiplierRules` block with
+  one of the supported rule shapes (flat, graded, etc.).
+
+Tier and class names are dynamic by plan, so ``BenefitMultipliers``
+and ``ClassMultipliers`` use ``extra="allow"``. A ``model_validator``
+promotes the raw extras to typed sub-models at parse time.
+"""
+
+from __future__ import annotations
+
+from typing import Optional, Union
+
+from pydantic import ConfigDict, Field, model_validator
+
+from pension_model.schemas.base import StrictModel
+from pension_model.schemas.conditions import Condition
+
+
+class FlatBeforeYear(StrictModel):
+    """Override the flat multiplier with ``mult`` for distribution
+    years on or before ``year``."""
+
+    year: int
+    mult: float
+
+
+class GradedRule(StrictModel):
+    """One row in a graded multiplier table.
+
+    The rule fires when **any** of the conditions in ``or_`` match
+    (logical OR over the list). The corresponding ``mult`` is then
+    used as the benefit multiplier.
+    """
+
+    or_: list[Condition] = Field(alias="or")
+    mult: float
+
+    # The JSON key is ``or`` (a Python keyword); we expose it as
+    # ``or_`` on the model. ``populate_by_name`` lets callers also
+    # construct via ``GradedRule(or_=...)`` programmatically.
+    model_config = ConfigDict(extra="forbid", frozen=True, populate_by_name=True)
+
+
+class MultiplierRules(StrictModel):
+    """Multiplier-rules block for one (class, tier) pair.
+
+    Exactly one of ``flat`` or ``graded`` is the primary rule
+    (validated). ``flat_before_year`` overrides ``flat`` for early
+    years; ``early_fallback`` is used as the multiplier when
+    ``status == "early"`` and no graded entry matched.
+    """
+
+    flat: Optional[float] = None
+    flat_before_year: Optional[FlatBeforeYear] = None
+    graded: Optional[list[GradedRule]] = None
+    early_fallback: Optional[float] = None
+
+    @model_validator(mode="after")
+    def _check_primary_rule(self) -> "MultiplierRules":
+        if self.flat is None and self.graded is None:
+            raise ValueError(
+                "MultiplierRules: must declare either 'flat' or 'graded' "
+                "as the primary rule. Neither was provided."
+            )
+        if self.flat is not None and self.graded is not None:
+            raise ValueError(
+                "MultiplierRules: 'flat' and 'graded' are mutually "
+                "exclusive primary rules. Pick one."
+            )
+        if self.flat_before_year is not None and self.flat is None:
+            raise ValueError(
+                "MultiplierRules: 'flat_before_year' requires 'flat' to "
+                "be the primary rule."
+            )
+        return self
+
+
+# Per-class entry: either typed rules or a string alias (``_same_as``).
+_PerClassEntry = Union[MultiplierRules, str]
+
+
+class ClassMultipliers(StrictModel):
+    """Per-class benefit-multiplier block.
+
+    Keys are tier names, ``all_tiers``, or ``<tier_name>_same_as``
+    strings. Values are :class:`MultiplierRules` (for tier names and
+    ``all_tiers``) or a string naming the target tier (for
+    ``_same_as`` aliases). ``extra="allow"`` admits the dynamic key
+    set; the validator promotes raw entries.
+    """
+
+    model_config = ConfigDict(extra="allow", frozen=True)
+
+    @model_validator(mode="after")
+    def _promote_entries(self) -> "ClassMultipliers":
+        if not self.model_extra:
+            return self
+        promoted = {}
+        for key, raw in self.model_extra.items():
+            if isinstance(raw, str):
+                # ``<tier>_same_as`` alias — keep as string.
+                promoted[key] = raw
+            elif isinstance(raw, MultiplierRules):
+                promoted[key] = raw
+            else:
+                promoted[key] = MultiplierRules.model_validate(raw)
+        object.__setattr__(self, "__pydantic_extra__", promoted)
+        return self
+
+    def resolve(self, tier_name: str) -> Optional[MultiplierRules]:
+        """Look up the multiplier rules for a tier.
+
+        Resolution order:
+          1. ``all_tiers`` if present (single rules block for every tier).
+          2. Direct match on ``tier_name``.
+          3. ``<tier_name>_same_as`` alias — recurse on the target.
+
+        Returns None if no rules match.
+        """
+        entries = self.model_extra or {}
+        if "all_tiers" in entries:
+            return entries["all_tiers"]
+        rules = entries.get(tier_name)
+        if rules is None:
+            alias_key = f"{tier_name}_same_as"
+            if alias_key in entries and isinstance(entries[alias_key], str):
+                return self.resolve(entries[alias_key])
+        return rules
+
+
+class BenefitMultipliers(StrictModel):
+    """Top-level benefit_multipliers block.
+
+    Keys are class names. Values are :class:`ClassMultipliers`
+    (admitted as extras and promoted at parse time).
+    """
+
+    model_config = ConfigDict(extra="allow", frozen=True)
+
+    @model_validator(mode="after")
+    def _promote_classes(self) -> "BenefitMultipliers":
+        if not self.model_extra:
+            return self
+        promoted = {}
+        for class_name, raw in self.model_extra.items():
+            if isinstance(raw, ClassMultipliers):
+                promoted[class_name] = raw
+            else:
+                promoted[class_name] = ClassMultipliers.model_validate(raw)
+        object.__setattr__(self, "__pydantic_extra__", promoted)
+        return self
+
+    def resolve(self, class_name: str, tier_name: str) -> Optional[MultiplierRules]:
+        """Look up multiplier rules for a (class, tier) pair.
+
+        Returns None if the class isn't declared or has no matching
+        tier rules.
+        """
+        class_rules = (self.model_extra or {}).get(class_name)
+        if class_rules is None:
+            return None
+        return class_rules.resolve(tier_name)
+
+    def class_multipliers(self, class_name: str) -> Optional[ClassMultipliers]:
+        """Return the typed ClassMultipliers for ``class_name``,
+        or None if absent."""
+        return (self.model_extra or {}).get(class_name)

--- a/src/pension_model/schemas/conditions.py
+++ b/src/pension_model/schemas/conditions.py
@@ -1,0 +1,39 @@
+"""Shared predicate types used by both eligibility rules and benefit-multiplier
+graded tables.
+
+Eligibility and graded multipliers both express "this rule applies when the
+member meets these conditions" — same shape, same set of fields. The schema
+keeps a single :class:`Condition` model so both consumers can reuse it.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from pension_model.schemas.base import StrictModel
+
+
+class Condition(StrictModel):
+    """A single predicate over (age, yos, entry_year).
+
+    A condition matches a member when **every** declared field is
+    satisfied. Missing fields don't constrain anything. Today's
+    supported fields:
+
+    * ``min_age`` — member's age >= this.
+    * ``min_yos`` — member's years of service >= this.
+    * ``rule_of`` — age + yos >= this (the "rule of N" pattern).
+
+    Plans express OR-combinations as a list of conditions inside a
+    higher-level container (e.g. ``GradedRule.or_`` or eligibility
+    rule lists).
+
+    A condition with no fields set is "always true" — used as a
+    catch-all in :class:`pension_model.schemas.tier_def`-style
+    early-retire-reduction rules. (Today's eligibility rules don't
+    use the empty form.)
+    """
+
+    min_age: Optional[int] = None
+    min_yos: Optional[int] = None
+    rule_of: Optional[int] = None

--- a/tests/test_pension_model/test_schemas.py
+++ b/tests/test_pension_model/test_schemas.py
@@ -15,18 +15,24 @@ from pension_model.schemas import (
     AgeGroup,
     AvaSmoothing,
     Benefit,
+    BenefitMultipliers,
     Calibration,
     CashBalance,
     ClassCalibration,
+    ClassMultipliers,
     Cola,
+    Condition,
     CorridorAvaSmoothing,
     DcSpec,
     Decrements,
     Economic,
+    FlatBeforeYear,
     Funding,
     GainLossAvaSmoothing,
+    GradedRule,
     LegDef,
     Modeling,
+    MultiplierRules,
     PlanDesign,
     PlanDesignRatios,
     RampSpec,
@@ -586,3 +592,118 @@ class TestPlanDesign:
         assert pd.group("regular_group").before_cutoff == 0.75
         assert set(pd.groups) == {"regular_group", "special_group"}
         assert pd.group("missing") is None
+
+
+# ---------------------------------------------------------------------------
+# Condition (shared predicate)
+# ---------------------------------------------------------------------------
+
+
+class TestCondition:
+    def test_empty_condition_loads(self):
+        c = Condition.model_validate({})
+        assert c.min_age is None and c.min_yos is None and c.rule_of is None
+
+    def test_typical_fields(self):
+        c = Condition.model_validate({"min_age": 65, "min_yos": 6})
+        assert c.min_age == 65
+        assert c.min_yos == 6
+
+    def test_extra_field_raises(self):
+        with pytest.raises(ValidationError, match="bogus"):
+            Condition.model_validate({"min_age": 65, "bogus": 1})
+
+
+# ---------------------------------------------------------------------------
+# MultiplierRules (primary-rule mutual exclusion)
+# ---------------------------------------------------------------------------
+
+
+class TestMultiplierRules:
+    def test_flat_only_loads(self):
+        r = MultiplierRules.model_validate({"flat": 0.023})
+        assert r.flat == 0.023
+
+    def test_graded_only_loads(self):
+        r = MultiplierRules.model_validate({
+            "graded": [
+                {"or": [{"min_age": 65}], "mult": 0.02},
+            ],
+        })
+        assert r.graded is not None
+        assert len(r.graded) == 1
+        assert r.graded[0].mult == 0.02
+        assert r.graded[0].or_[0].min_age == 65
+
+    def test_flat_with_flat_before_year(self):
+        r = MultiplierRules.model_validate({
+            "flat": 0.03,
+            "flat_before_year": {"year": 1974, "mult": 0.02},
+        })
+        assert r.flat_before_year is not None
+        assert r.flat_before_year.year == 1974
+
+    def test_neither_flat_nor_graded_raises(self):
+        with pytest.raises(ValidationError, match="must declare either"):
+            MultiplierRules.model_validate({"early_fallback": 0.01})
+
+    def test_both_flat_and_graded_raises(self):
+        with pytest.raises(ValidationError, match="mutually exclusive"):
+            MultiplierRules.model_validate({
+                "flat": 0.02,
+                "graded": [{"or": [{"min_age": 65}], "mult": 0.02}],
+            })
+
+    def test_flat_before_year_without_flat_raises(self):
+        with pytest.raises(ValidationError, match="requires 'flat'"):
+            MultiplierRules.model_validate({
+                "graded": [{"or": [{"min_age": 65}], "mult": 0.02}],
+                "flat_before_year": {"year": 1974, "mult": 0.02},
+            })
+
+
+# ---------------------------------------------------------------------------
+# BenefitMultipliers (lookup + same_as resolution)
+# ---------------------------------------------------------------------------
+
+
+class TestBenefitMultipliers:
+    def _frs_like(self):
+        return {
+            "regular": {
+                "tier_1": {"flat": 0.0168},
+                "tier_2": {"flat": 0.016},
+                "tier_3_same_as": "tier_2",
+            },
+            "judges": {
+                "all_tiers": {"flat": 0.0333},
+            },
+        }
+
+    def test_resolve_direct_tier(self):
+        bm = BenefitMultipliers.model_validate(self._frs_like())
+        rules = bm.resolve("regular", "tier_1")
+        assert isinstance(rules, MultiplierRules)
+        assert rules.flat == 0.0168
+
+    def test_resolve_all_tiers(self):
+        bm = BenefitMultipliers.model_validate(self._frs_like())
+        rules = bm.resolve("judges", "tier_1")
+        assert rules is not None and rules.flat == 0.0333
+        # Any tier name resolves the same way under all_tiers.
+        assert bm.resolve("judges", "tier_99").flat == 0.0333
+
+    def test_resolve_same_as_alias(self):
+        bm = BenefitMultipliers.model_validate(self._frs_like())
+        rules = bm.resolve("regular", "tier_3")
+        assert rules is not None and rules.flat == 0.016  # tier_2's value
+
+    def test_resolve_unknown_class(self):
+        bm = BenefitMultipliers.model_validate(self._frs_like())
+        assert bm.resolve("nonexistent", "tier_1") is None
+
+    def test_resolve_unknown_tier(self):
+        bm = BenefitMultipliers.model_validate({
+            "regular": {"tier_1": {"flat": 0.02}},
+        })
+        assert bm.resolve("regular", "tier_2") is None


### PR DESCRIPTION
Fifth PR of the pydantic schema migration. Closes #156. Builds on #149, #151, #153, #155.

Migrates \`benefit_multipliers\` (class × tier nested) to typed pydantic models. Introduces a shared \`Condition\` predicate type that PR 6 (Eligibility) will reuse — same \`min_age\` / \`min_yos\` / \`rule_of\` shape.

## What's new

### \`schemas/conditions.py\` — shared

| Model | Purpose |
|---|---|
| \`Condition\` | Typed \`{min_age?, min_yos?, rule_of?}\`. Reused by \`BenefitMultipliers\` (this PR) and \`Eligibility\` (PR 6). |

### \`schemas/benefit_multipliers.py\`

| Model | Purpose |
|---|---|
| \`FlatBeforeYear\` | \`{year, mult}\`. |
| \`GradedRule\` | \`{or: list[Condition], mult}\`. The JSON key \`or\` exposed as \`or_\` on the model (Python keyword); \`Field(alias=\"or\")\` + \`populate_by_name\`. |
| \`MultiplierRules\` | Leaf rules block. Validators enforce mutual exclusion of \`flat\` / \`graded\` and that \`flat_before_year\` requires \`flat\`. |
| \`ClassMultipliers\` | Per-class block. \`extra=\"allow\"\` admits dynamic tier-name keys; \`model_validator\` promotes raw dicts to \`MultiplierRules\` (or keeps strings for \`*_same_as\`). \`resolve(tier_name)\` method encapsulates the \`all_tiers\` / direct / \`same_as\` lookup. |
| \`BenefitMultipliers\` | Top-level. \`resolve(class_name, tier_name)\` helper for the full lookup. |

## PlanConfig migration

- \`benefit_mult_defs: dict\` → \`BenefitMultipliers\` (typed).
- New helper \`PlanConfig.resolve_ben_mult(class_name, tier_name) -> Optional[MultiplierRules]\`.

## Consumer fixes

- **\`get_ben_mult\`** (scalar) — typed attribute access (\`rules.flat\`, \`rules.graded\`, \`entry.or_\`). Conditions converted to dict via \`cond.model_dump(exclude_none=True)\` for the existing \`_matches_condition\` helper (which still works on dicts).
- **\`resolve_ben_mult_vec\`** (vectorized) — same pattern. Removed import of \`_resolve_ben_mult_rules\` (resolution now happens in the typed model).

## Validation

- \`make r-match\` — 8/8 truth-table cells pass at relative diff < 1e-10.
- \`make test\` — 405 passed (was 391 + 14 new schema tests), 2 skipped.

## Diff

8 files, +401 / -45.

🤖 Generated with [Claude Code](https://claude.com/claude-code)