### PR TITLE
Pydantic schema migration — PR 6: EligibilitySpec

### DIFF
--- a/src/pension_model/config_resolver_common.py
+++ b/src/pension_model/config_resolver_common.py
@@ -41,7 +41,15 @@ def _resolve_tier_def(tier_name: str, tier_defs: tuple) -> dict:
     raise ValueError(f"Unknown tier: {tier_name}")
 
 
-def _get_eligibility(tier_def: dict, group: str, all_tier_defs: tuple) -> dict:
+def _get_eligibility(tier_def: dict, group: str, all_tier_defs: tuple):
+    """Resolve a tier's eligibility for ``group`` to a typed
+    :class:`EligibilitySpec`, following ``eligibility_same_as``
+    references. Returns None when no matching eligibility (or
+    ``default`` fallback) exists — today this happens only for
+    DROP-shaped tier defs and similar edge cases.
+    """
+    from pension_model.schemas import EligibilitySpec  # local to avoid cycle
+
     current = tier_def
     seen = set()
     while "eligibility_same_as" in current:
@@ -52,7 +60,10 @@ def _get_eligibility(tier_def: dict, group: str, all_tier_defs: tuple) -> dict:
         current = _resolve_tier_def(ref, all_tier_defs)
 
     eligibility = current["eligibility"]
-    return eligibility.get(group, eligibility.get("default", {}))
+    raw = eligibility.get(group, eligibility.get("default"))
+    if raw is None:
+        return None
+    return EligibilitySpec.model_validate(raw)
 
 
 def _entry_year_in_tier(entry_year: int, tier_def: dict, new_year: int) -> bool:

--- a/src/pension_model/config_resolvers_scalar.py
+++ b/src/pension_model/config_resolvers_scalar.py
@@ -10,8 +10,6 @@ from pension_model.config_resolver_common import (
     _get_eligibility,
     _is_grandfathered,
     _lookup_reduce_table,
-    _matches_any,
-    _matches_condition,
     _resolve_tier_def,
 )
 
@@ -71,17 +69,16 @@ def get_tier(
     tier_name = matched_tier["name"]
     eligibility = _get_eligibility(matched_tier, group, config.tier_defs)
 
-    if not eligibility:
+    if eligibility is None:
         return tier_name, "non_vested"
 
-    if _matches_any(eligibility.get("normal", []), age, yos, entry_year, entry_age):
+    if eligibility.matches_normal(age, yos):
         return tier_name, "norm"
 
-    if _matches_any(eligibility.get("early", []), age, yos, entry_year, entry_age):
+    if eligibility.matches_early(age, yos):
         return tier_name, "early"
 
-    vesting_yos = eligibility["vesting_yos"]
-    if yos >= vesting_yos:
+    if yos >= eligibility.vesting_yos:
         return tier_name, "vested"
 
     return tier_name, "non_vested"
@@ -108,7 +105,7 @@ def get_ben_mult(
     if rules.graded is not None:
         for entry in rules.graded:
             for cond in entry.or_:
-                if _matches_condition(cond.model_dump(exclude_none=True), dist_age, yos):
+                if cond.matches(dist_age, yos):
                     return entry.mult
         if status == "early" and rules.early_fallback is not None:
             return rules.early_fallback

--- a/src/pension_model/config_resolvers_vectorized.py
+++ b/src/pension_model/config_resolvers_vectorized.py
@@ -15,8 +15,6 @@ from pension_model.config_resolver_common import (
     _get_eligibility,
     _is_grandfathered_vec,
     _lookup_reduce_table,
-    _matches_any_vec,
-    _matches_condition_vec,
     _reduce_condition_vec,
     _resolve_tier_def,
 )
@@ -165,14 +163,14 @@ def resolve_tiers_vec(
             combo_mask = tier_mask & (group_codes == group_code)
             if not combo_mask.any():
                 continue
-            if not eligibility:
+            if eligibility is None:
                 continue
 
             sub_age = age[combo_mask]
             sub_yos = yos[combo_mask]
-            norm_mask = _matches_any_vec(eligibility.get("normal", []), sub_age, sub_yos)
-            early_mask = _matches_any_vec(eligibility.get("early", []), sub_age, sub_yos) & ~norm_mask
-            vested_mask = (sub_yos >= eligibility["vesting_yos"]) & ~norm_mask & ~early_mask
+            norm_mask = eligibility.matches_normal_vec(sub_age, sub_yos)
+            early_mask = eligibility.matches_early_vec(sub_age, sub_yos) & ~norm_mask
+            vested_mask = (sub_yos >= eligibility.vesting_yos) & ~norm_mask & ~early_mask
 
             sub_status = np.full(combo_mask.sum(), NON_VESTED, dtype=np.int8)
             sub_status[norm_mask] = NORM
@@ -264,9 +262,7 @@ def resolve_ben_mult_vec(
             for entry in rules.graded:
                 entry_mask = np.zeros(len(idx_arr), dtype=bool)
                 for cond in entry.or_:
-                    entry_mask |= _matches_condition_vec(
-                        cond.model_dump(exclude_none=True), sub_age, sub_yos
-                    )
+                    entry_mask |= cond.matches_vec(sub_age, sub_yos)
                 new_assign = entry_mask & ~assigned
                 if new_assign.any():
                     sub_vals[new_assign] = entry.mult

--- a/src/pension_model/schemas/__init__.py
+++ b/src/pension_model/schemas/__init__.py
@@ -34,6 +34,7 @@ from pension_model.schemas.benefit_multipliers import (
 from pension_model.schemas.calibration import Calibration, ClassCalibration
 from pension_model.schemas.conditions import Condition
 from pension_model.schemas.decrements import Decrements
+from pension_model.schemas.eligibility import EligibilitySpec
 from pension_model.schemas.economic import Economic
 from pension_model.schemas.funding import (
     AvaSmoothing,
@@ -68,6 +69,7 @@ __all__ = [
     "DcSpec",
     "Decrements",
     "Economic",
+    "EligibilitySpec",
     "FlatBeforeYear",
     "Funding",
     "GainLossAvaSmoothing",

--- a/src/pension_model/schemas/conditions.py
+++ b/src/pension_model/schemas/conditions.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 
 from typing import Optional
 
+import numpy as np
+
 from pension_model.schemas.base import StrictModel
 
 
@@ -29,11 +31,33 @@ class Condition(StrictModel):
     rule lists).
 
     A condition with no fields set is "always true" — used as a
-    catch-all in :class:`pension_model.schemas.tier_def`-style
-    early-retire-reduction rules. (Today's eligibility rules don't
-    use the empty form.)
+    catch-all in early-retire-reduction rules. (Today's eligibility
+    rules don't use the empty form.)
     """
 
     min_age: Optional[int] = None
     min_yos: Optional[int] = None
     rule_of: Optional[int] = None
+
+    def matches(self, age: int, yos: int) -> bool:
+        """Scalar predicate evaluation. Returns True iff all declared
+        fields are satisfied for the given (age, yos)."""
+        if self.min_age is not None and age < self.min_age:
+            return False
+        if self.min_yos is not None and yos < self.min_yos:
+            return False
+        if self.rule_of is not None and (age + yos) < self.rule_of:
+            return False
+        return True
+
+    def matches_vec(self, ages: np.ndarray, yos: np.ndarray) -> np.ndarray:
+        """Vectorized predicate evaluation. Returns a bool array
+        with one entry per (ages[i], yos[i]) pair."""
+        mask = np.ones(len(ages), dtype=bool)
+        if self.min_age is not None:
+            mask &= ages >= self.min_age
+        if self.min_yos is not None:
+            mask &= yos >= self.min_yos
+        if self.rule_of is not None:
+            mask &= (ages + yos) >= self.rule_of
+        return mask

--- a/src/pension_model/schemas/eligibility.py
+++ b/src/pension_model/schemas/eligibility.py
@@ -1,0 +1,54 @@
+"""Schema for tier eligibility rules (per (tier, group))."""
+
+from __future__ import annotations
+
+import numpy as np
+from pydantic import Field
+
+from pension_model.schemas.base import StrictModel
+from pension_model.schemas.conditions import Condition
+
+
+def _any_match_vec(conditions: list[Condition], ages: np.ndarray, yos: np.ndarray) -> np.ndarray:
+    """Vectorized OR of per-condition matches. Empty list → all-False."""
+    if not conditions:
+        return np.zeros(len(ages), dtype=bool)
+    mask = conditions[0].matches_vec(ages, yos)
+    for c in conditions[1:]:
+        mask |= c.matches_vec(ages, yos)
+    return mask
+
+
+class EligibilitySpec(StrictModel):
+    """Eligibility rules for one (tier, group) pair.
+
+    The ``normal`` and ``early`` lists are OR-combinations of
+    conditions: the member is eligible if **any** condition in the
+    list matches. ``vesting_yos`` is the years-of-service threshold
+    above which a terminated member is treated as deferred-vested
+    (rather than non-vested with refund only).
+    """
+
+    normal: list[Condition] = Field(default_factory=list)
+    early: list[Condition] = Field(default_factory=list)
+    vesting_yos: int
+
+    def matches_normal(self, age: int, yos: int) -> bool:
+        """True if any normal-retirement condition matches."""
+        return any(c.matches(age, yos) for c in self.normal)
+
+    def matches_early(self, age: int, yos: int) -> bool:
+        """True if any early-retirement condition matches."""
+        return any(c.matches(age, yos) for c in self.early)
+
+    def matches_normal_vec(
+        self, ages: np.ndarray, yos: np.ndarray
+    ) -> np.ndarray:
+        """Vectorized normal-retirement match. Returns bool array."""
+        return _any_match_vec(self.normal, ages, yos)
+
+    def matches_early_vec(
+        self, ages: np.ndarray, yos: np.ndarray
+    ) -> np.ndarray:
+        """Vectorized early-retirement match. Returns bool array."""
+        return _any_match_vec(self.early, ages, yos)

--- a/tests/test_pension_model/test_schemas.py
+++ b/tests/test_pension_model/test_schemas.py
@@ -11,6 +11,8 @@ pytestmark = [pytest.mark.unit]
 
 from pydantic import ValidationError
 
+import numpy as np
+
 from pension_model.schemas import (
     AgeGroup,
     AvaSmoothing,
@@ -26,6 +28,7 @@ from pension_model.schemas import (
     DcSpec,
     Decrements,
     Economic,
+    EligibilitySpec,
     FlatBeforeYear,
     Funding,
     GainLossAvaSmoothing,
@@ -707,3 +710,94 @@ class TestBenefitMultipliers:
             "regular": {"tier_1": {"flat": 0.02}},
         })
         assert bm.resolve("regular", "tier_2") is None
+
+
+# ---------------------------------------------------------------------------
+# Condition.matches helpers
+# ---------------------------------------------------------------------------
+
+
+class TestConditionMatches:
+    def test_min_age_only(self):
+        c = Condition(min_age=65)
+        assert c.matches(65, 0) is True
+        assert c.matches(64, 100) is False
+
+    def test_min_yos_only(self):
+        c = Condition(min_yos=30)
+        assert c.matches(20, 30) is True
+        assert c.matches(99, 29) is False
+
+    def test_rule_of(self):
+        c = Condition(rule_of=80)
+        assert c.matches(60, 20) is True  # 60+20=80
+        assert c.matches(60, 19) is False  # 79<80
+
+    def test_combined(self):
+        c = Condition(min_age=55, min_yos=5, rule_of=80)
+        assert c.matches(60, 25) is True
+        assert c.matches(54, 30) is False  # fails min_age
+
+    def test_empty_matches_anything(self):
+        c = Condition()
+        assert c.matches(0, 0) is True
+
+    def test_matches_vec(self):
+        c = Condition(min_age=55, min_yos=5)
+        ages = np.array([54, 55, 60, 65])
+        yos = np.array([10, 5, 4, 5])
+        # 54/10: fails age. 55/5: passes. 60/4: fails yos. 65/5: passes.
+        assert list(c.matches_vec(ages, yos)) == [False, True, False, True]
+
+
+# ---------------------------------------------------------------------------
+# EligibilitySpec
+# ---------------------------------------------------------------------------
+
+
+class TestEligibilitySpec:
+    def _frs_tier_1_regular(self):
+        return EligibilitySpec.model_validate({
+            "normal": [{"min_yos": 30}, {"min_age": 62, "min_yos": 6}],
+            "early": [{"min_age": 58, "min_yos": 6}],
+            "vesting_yos": 6,
+        })
+
+    def test_loads_with_typed_conditions(self):
+        e = self._frs_tier_1_regular()
+        assert e.vesting_yos == 6
+        assert all(isinstance(c, Condition) for c in e.normal)
+        assert e.normal[0].min_yos == 30
+
+    def test_matches_normal_30_yos(self):
+        e = self._frs_tier_1_regular()
+        # 30 YOS, any age → normal eligible.
+        assert e.matches_normal(50, 30) is True
+
+    def test_matches_normal_age62_6yos(self):
+        e = self._frs_tier_1_regular()
+        assert e.matches_normal(62, 6) is True
+
+    def test_matches_normal_too_young(self):
+        e = self._frs_tier_1_regular()
+        assert e.matches_normal(55, 6) is False  # neither rule fires
+
+    def test_matches_early(self):
+        e = self._frs_tier_1_regular()
+        assert e.matches_early(58, 6) is True
+        assert e.matches_early(57, 6) is False
+
+    def test_matches_vec(self):
+        e = self._frs_tier_1_regular()
+        ages = np.array([50, 58, 62])
+        yos = np.array([30, 6, 6])
+        # 50/30: normal (min_yos=30). 58/6: not normal but yes early.
+        # 62/6: normal (min_age+min_yos) AND early (min_age 58, min_yos 6).
+        assert list(e.matches_normal_vec(ages, yos)) == [True, False, True]
+        assert list(e.matches_early_vec(ages, yos)) == [False, True, True]
+
+    def test_missing_vesting_yos_raises(self):
+        with pytest.raises(ValidationError, match="vesting_yos"):
+            EligibilitySpec.model_validate({
+                "normal": [{"min_yos": 30}],
+            })


### PR DESCRIPTION
Sixth PR of the pydantic schema migration. Closes #158. Builds on #149, #151, #153, #155, #157.

Migrates eligibility blocks to typed pydantic models. Reuses the \`Condition\` predicate from PR 5; adds \`Condition.matches\` / \`matches_vec\` so consumers use typed predicates directly without dict round-trips.

## What's new

\`schemas/eligibility.py\`:
- \`EligibilitySpec\` — \`{normal: list[Condition], early: list[Condition], vesting_yos: int}\`. One block per (tier, group).
- Scalar helpers: \`matches_normal(age, yos)\`, \`matches_early(age, yos)\`.
- Vectorized helpers: \`matches_normal_vec(ages, yos)\`, \`matches_early_vec(ages, yos)\`.

\`schemas/conditions.py\` (extended):
- \`Condition.matches(age, yos)\` — scalar predicate.
- \`Condition.matches_vec(ages, yos)\` — vectorized.

Both preserve today's exact predicate semantics for \`min_age\` / \`min_yos\` / \`rule_of\`.

## Loader/resolver updates

- \`config_resolver_common._get_eligibility\` now returns \`Optional[EligibilitySpec]\`. Validates the raw eligibility dict at access time. (PR 7 will store typed eligibility on tier defs at parse time, eliminating the re-validation overhead.)
- \`config_resolvers_scalar.get_tier\` — typed access (\`eligibility.matches_normal(...)\`, \`eligibility.vesting_yos\`).
- \`config_resolvers_vectorized\` — typed access via \`matches_normal_vec\` / \`matches_early_vec\`.

## Incidental cleanup

PR 5's \`get_ben_mult\` consumers were threading typed Conditions through dict-shaped helpers. Now they use the typed \`cond.matches\` / \`matches_vec\` directly:
- 2 sites in \`config_resolvers_scalar\` and \`config_resolvers_vectorized\`.
- 4 unused dict-based helper imports removed.

## Validation

- \`make r-match\` — 8/8 truth-table cells pass at relative diff < 1e-10.
- \`make test\` — 418 passed (was 405 + 13 new schema tests), 2 skipped.

## Diff

7 files, +200 / -22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)