### PR TITLE
Pydantic schema migration — PR 8: Top-level PlanConfig + JSON Schema

### DIFF
--- a/plans/_schema/plan_config.schema.json
+++ b/plans/_schema/plan_config.schema.json
@@ -1,0 +1,1723 @@
+{
+  "$defs": {
+    "AgeGroup": {
+      "additionalProperties": false,
+      "description": "One age band used by YOS-only termination-rate tables.\n\nEither ``min_age`` or ``max_age`` (or both) may be omitted to\nmean open-ended. ``label`` is the column name in the wide-format\nterm_rate_avg table.",
+      "properties": {
+        "label": {
+          "title": "Label",
+          "type": "string"
+        },
+        "max_age": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Max Age"
+        },
+        "min_age": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Min Age"
+        }
+      },
+      "required": [
+        "label"
+      ],
+      "title": "AgeGroup",
+      "type": "object"
+    },
+    "Benefit": {
+      "additionalProperties": false,
+      "description": "Plan-level benefit assumptions.\n\n``cal_factor`` and ``min_benefit_monthly`` are admitted but are\nnot yet used by every plan \u2014 the loader injects ``cal_factor``\nfrom ``calibration.json`` if the plan has one, and\n``min_benefit_monthly`` is a TXTRS-only feature today.",
+      "properties": {
+        "benefit_types": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Benefit Types",
+          "type": "array"
+        },
+        "cal_factor": {
+          "default": 1.0,
+          "description": "Plan-wide calibration scalar applied to DB benefits. Injected by the loader from calibration.json when present.",
+          "title": "Cal Factor",
+          "type": "number"
+        },
+        "cash_balance": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CashBalance"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "cola": {
+          "$ref": "#/$defs/Cola"
+        },
+        "db_ee_cont_rate": {
+          "title": "Db Ee Cont Rate",
+          "type": "number"
+        },
+        "db_ee_interest_rate": {
+          "default": 0.0,
+          "title": "Db Ee Interest Rate",
+          "type": "number"
+        },
+        "dc": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DcSpec"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "fas_years_default": {
+          "title": "Fas Years Default",
+          "type": "integer"
+        },
+        "fas_years_grandfathered": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Override fas_years for grandfathered tiers (TXTRS).",
+          "title": "Fas Years Grandfathered"
+        },
+        "min_benefit_monthly": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Floor on monthly benefit at retirement (TXTRS).",
+          "title": "Min Benefit Monthly"
+        },
+        "retire_refund_ratio": {
+          "default": 1.0,
+          "title": "Retire Refund Ratio",
+          "type": "number"
+        }
+      },
+      "required": [
+        "db_ee_cont_rate",
+        "fas_years_default"
+      ],
+      "title": "Benefit",
+      "type": "object"
+    },
+    "BenefitMultipliers": {
+      "additionalProperties": true,
+      "description": "Top-level benefit_multipliers block.\n\nKeys are class names. Values are :class:`ClassMultipliers`\n(admitted as extras and promoted at parse time).",
+      "properties": {},
+      "title": "BenefitMultipliers",
+      "type": "object"
+    },
+    "CashBalance": {
+      "additionalProperties": false,
+      "description": "Cash-balance plan parameters (TXTRS-style).",
+      "properties": {
+        "annuity_conversion_rate": {
+          "title": "Annuity Conversion Rate",
+          "type": "number"
+        },
+        "ee_pay_credit": {
+          "title": "Ee Pay Credit",
+          "type": "number"
+        },
+        "er_pay_credit": {
+          "title": "Er Pay Credit",
+          "type": "number"
+        },
+        "icr_cap": {
+          "title": "Icr Cap",
+          "type": "number"
+        },
+        "icr_floor": {
+          "title": "Icr Floor",
+          "type": "number"
+        },
+        "icr_smooth_period": {
+          "title": "Icr Smooth Period",
+          "type": "integer"
+        },
+        "icr_upside_share": {
+          "title": "Icr Upside Share",
+          "type": "number"
+        },
+        "return_volatility": {
+          "default": 0.12,
+          "title": "Return Volatility",
+          "type": "number"
+        },
+        "vesting_yos": {
+          "title": "Vesting Yos",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "ee_pay_credit",
+        "er_pay_credit",
+        "vesting_yos",
+        "icr_smooth_period",
+        "icr_floor",
+        "icr_cap",
+        "icr_upside_share",
+        "annuity_conversion_rate"
+      ],
+      "title": "CashBalance",
+      "type": "object"
+    },
+    "ClassCalibration": {
+      "additionalProperties": false,
+      "description": "Per-class calibration values.",
+      "properties": {
+        "nc_cal": {
+          "default": 1.0,
+          "description": "Normal-cost calibration scalar. Multiplies the model's NC rate to match AV. Values near 1.0 mean the model is accurate for that class.",
+          "title": "Nc Cal",
+          "type": "number"
+        },
+        "pvfb_term_current": {
+          "default": 0.0,
+          "description": "PVFB on term-vested members at start year. Seeds the term-vested AAL where the AV doesn't break out a specific number.",
+          "title": "Pvfb Term Current",
+          "type": "number"
+        }
+      },
+      "title": "ClassCalibration",
+      "type": "object"
+    },
+    "Cola": {
+      "additionalProperties": true,
+      "description": "Cost-of-living adjustment assumptions.\n\nHas two layers of fields:\n\n* **Typed fixed fields** for retiree-side and proration:\n  ``current_retire``, ``current_retire_one_time``, ``one_time_cola``,\n  ``proration_cutoff_year``.\n\n* **Dynamic per-tier active rates** (e.g. ``tier_1_active``,\n  ``tier_2_active_constant``) \u2014 admitted via ``extra=\"allow\"``\n  because the keys depend on the plan's tier names. Read these\n  via ``getattr(cola, key, default)`` from caller code.\n\nA future cleanup PR may move per-tier rates into a typed sub-dict\nso the whole model can be strict; for now the loose form\npreserves the existing JSON shape.",
+      "properties": {
+        "current_retire": {
+          "default": 0.0,
+          "title": "Current Retire",
+          "type": "number"
+        },
+        "current_retire_one_time": {
+          "default": 0.0,
+          "title": "Current Retire One Time",
+          "type": "number"
+        },
+        "one_time_cola": {
+          "default": false,
+          "title": "One Time Cola",
+          "type": "boolean"
+        },
+        "proration_cutoff_year": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Proration Cutoff Year"
+        }
+      },
+      "title": "Cola",
+      "type": "object"
+    },
+    "Condition": {
+      "additionalProperties": false,
+      "description": "A single predicate over (age, yos, entry_year).\n\nA condition matches a member when **every** declared field is\nsatisfied. Missing fields don't constrain anything. Today's\nsupported fields:\n\n* ``min_age`` \u2014 member's age >= this.\n* ``min_yos`` \u2014 member's years of service >= this.\n* ``rule_of`` \u2014 age + yos >= this (the \"rule of N\" pattern).\n\nPlans express OR-combinations as a list of conditions inside a\nhigher-level container (e.g. ``GradedRule.or_`` or eligibility\nrule lists).\n\nA condition with no fields set is \"always true\" \u2014 used as a\ncatch-all in early-retire-reduction rules. (Today's eligibility\nrules don't use the empty form.)",
+      "properties": {
+        "min_age": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Min Age"
+        },
+        "min_yos": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Min Yos"
+        },
+        "rule_of": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Rule Of"
+        }
+      },
+      "title": "Condition",
+      "type": "object"
+    },
+    "CorridorAvaSmoothing": {
+      "additionalProperties": false,
+      "description": "Corridor smoothing parameters.\n\nEach year, smooths AVA toward MVA by ``recognition_fraction`` of\nthe gap, bounded to ``[corridor_low * mva, corridor_high * mva]``.",
+      "properties": {
+        "corridor_high": {
+          "default": 1.2,
+          "title": "Corridor High",
+          "type": "number"
+        },
+        "corridor_low": {
+          "default": 0.8,
+          "title": "Corridor Low",
+          "type": "number"
+        },
+        "method": {
+          "const": "corridor",
+          "title": "Method",
+          "type": "string"
+        },
+        "recognition_fraction": {
+          "default": 0.2,
+          "title": "Recognition Fraction",
+          "type": "number"
+        }
+      },
+      "required": [
+        "method"
+      ],
+      "title": "CorridorAvaSmoothing",
+      "type": "object"
+    },
+    "DataSpec": {
+      "additionalProperties": false,
+      "properties": {
+        "data_dir": {
+          "title": "Data Dir",
+          "type": "string"
+        }
+      },
+      "required": [
+        "data_dir"
+      ],
+      "title": "DataSpec",
+      "type": "object"
+    },
+    "DcSpec": {
+      "additionalProperties": false,
+      "description": "Defined-contribution sub-block (TXTRS-style).",
+      "properties": {
+        "assumed_return": {
+          "title": "Assumed Return",
+          "type": "number"
+        },
+        "ee_cont_rate": {
+          "title": "Ee Cont Rate",
+          "type": "number"
+        },
+        "return_volatility": {
+          "default": 0.12,
+          "title": "Return Volatility",
+          "type": "number"
+        }
+      },
+      "required": [
+        "ee_cont_rate",
+        "assumed_return"
+      ],
+      "title": "DcSpec",
+      "type": "object"
+    },
+    "Decrements": {
+      "additionalProperties": false,
+      "description": "Decrement-method dispatch.\n\nTwo supported methods, mapped to builders by\n``data_loader._DECREMENT_BUILDERS``.",
+      "properties": {
+        "method": {
+          "enum": [
+            "yos_only",
+            "years_from_nr"
+          ],
+          "title": "Method",
+          "type": "string"
+        }
+      },
+      "required": [
+        "method"
+      ],
+      "title": "Decrements",
+      "type": "object"
+    },
+    "EarlyRetireReduction": {
+      "additionalProperties": false,
+      "description": "Tier-level early-retire reduction spec.\n\nEither flat-shape (``rate_per_year`` + ``nra``) **or** rule-list\n(``rules``). The validator enforces exactly one shape \u2014 both\npopulated, or neither, raises.",
+      "properties": {
+        "nra": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "type": "integer"
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Nra"
+        },
+        "rate_per_year": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Rate Per Year"
+        },
+        "rules": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/EarlyRetireRule"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Rules"
+        }
+      },
+      "title": "EarlyRetireReduction",
+      "type": "object"
+    },
+    "EarlyRetireRule": {
+      "additionalProperties": false,
+      "description": "One rule in a rule-list early-retire reduction.\n\nEvery rule has a ``condition`` (possibly empty for a catch-all)\nand a ``formula``. ``formula=\"linear\"`` requires ``rate_per_year``\nand ``nra``; ``formula=\"table\"`` requires ``table_key`` (looked up\nagainst the plan's reduce-tables CSVs at runtime).",
+      "properties": {
+        "condition": {
+          "$ref": "#/$defs/ReduceCondition",
+          "default": {
+            "grandfathered": null,
+            "min_age": null,
+            "min_yos": null,
+            "or": null,
+            "rule_of": null
+          }
+        },
+        "formula": {
+          "default": "linear",
+          "enum": [
+            "linear",
+            "table"
+          ],
+          "title": "Formula",
+          "type": "string"
+        },
+        "nra": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Nra"
+        },
+        "rate_per_year": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Rate Per Year"
+        },
+        "table_key": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Table Key"
+        }
+      },
+      "title": "EarlyRetireRule",
+      "type": "object"
+    },
+    "Economic": {
+      "additionalProperties": false,
+      "description": "Plan-level economic assumptions.\n\nSource-of-truth for discount rates, payroll/population growth,\nand the asset-return scenario reference. ``baseline_*`` fields\nare populated by the loader from the pre-scenario raw config so\nthat scenario overrides don't disturb the term-vested cashflow\nscaling \u2014 see ``docs/design/discount_rate_scenarios.md``.",
+      "properties": {
+        "asset_return_path": {
+          "anyOf": [
+            {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Asset Return Path"
+        },
+        "baseline_dr_current": {
+          "title": "Baseline Dr Current",
+          "type": "number"
+        },
+        "baseline_model_return": {
+          "title": "Baseline Model Return",
+          "type": "number"
+        },
+        "dr_current": {
+          "description": "Current discount rate.",
+          "title": "Dr Current",
+          "type": "number"
+        },
+        "dr_new": {
+          "description": "Discount rate for new hires.",
+          "title": "Dr New",
+          "type": "number"
+        },
+        "dr_old": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Legacy discount rate (used in some amortization calcs). Defaults to dr_current.",
+          "title": "Dr Old"
+        },
+        "model_return": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Asset return assumption for the funding model. Defaults to dr_current.",
+          "title": "Model Return"
+        },
+        "payroll_growth": {
+          "title": "Payroll Growth",
+          "type": "number"
+        },
+        "pop_growth": {
+          "default": 0.0,
+          "title": "Pop Growth",
+          "type": "number"
+        }
+      },
+      "required": [
+        "dr_current",
+        "dr_new",
+        "payroll_growth",
+        "baseline_dr_current",
+        "baseline_model_return"
+      ],
+      "title": "Economic",
+      "type": "object"
+    },
+    "EligibilitySpec": {
+      "additionalProperties": false,
+      "description": "Eligibility rules for one (tier, group) pair.\n\nThe ``normal`` and ``early`` lists are OR-combinations of\nconditions: the member is eligible if **any** condition in the\nlist matches. ``vesting_yos`` is the years-of-service threshold\nabove which a terminated member is treated as deferred-vested\n(rather than non-vested with refund only).",
+      "properties": {
+        "early": {
+          "items": {
+            "$ref": "#/$defs/Condition"
+          },
+          "title": "Early",
+          "type": "array"
+        },
+        "normal": {
+          "items": {
+            "$ref": "#/$defs/Condition"
+          },
+          "title": "Normal",
+          "type": "array"
+        },
+        "vesting_yos": {
+          "title": "Vesting Yos",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "vesting_yos"
+      ],
+      "title": "EligibilitySpec",
+      "type": "object"
+    },
+    "Funding": {
+      "additionalProperties": false,
+      "description": "Funding-model parameters.",
+      "properties": {
+        "amo_method": {
+          "title": "Amo Method",
+          "type": "string"
+        },
+        "amo_pay_growth": {
+          "title": "Amo Pay Growth",
+          "type": "number"
+        },
+        "amo_period_current": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Amo Period Current"
+        },
+        "amo_period_new": {
+          "title": "Amo Period New",
+          "type": "integer"
+        },
+        "amo_period_term": {
+          "default": 50,
+          "title": "Amo Period Term",
+          "type": "integer"
+        },
+        "amo_term_growth": {
+          "default": 0.03,
+          "title": "Amo Term Growth",
+          "type": "number"
+        },
+        "ava_smoothing": {
+          "discriminator": {
+            "mapping": {
+              "corridor": "#/$defs/CorridorAvaSmoothing",
+              "gain_loss": "#/$defs/GainLossAvaSmoothing"
+            },
+            "propertyName": "method"
+          },
+          "oneOf": [
+            {
+              "$ref": "#/$defs/CorridorAvaSmoothing"
+            },
+            {
+              "$ref": "#/$defs/GainLossAvaSmoothing"
+            }
+          ],
+          "title": "Ava Smoothing"
+        },
+        "contribution_strategy": {
+          "enum": [
+            "statutory",
+            "actuarial"
+          ],
+          "title": "Contribution Strategy",
+          "type": "string"
+        },
+        "drop_reference_class": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Drop Reference Class"
+        },
+        "funding_lag": {
+          "default": 1,
+          "title": "Funding Lag",
+          "type": "integer"
+        },
+        "has_drop": {
+          "default": false,
+          "title": "Has Drop",
+          "type": "boolean"
+        },
+        "legs": {
+          "items": {
+            "$ref": "#/$defs/LegDef"
+          },
+          "title": "Legs",
+          "type": "array"
+        },
+        "policy": {
+          "description": "Funding policy. Today: 'statutory' or 'adc'.",
+          "title": "Policy",
+          "type": "string"
+        },
+        "statutory_rates": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/StatutoryRates"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "required": [
+        "contribution_strategy",
+        "policy",
+        "amo_method",
+        "amo_period_new",
+        "amo_pay_growth",
+        "ava_smoothing"
+      ],
+      "title": "Funding",
+      "type": "object"
+    },
+    "GainLossAvaSmoothing": {
+      "additionalProperties": false,
+      "description": "Gain/loss deferral cascade parameters.\n\nEach year's asset gain/loss is deferred and recognized over\n``recognition_period`` years.",
+      "properties": {
+        "method": {
+          "const": "gain_loss",
+          "title": "Method",
+          "type": "string"
+        },
+        "recognition_period": {
+          "title": "Recognition Period",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "method",
+        "recognition_period"
+      ],
+      "title": "GainLossAvaSmoothing",
+      "type": "object"
+    },
+    "GrandfatheredCondition": {
+      "additionalProperties": false,
+      "description": "One alternative inside a grandfathered-rule predicate.\n\nEach condition stands alone \u2014 the parent :class:`GrandfatheredParams`\nOR-combines its conditions. Today's plans use exactly one of the\nthree fields per condition; the validator enforces that.",
+      "properties": {
+        "min_age_at_cutoff": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Min Age At Cutoff"
+        },
+        "min_yos_at_cutoff": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Min Yos At Cutoff"
+        },
+        "rule_of_at_cutoff": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Rule Of At Cutoff"
+        }
+      },
+      "title": "GrandfatheredCondition",
+      "type": "object"
+    },
+    "GrandfatheredParams": {
+      "additionalProperties": false,
+      "description": "The full grandfathered-rule predicate for a tier.\n\nA member is grandfathered when, evaluated at ``cutoff_year`` using\nthe member's age + yos as of that cutoff, **any** of the\n``conditions`` matches.\n\nMembers hired after ``cutoff_year`` are never grandfathered (their\nyos at cutoff would be negative).",
+      "properties": {
+        "conditions": {
+          "items": {
+            "$ref": "#/$defs/GrandfatheredCondition"
+          },
+          "title": "Conditions",
+          "type": "array"
+        },
+        "cutoff_year": {
+          "title": "Cutoff Year",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "cutoff_year",
+        "conditions"
+      ],
+      "title": "GrandfatheredParams",
+      "type": "object"
+    },
+    "LegDef": {
+      "additionalProperties": false,
+      "description": "One funding leg.\n\nEither or both of ``entry_year_min`` and ``entry_year_max`` may be\nomitted to mean open-ended. ``*_param`` strings of ``\"new_year\"``\nresolve to ``Ranges.new_year`` at access time (today the only\nsupported parametric reference).",
+      "properties": {
+        "entry_year_max": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Entry Year Max"
+        },
+        "entry_year_max_param": {
+          "anyOf": [
+            {
+              "const": "new_year",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Entry Year Max Param"
+        },
+        "entry_year_min": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Entry Year Min"
+        },
+        "entry_year_min_param": {
+          "anyOf": [
+            {
+              "const": "new_year",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Entry Year Min Param"
+        },
+        "name": {
+          "title": "Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "title": "LegDef",
+      "type": "object"
+    },
+    "Modeling": {
+      "additionalProperties": false,
+      "description": "Model-implementation knobs and modeling assumptions.\n\nMixes actuarial choices (``use_earliest_retire``, ``age_groups``)\nwith implementation knobs (``entrant_salary_at_start_year``,\n``male_mp_forward_shift``). A future refactor should split these\ninto two namespaces; for now they live together because\nplan_config.json organizes them that way.",
+      "properties": {
+        "age_groups": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/AgeGroup"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Age Groups"
+        },
+        "entrant_salary_at_start_year": {
+          "default": false,
+          "title": "Entrant Salary At Start Year",
+          "type": "boolean"
+        },
+        "male_mp_forward_shift": {
+          "default": 0,
+          "title": "Male Mp Forward Shift",
+          "type": "integer"
+        },
+        "use_earliest_retire": {
+          "default": false,
+          "title": "Use Earliest Retire",
+          "type": "boolean"
+        }
+      },
+      "title": "Modeling",
+      "type": "object"
+    },
+    "MortalitySpec": {
+      "additionalProperties": false,
+      "properties": {
+        "base_table": {
+          "default": "general",
+          "title": "Base Table",
+          "type": "string"
+        },
+        "improvement_scale": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Improvement Scale"
+        }
+      },
+      "title": "MortalitySpec",
+      "type": "object"
+    },
+    "PlanDesign": {
+      "additionalProperties": true,
+      "description": "Top-level plan_design block.\n\nHas a fixed ``cutoff_year`` plus a variable-shape map of group\nname \u2192 :class:`PlanDesignRatios`. Group names depend on the\nplan's class_groups configuration (FRS uses ``regular_group`` /\n``special_group``; TXTRS uses ``default``).\n\nGroups arrive in JSON as top-level keys; an ``after``-mode\nvalidator promotes each group's raw dict to a typed\n``PlanDesignRatios`` instance and exposes them via the\n``groups`` property.",
+      "properties": {
+        "cutoff_year": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Cutoff Year"
+        }
+      },
+      "title": "PlanDesign",
+      "type": "object"
+    },
+    "RampSpec": {
+      "additionalProperties": false,
+      "description": "Linear ramp parameters for an employer-rate component.",
+      "properties": {
+        "end_year": {
+          "title": "End Year",
+          "type": "integer"
+        },
+        "rate_per_year": {
+          "title": "Rate Per Year",
+          "type": "number"
+        }
+      },
+      "required": [
+        "rate_per_year",
+        "end_year"
+      ],
+      "title": "RampSpec",
+      "type": "object"
+    },
+    "Ranges": {
+      "additionalProperties": false,
+      "description": "Year/age/YOS bounds for the simulation. Derived ranges\n(``entry_year_range``, ``age_range``, ``yos_range``,\n``max_year``, ``max_entry_year``) are computed properties.",
+      "properties": {
+        "max_age": {
+          "title": "Max Age",
+          "type": "integer"
+        },
+        "max_yos": {
+          "default": 70,
+          "title": "Max Yos",
+          "type": "integer"
+        },
+        "min_age": {
+          "title": "Min Age",
+          "type": "integer"
+        },
+        "min_entry_year": {
+          "default": 1970,
+          "title": "Min Entry Year",
+          "type": "integer"
+        },
+        "model_period": {
+          "title": "Model Period",
+          "type": "integer"
+        },
+        "new_year": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Year boundary that separates legacy hires from new hires. Defaults to start_year if omitted.",
+          "title": "New Year"
+        },
+        "start_year": {
+          "title": "Start Year",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "min_age",
+        "max_age",
+        "start_year",
+        "model_period"
+      ],
+      "title": "Ranges",
+      "type": "object"
+    },
+    "RateComponentSpec": {
+      "additionalProperties": false,
+      "description": "One term in the statutory employer-rate cascade.\n\nEach component contributes ``rate(year) * payroll_share`` to the\neffective employer rate. Rate is specified as either a step\nschedule or a linear ramp \u2014 exactly one must be present.",
+      "properties": {
+        "initial_rate": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Initial Rate"
+        },
+        "name": {
+          "title": "Name",
+          "type": "string"
+        },
+        "payroll_share": {
+          "default": 1.0,
+          "title": "Payroll Share",
+          "type": "number"
+        },
+        "ramp": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RampSpec"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "schedule": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/RateScheduleEntry"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Schedule"
+        },
+        "start_year": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Start Year"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "title": "RateComponentSpec",
+      "type": "object"
+    },
+    "RateScheduleEntry": {
+      "additionalProperties": false,
+      "description": "One step in a year-keyed step-function rate schedule.",
+      "properties": {
+        "from_year": {
+          "title": "From Year",
+          "type": "integer"
+        },
+        "rate": {
+          "title": "Rate",
+          "type": "number"
+        }
+      },
+      "required": [
+        "from_year",
+        "rate"
+      ],
+      "title": "RateScheduleEntry",
+      "type": "object"
+    },
+    "ReduceCondition": {
+      "additionalProperties": false,
+      "description": "Predicate inside one rule of a rule-list early-retire reduction.\n\nLike :class:`pension_model.schemas.conditions.Condition` it has\n``min_age`` / ``min_yos`` / ``rule_of``, but adds two\nERR-specific fields:\n\n* ``grandfathered`` \u2014 when True, the rule applies only to members\n  whose tier name contains ``\"grandfathered\"``. (A simple way to\n  gate one rule on tier identity without threading the tier in\n  separately.)\n* ``or_`` (JSON: ``or``) \u2014 sub-conditions OR-combined. The parent\n  condition's other fields still must match in addition to one of\n  the ``or`` alternatives.\n\nAn empty condition (no fields set) is \"always true\" \u2014 used as the\ncatch-all final rule in plan configs.",
+      "properties": {
+        "grandfathered": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Grandfathered"
+        },
+        "min_age": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Min Age"
+        },
+        "min_yos": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Min Yos"
+        },
+        "or": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/ReduceCondition"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Or"
+        },
+        "rule_of": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Rule Of"
+        }
+      },
+      "title": "ReduceCondition",
+      "type": "object"
+    },
+    "StatutoryRates": {
+      "additionalProperties": false,
+      "description": "Statutory contribution-rate definitions.\n\nRequired when ``Funding.contribution_strategy == \"statutory\"``.",
+      "properties": {
+        "ee_rate_schedule": {
+          "items": {
+            "$ref": "#/$defs/RateScheduleEntry"
+          },
+          "title": "Ee Rate Schedule",
+          "type": "array"
+        },
+        "er_rate_components": {
+          "items": {
+            "$ref": "#/$defs/RateComponentSpec"
+          },
+          "title": "Er Rate Components",
+          "type": "array"
+        }
+      },
+      "required": [
+        "ee_rate_schedule",
+        "er_rate_components"
+      ],
+      "title": "StatutoryRates",
+      "type": "object"
+    },
+    "TermVested": {
+      "additionalProperties": false,
+      "properties": {
+        "avg_deferral_years": {
+          "title": "Avg Deferral Years",
+          "type": "integer"
+        },
+        "avg_payout_years": {
+          "title": "Avg Payout Years",
+          "type": "integer"
+        },
+        "method": {
+          "const": "deferred_annuity",
+          "title": "Method",
+          "type": "string"
+        },
+        "notes": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Notes"
+        }
+      },
+      "required": [
+        "avg_deferral_years",
+        "avg_payout_years",
+        "method"
+      ],
+      "title": "TermVested",
+      "type": "object"
+    },
+    "Tier": {
+      "additionalProperties": false,
+      "description": "One tier in a plan's tiers list.\n\nSee module docstring for the composition story. Field-level\ninvariants checked here:\n\n* Either ``eligibility`` or ``eligibility_same_as`` is set (not\n  both, and at least one must be present).\n* Either ``early_retire_reduction`` or\n  ``early_retire_reduction_same_as`` is set (same rule).\n* Tiers with ``assignment=\"grandfathered_rule\"`` must declare\n  ``grandfathered_params``; non-grandfathered tiers must not.",
+      "properties": {
+        "assignment": {
+          "anyOf": [
+            {
+              "const": "grandfathered_rule",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assignment"
+        },
+        "cola_key": {
+          "title": "Cola Key",
+          "type": "string"
+        },
+        "discount_rate_key": {
+          "default": "dr_current",
+          "title": "Discount Rate Key",
+          "type": "string"
+        },
+        "early_retire_reduction": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/EarlyRetireReduction"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "early_retire_reduction_same_as": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Early Retire Reduction Same As"
+        },
+        "eligibility": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "$ref": "#/$defs/EligibilitySpec"
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Eligibility"
+        },
+        "eligibility_same_as": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Eligibility Same As"
+        },
+        "entry_year_max": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Entry Year Max"
+        },
+        "entry_year_max_param": {
+          "anyOf": [
+            {
+              "const": "new_year",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Entry Year Max Param"
+        },
+        "entry_year_min": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Entry Year Min"
+        },
+        "entry_year_min_param": {
+          "anyOf": [
+            {
+              "const": "new_year",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Entry Year Min Param"
+        },
+        "fas_years": {
+          "title": "Fas Years",
+          "type": "integer"
+        },
+        "grandfathered_params": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GrandfatheredParams"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "name": {
+          "title": "Name",
+          "type": "string"
+        },
+        "not_grandfathered": {
+          "default": false,
+          "title": "Not Grandfathered",
+          "type": "boolean"
+        },
+        "prorate_cola": {
+          "default": false,
+          "title": "Prorate Cola",
+          "type": "boolean"
+        },
+        "retirement_rate_set": {
+          "title": "Retirement Rate Set",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "cola_key",
+        "fas_years",
+        "retirement_rate_set"
+      ],
+      "title": "Tier",
+      "type": "object"
+    },
+    "ValuationInputs": {
+      "additionalProperties": false,
+      "description": "One class's actuarial-valuation snapshot.\n\nUsed to seed initial AAL / payroll / member counts and\nbenefit-payment streams. Each plan declares one entry per class\nunder ``valuation_inputs`` in plan_config.json.",
+      "properties": {
+        "ben_payment": {
+          "description": "Initial-year pension benefit payments to current retirees. Seeds the retiree liability projection.",
+          "title": "Ben Payment",
+          "type": "number"
+        },
+        "er_dc_cont_rate": {
+          "default": 0.0,
+          "description": "Employer DC contribution rate (used when benefit_types includes 'dc').",
+          "title": "Er Dc Cont Rate",
+          "type": "number"
+        },
+        "headcount_group": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Classes whose headcount totals must agree (FRS uses this to enforce eco/eso/judges share total_active_member).",
+          "title": "Headcount Group"
+        },
+        "retiree_pop": {
+          "title": "Retiree Pop",
+          "type": "integer"
+        },
+        "total_active_member": {
+          "title": "Total Active Member",
+          "type": "integer"
+        },
+        "val_aal": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "AV-published actuarial accrued liability (used for component-by-component calibration; optional).",
+          "title": "Val Aal"
+        },
+        "val_norm_cost": {
+          "title": "Val Norm Cost",
+          "type": "number"
+        },
+        "val_payroll": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "AV-published payroll for this class (FRS-only today).",
+          "title": "Val Payroll"
+        }
+      },
+      "required": [
+        "ben_payment",
+        "retiree_pop",
+        "total_active_member",
+        "val_norm_cost"
+      ],
+      "title": "ValuationInputs",
+      "type": "object"
+    }
+  },
+  "description": "Top-level plan_config.json model.\n\nSection sub-models (`economic`, `funding`, etc.) are validated\nstrictly. The top level itself ignores unknown keys so that\nembedded documentation (``*_notes``, ``source_notes``,\n``_scenario_name``) doesn't fail load. ``frozen=True`` keeps\nconfigs immutable; the few lookup tables computed at load time\nuse ``object.__setattr__`` in :func:`build_plan_config_from_raw`.",
+  "properties": {
+    "_scenario_name": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Scenario Name"
+    },
+    "base_table_map": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "title": "Base Table Map",
+      "type": "object"
+    },
+    "benefit": {
+      "$ref": "#/$defs/Benefit"
+    },
+    "benefit_multipliers": {
+      "$ref": "#/$defs/BenefitMultipliers"
+    },
+    "calibration": {
+      "additionalProperties": {
+        "$ref": "#/$defs/ClassCalibration"
+      },
+      "title": "Calibration",
+      "type": "object"
+    },
+    "class_groups": {
+      "additionalProperties": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "title": "Class Groups",
+      "type": "object"
+    },
+    "class_to_group": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "title": "Class To Group",
+      "type": "object"
+    },
+    "classes": {
+      "items": {
+        "type": "string"
+      },
+      "title": "Classes",
+      "type": "array"
+    },
+    "data": {
+      "$ref": "#/$defs/DataSpec"
+    },
+    "decrements": {
+      "$ref": "#/$defs/Decrements"
+    },
+    "design_ratio_group_map": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "title": "Design Ratio Group Map",
+      "type": "object"
+    },
+    "economic": {
+      "$ref": "#/$defs/Economic"
+    },
+    "funding": {
+      "$ref": "#/$defs/Funding"
+    },
+    "modeling": {
+      "$ref": "#/$defs/Modeling"
+    },
+    "mortality": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/MortalitySpec"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    },
+    "plan_description": {
+      "default": "",
+      "title": "Plan Description",
+      "type": "string"
+    },
+    "plan_design": {
+      "$ref": "#/$defs/PlanDesign"
+    },
+    "plan_name": {
+      "title": "Plan Name",
+      "type": "string"
+    },
+    "ranges": {
+      "$ref": "#/$defs/Ranges"
+    },
+    "reduce_tables": {
+      "anyOf": [
+        {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Reduce Tables"
+    },
+    "salary_growth_col_map": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "title": "Salary Growth Col Map",
+      "type": "object"
+    },
+    "term_vested": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/TermVested"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    },
+    "tier_id_to_cola_key": {
+      "default": [],
+      "items": {
+        "type": "string"
+      },
+      "title": "Tier Id To Cola Key",
+      "type": "array"
+    },
+    "tier_id_to_dr_key": {
+      "default": [],
+      "items": {
+        "type": "string"
+      },
+      "title": "Tier Id To Dr Key",
+      "type": "array"
+    },
+    "tier_id_to_fas_years": {
+      "default": [],
+      "items": {
+        "type": "integer"
+      },
+      "title": "Tier Id To Fas Years",
+      "type": "array"
+    },
+    "tier_id_to_name": {
+      "default": [],
+      "items": {
+        "type": "string"
+      },
+      "title": "Tier Id To Name",
+      "type": "array"
+    },
+    "tier_id_to_retire_rate_set": {
+      "default": [],
+      "items": {
+        "type": "string"
+      },
+      "title": "Tier Id To Retire Rate Set",
+      "type": "array"
+    },
+    "tier_name_to_id": {
+      "additionalProperties": {
+        "type": "integer"
+      },
+      "title": "Tier Name To Id",
+      "type": "object"
+    },
+    "tiers": {
+      "default": [],
+      "items": {
+        "$ref": "#/$defs/Tier"
+      },
+      "title": "Tiers",
+      "type": "array"
+    },
+    "valuation_inputs": {
+      "additionalProperties": {
+        "$ref": "#/$defs/ValuationInputs"
+      },
+      "title": "Valuation Inputs",
+      "type": "object"
+    }
+  },
+  "required": [
+    "plan_name",
+    "classes",
+    "economic",
+    "ranges",
+    "decrements",
+    "funding",
+    "benefit",
+    "data"
+  ],
+  "title": "PlanConfig",
+  "type": "object"
+}

--- a/src/pension_model/config_loading.py
+++ b/src/pension_model/config_loading.py
@@ -222,10 +222,26 @@ def load_plan_config(
         raw.get("benefit_multipliers", {})
     )
 
+    from pension_model.schemas import DataSpec, MortalitySpec, TermVested
+
+    data_model = DataSpec.model_validate(
+        raw.get("data", {"data_dir": f"plans/{raw['plan_name']}/data"})
+    )
+    mortality_model = (
+        MortalitySpec.model_validate(raw["mortality"])
+        if raw.get("mortality") is not None
+        else None
+    )
+    term_vested_model = (
+        TermVested.model_validate(raw["term_vested"])
+        if raw.get("term_vested") is not None
+        else None
+    )
+
     config = PlanConfig(
         plan_name=raw["plan_name"],
         plan_description=raw.get("plan_description", ""),
-        raw=raw,
+        scenario_name=scenario_name,
         classes=tuple(raw["classes"]),
         class_groups=raw.get("class_groups", {}),
         tier_defs=tiers,
@@ -238,14 +254,20 @@ def load_plan_config(
         modeling=modeling_model,
         funding=funding_model,
         benefit=benefit_model,
+        data=data_model,
+        mortality=mortality_model,
+        term_vested=term_vested_model,
+        salary_growth_col_map=raw.get("salary_growth_col_map", {}),
+        base_table_map=raw.get("base_table_map", {}),
+        design_ratio_group_map=raw.get("design_ratio_group_map", {}),
         calibration=calibration,
-        _class_to_group=class_to_group,
-        _tier_name_to_id=tier_name_to_id,
-        _tier_id_to_name=tier_id_to_name,
-        _tier_id_to_cola_key=tier_id_to_cola_key,
-        _tier_id_to_fas_years=tier_id_to_fas_years,
-        _tier_id_to_dr_key=tier_id_to_dr_key,
-        _tier_id_to_retire_rate_set=tier_id_to_retire_rate_set,
+        class_to_group=class_to_group,
+        tier_name_to_id=tier_name_to_id,
+        tier_id_to_name=tier_id_to_name,
+        tier_id_to_cola_key=tier_id_to_cola_key,
+        tier_id_to_fas_years=tier_id_to_fas_years,
+        tier_id_to_dr_key=tier_id_to_dr_key,
+        tier_id_to_retire_rate_set=tier_id_to_retire_rate_set,
     )
 
     # Fatal: legs must be non-overlapping and cover the full

--- a/src/pension_model/config_schema.py
+++ b/src/pension_model/config_schema.py
@@ -1,24 +1,41 @@
-"""Plan config schema and status constants."""
+"""Plan config schema and status constants.
 
-from dataclasses import dataclass, field
+The top-level :class:`PlanConfig` is now a pydantic ``BaseModel``
+that composes every section schema. Strict (``extra="forbid"``) is
+the rule on sub-models; the top-level uses ``extra="ignore"`` so
+plain documentation keys (``*_notes``, ``source_notes``) embedded
+in plan_config.json don't fail validation. Required sections —
+``economic``, ``ranges``, ``decrements``, ``funding``, ``benefit`` —
+are still required, so a typo at the top level surfaces as a
+"missing required field" error, not a silent drop.
+"""
+
+from __future__ import annotations
+
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
-from pension_model.config_validation import validate_config, validate_data_files
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
 from pension_model.schemas import (
     Benefit,
     BenefitMultipliers,
     ClassCalibration,
     ClassData,
+    DataSpec,
     Decrements,
     Economic,
     Funding,
     Modeling,
+    MortalitySpec,
     MultiplierRules,
     PlanDesign,
+    PlanDesignRatios,
     Ranges,
+    TermVested,
     Tier,
     ValuationInputs,
+    validate_tier_cross_references,
 )
 
 
@@ -28,38 +45,81 @@ EARLY = 2
 NORM = 3
 
 
-@dataclass(frozen=True)
-class PlanConfig:
+class PlanConfig(BaseModel):
+    """Top-level plan_config.json model.
+
+    Section sub-models (`economic`, `funding`, etc.) are validated
+    strictly. The top level itself ignores unknown keys so that
+    embedded documentation (``*_notes``, ``source_notes``,
+    ``_scenario_name``) doesn't fail load. ``frozen=True`` keeps
+    configs immutable; the few lookup tables computed at load time
+    use ``object.__setattr__`` in :func:`build_plan_config_from_raw`.
+    """
+
+    model_config = ConfigDict(
+        extra="ignore",
+        frozen=True,
+        populate_by_name=True,
+        arbitrary_types_allowed=True,
+    )
+
     plan_name: str
-    plan_description: str
-    raw: dict
+    plan_description: str = ""
+
     classes: Tuple[str, ...]
-    class_groups: Dict[str, List[str]]
-    tier_defs: Tuple[Tier, ...]
-    benefit_mult_defs: BenefitMultipliers
-    plan_design: PlanDesign
-    valuation_inputs: Dict[str, ValuationInputs]
+    class_groups: Dict[str, List[str]] = Field(default_factory=dict)
+
     economic: Economic
     ranges: Ranges
     decrements: Decrements
-    modeling: Modeling
+    modeling: Modeling = Field(default_factory=Modeling)
     funding: Funding
     benefit: Benefit
-    calibration: Dict[str, ClassCalibration] = field(default_factory=dict)
-    reduce_tables: Optional[Dict[str, object]] = None
-    _class_to_group: Dict[str, str] = field(default_factory=dict)
-    _tier_name_to_id: Dict[str, int] = field(default_factory=dict)
-    _tier_id_to_name: Tuple[str, ...] = ()
-    _tier_id_to_cola_key: Tuple[str, ...] = ()
-    _tier_id_to_fas_years: Tuple[int, ...] = ()
-    _tier_id_to_dr_key: Tuple[str, ...] = ()
-    _tier_id_to_retire_rate_set: Tuple[str, ...] = ()
+
+    valuation_inputs: Dict[str, ValuationInputs] = Field(default_factory=dict)
+    plan_design: PlanDesign = Field(default_factory=PlanDesign)
+    benefit_mult_defs: BenefitMultipliers = Field(
+        default_factory=BenefitMultipliers, alias="benefit_multipliers"
+    )
+    tier_defs: Tuple[Tier, ...] = Field(default=(), alias="tiers")
+
+    data: DataSpec
+    mortality: Optional[MortalitySpec] = None
+    term_vested: Optional[TermVested] = None
+
+    salary_growth_col_map: Dict[str, str] = Field(default_factory=dict)
+    base_table_map: Dict[str, str] = Field(default_factory=dict)
+    design_ratio_group_map: Dict[str, str] = Field(default_factory=dict)
+
+    scenario_name: Optional[str] = Field(default=None, alias="_scenario_name")
+
+    # Populated post-load (calibration is read from a sibling file;
+    # reduce_tables and the lookup caches are built during loading).
+    calibration: Dict[str, ClassCalibration] = Field(default_factory=dict)
+    reduce_tables: Optional[Dict[str, Any]] = None
+    class_to_group: Dict[str, str] = Field(default_factory=dict)
+    tier_name_to_id: Dict[str, int] = Field(default_factory=dict)
+    tier_id_to_name: Tuple[str, ...] = ()
+    tier_id_to_cola_key: Tuple[str, ...] = ()
+    tier_id_to_fas_years: Tuple[int, ...] = ()
+    tier_id_to_dr_key: Tuple[str, ...] = ()
+    tier_id_to_retire_rate_set: Tuple[str, ...] = ()
 
     # ------------------------------------------------------------------
-    # Delegating accessors to the typed-model fields. The typed model
-    # is the source of truth; these accessors preserve the legacy
-    # ``config.dr_current`` / ``config.start_year`` access pattern so
-    # consumers don't change as sections migrate.
+    # Cross-reference validation. tier_defs ``*_same_as`` references
+    # must resolve to existing tier names; cycles raise.
+    # ------------------------------------------------------------------
+
+    @model_validator(mode="after")
+    def _validate_tier_cross_refs(self):
+        if self.tier_defs:
+            validate_tier_cross_references(self.tier_defs)
+        return self
+
+    # ------------------------------------------------------------------
+    # Delegating accessors to typed-model fields. The typed model is
+    # the source of truth; these accessors preserve the legacy
+    # ``config.dr_current`` / ``config.start_year`` access pattern.
     # ------------------------------------------------------------------
 
     @property
@@ -162,13 +222,8 @@ class PlanConfig:
         """Typed CashBalance model, or None if not declared."""
         return self.benefit.cash_balance
 
-    @property
-    def scenario_name(self) -> Optional[str]:
-        return self.raw.get("_scenario_name")
-
     def resolve_data_dir(self) -> Path:
-        data_cfg = self.raw.get("data", {})
-        data_dir_str = data_cfg.get("data_dir", f"plans/{self.plan_name}/data")
+        data_dir_str = self.data.data_dir
         data_dir = Path(data_dir_str)
         if not data_dir.is_absolute():
             project_root = Path(__file__).parents[2]
@@ -196,16 +251,10 @@ class PlanConfig:
         return self.plan_design.cutoff_year
 
     @property
-    def salary_growth_col_map(self) -> Dict[str, str]:
-        return self.raw.get("salary_growth_col_map", {})
-
-    @property
     def mortality_base_table(self) -> str:
-        return self.raw.get("mortality", {}).get("base_table", "general")
-
-    @property
-    def base_table_map(self) -> Dict[str, str]:
-        return self.raw.get("base_table_map", {})
+        if self.mortality is not None:
+            return self.mortality.base_table
+        return "general"
 
     def get_base_table_type(self, class_name: str) -> str:
         return self.base_table_map.get(class_name, "general")
@@ -296,10 +345,6 @@ class PlanConfig:
         return self.decrements.method
 
     @property
-    def design_ratio_group_map(self) -> Dict[str, str]:
-        return self.raw.get("design_ratio_group_map", {})
-
-    @property
     def max_entry_year(self) -> int:
         return self.ranges.max_entry_year
 
@@ -355,8 +400,6 @@ class PlanConfig:
         }
 
     def get_design_ratios(self, class_name: str) -> Dict[str, Tuple[float, float, float]]:
-        from pension_model.schemas import PlanDesignRatios
-
         group_name = self.design_ratio_group_map.get(class_name, self.class_group(class_name))
         ratios = (
             self.plan_design.group(group_name)
@@ -380,7 +423,7 @@ class PlanConfig:
         return result
 
     def class_group(self, class_name: str) -> str:
-        return self._class_to_group.get(class_name, "default")
+        return self.class_to_group.get(class_name, "default")
 
     def resolve_ben_mult(
         self, class_name: str, tier_name: str
@@ -404,7 +447,43 @@ class PlanConfig:
         return base
 
     def validate(self) -> list:
+        from pension_model.config_validation import validate_config
         return validate_config(self)
 
     def validate_data_files(self) -> list:
+        from pension_model.config_validation import validate_data_files
         return validate_data_files(self)
+
+    # ------------------------------------------------------------------
+    # Underscore-name aliases for legacy resolver code that still reads
+    # ``config._class_to_group`` etc. Defined as @property so they
+    # don't conflict with pydantic's field-name expectations.
+    # ------------------------------------------------------------------
+
+    @property
+    def _class_to_group(self) -> Dict[str, str]:
+        return self.class_to_group
+
+    @property
+    def _tier_name_to_id(self) -> Dict[str, int]:
+        return self.tier_name_to_id
+
+    @property
+    def _tier_id_to_name(self) -> Tuple[str, ...]:
+        return self.tier_id_to_name
+
+    @property
+    def _tier_id_to_cola_key(self) -> Tuple[str, ...]:
+        return self.tier_id_to_cola_key
+
+    @property
+    def _tier_id_to_fas_years(self) -> Tuple[int, ...]:
+        return self.tier_id_to_fas_years
+
+    @property
+    def _tier_id_to_dr_key(self) -> Tuple[str, ...]:
+        return self.tier_id_to_dr_key
+
+    @property
+    def _tier_id_to_retire_rate_set(self) -> Tuple[str, ...]:
+        return self.tier_id_to_retire_rate_set

--- a/src/pension_model/core/data_loader.py
+++ b/src/pension_model/core/data_loader.py
@@ -13,7 +13,6 @@ Entry points:
   - load_plan_data(class_name, constants): per-class loader (called
     internally by load_plan_inputs; still available for debugging).
 """
-from dataclasses import replace
 from pathlib import Path
 import pandas as pd
 import numpy as np
@@ -550,7 +549,7 @@ def load_plan_inputs(constants: PlanConfig) -> tuple[PlanConfig, dict]:
             reduction_tables = rt
             break
 
-    constants = replace(constants, reduce_tables=reduction_tables)
+    constants = constants.model_copy(update={"reduce_tables": reduction_tables})
 
     # Build the shared annual return stream once. Used by the CB
     # crediting path here and by the funding model's asset roll-forward.

--- a/src/pension_model/schemas/__init__.py
+++ b/src/pension_model/schemas/__init__.py
@@ -33,6 +33,7 @@ from pension_model.schemas.benefit_multipliers import (
 )
 from pension_model.schemas.calibration import Calibration, ClassCalibration
 from pension_model.schemas.conditions import Condition
+from pension_model.schemas.data_spec import DataSpec
 from pension_model.schemas.decrements import Decrements
 from pension_model.schemas.early_retire_reduction import (
     EarlyRetireReduction,
@@ -57,8 +58,10 @@ from pension_model.schemas.grandfathered import (
     GrandfatheredParams,
 )
 from pension_model.schemas.modeling import AgeGroup, Modeling
+from pension_model.schemas.mortality import MortalitySpec
 from pension_model.schemas.plan_design import PlanDesign, PlanDesignRatios
 from pension_model.schemas.ranges import Ranges
+from pension_model.schemas.term_vested import TermVested
 from pension_model.schemas.tier import Tier, validate_tier_cross_references
 from pension_model.schemas.valuation_inputs import ClassData, ValuationInputs
 
@@ -76,6 +79,7 @@ __all__ = [
     "Cola",
     "Condition",
     "CorridorAvaSmoothing",
+    "DataSpec",
     "DcSpec",
     "Decrements",
     "EarlyRetireReduction",
@@ -90,6 +94,7 @@ __all__ = [
     "GrandfatheredParams",
     "LegDef",
     "Modeling",
+    "MortalitySpec",
     "MultiplierRules",
     "PlanDesign",
     "PlanDesignRatios",
@@ -100,6 +105,7 @@ __all__ = [
     "ReduceCondition",
     "StatutoryRates",
     "StrictModel",
+    "TermVested",
     "Tier",
     "ValuationInputs",
     "validate_tier_cross_references",

--- a/src/pension_model/schemas/data_spec.py
+++ b/src/pension_model/schemas/data_spec.py
@@ -1,0 +1,14 @@
+"""Schema for the ``data`` section of plan_config.json.
+
+Just one field today: where the plan's CSV inputs live. Kept as its
+own model so future fields (URLs, version pins, alternate-source
+toggles) can land in a typed home.
+"""
+
+from __future__ import annotations
+
+from pension_model.schemas.base import StrictModel
+
+
+class DataSpec(StrictModel):
+    data_dir: str

--- a/src/pension_model/schemas/mortality.py
+++ b/src/pension_model/schemas/mortality.py
@@ -1,0 +1,19 @@
+"""Schema for the optional ``mortality`` section of plan_config.json.
+
+TXTRS-style plans declare a single base mortality table for everyone.
+FRS-style plans use the per-class ``base_table_map`` instead and don't
+declare this section. Either pattern is fine; consumers that need a
+class-specific table check ``base_table_map`` first and fall back to
+``mortality.base_table``.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from pension_model.schemas.base import StrictModel
+
+
+class MortalitySpec(StrictModel):
+    base_table: str = "general"
+    improvement_scale: Optional[str] = None

--- a/src/pension_model/schemas/term_vested.py
+++ b/src/pension_model/schemas/term_vested.py
@@ -1,0 +1,21 @@
+"""Schema for the ``term_vested`` section of plan_config.json.
+
+Used only by data prep — the runtime reads ``current_term_vested_cashflow.csv``
+and never consults this section. Kept here so prep scripts can validate
+the same way the runtime config does.
+
+Today this is TXTRS-AV only; other plans omit it.
+"""
+
+from __future__ import annotations
+
+from typing import Literal, Optional
+
+from pension_model.schemas.base import StrictModel
+
+
+class TermVested(StrictModel):
+    avg_deferral_years: int
+    avg_payout_years: int
+    method: Literal["deferred_annuity"]
+    notes: Optional[str] = None

--- a/tests/test_pension_model/test_multi_class_gainloss.py
+++ b/tests/test_pension_model/test_multi_class_gainloss.py
@@ -12,7 +12,6 @@ coupling) the two class frames should be byte-identical, and the
 aggregate should sum flow columns 2x.
 """
 
-import dataclasses
 import sys
 from pathlib import Path
 
@@ -44,12 +43,11 @@ def two_class_gainloss_outputs():
     one_cal = constants.calibration.get(sole_class) or ClassCalibration()
     init_row = funding_inputs["init_funding"].iloc[0].to_dict()
 
-    new_constants = dataclasses.replace(
-        constants,
-        classes=("a", "b"),
-        valuation_inputs={"a": one_vi, "b": one_vi},
-        calibration={"a": one_cal, "b": one_cal},
-    )
+    new_constants = constants.model_copy(update={
+        "classes": ("a", "b"),
+        "valuation_inputs": {"a": one_vi, "b": one_vi},
+        "calibration": {"a": one_cal, "b": one_cal},
+    })
 
     new_liability = {"a": one_liab.copy(), "b": one_liab.copy()}
 

--- a/tests/test_pension_model/test_rundown.py
+++ b/tests/test_pension_model/test_rundown.py
@@ -24,7 +24,6 @@ The test verifies:
 """
 
 import sys
-from dataclasses import replace
 from pathlib import Path
 import pytest
 import numpy as np
@@ -55,7 +54,7 @@ def rundown_results():
     # model_copy so the derived properties (entry_year_range etc.)
     # follow.
     new_ranges = constants.ranges.model_copy(update={"model_period": RUNDOWN_PERIOD})
-    constants = replace(constants, ranges=new_ranges)
+    constants = constants.model_copy(update={"ranges": new_ranges})
 
     liability = run_plan_pipeline(constants, no_new_entrants=True)
 

--- a/tests/test_pension_model/test_schemas.py
+++ b/tests/test_pension_model/test_schemas.py
@@ -23,6 +23,7 @@ from pension_model.schemas import (
     Cola,
     Condition,
     CorridorAvaSmoothing,
+    DataSpec,
     Decrements,
     EarlyRetireReduction,
     EarlyRetireRule,
@@ -33,12 +34,14 @@ from pension_model.schemas import (
     GrandfatheredCondition,
     GrandfatheredParams,
     Modeling,
+    MortalitySpec,
     MultiplierRules,
     PlanDesign,
     PlanDesignRatios,
     Ranges,
     RateComponentSpec,
     ReduceCondition,
+    TermVested,
     Tier,
     ValuationInputs,
     validate_tier_cross_references,
@@ -1125,3 +1128,112 @@ class TestTier:
         })
         with pytest.raises(ValueError, match="circular"):
             validate_tier_cross_references([t1, t2])
+
+
+# ---------------------------------------------------------------------------
+# DataSpec / MortalitySpec / TermVested
+# ---------------------------------------------------------------------------
+
+
+class TestDataSpec:
+    def test_loads(self):
+        d = DataSpec.model_validate({"data_dir": "plans/frs/data"})
+        assert d.data_dir == "plans/frs/data"
+
+    def test_missing_data_dir_raises(self):
+        with pytest.raises(ValidationError, match="data_dir"):
+            DataSpec.model_validate({})
+
+    def test_extra_field_raises(self):
+        with pytest.raises(ValidationError, match="extra"):
+            DataSpec.model_validate({"data_dir": "x", "extra_key": "y"})
+
+
+class TestMortalitySpec:
+    def test_loads_with_improvement_scale(self):
+        m = MortalitySpec.model_validate({
+            "base_table": "pub_2010_teacher_below_median",
+            "improvement_scale": "mp_2021",
+        })
+        assert m.base_table == "pub_2010_teacher_below_median"
+        assert m.improvement_scale == "mp_2021"
+
+    def test_default_base_table(self):
+        m = MortalitySpec.model_validate({})
+        assert m.base_table == "general"
+        assert m.improvement_scale is None
+
+
+class TestTermVested:
+    def test_loads(self):
+        tv = TermVested.model_validate({
+            "avg_deferral_years": 12,
+            "avg_payout_years": 25,
+            "method": "deferred_annuity",
+        })
+        assert tv.avg_deferral_years == 12
+        assert tv.method == "deferred_annuity"
+
+    def test_unknown_method_raises(self):
+        with pytest.raises(ValidationError, match="deferred_annuity"):
+            TermVested.model_validate({
+                "avg_deferral_years": 12,
+                "avg_payout_years": 25,
+                "method": "made_up_method",
+            })
+
+
+# ---------------------------------------------------------------------------
+# Top-level PlanConfig
+# ---------------------------------------------------------------------------
+
+
+class TestPlanConfigTopLevel:
+    """Regression checks for the pydantic top-level PlanConfig.
+
+    Schema-level concerns only — bit-identity vs R lives in the truth-
+    table tests. These cover: typed access works for every section,
+    documentation `*_notes` keys at top level don't break load, missing
+    required sections fail fast, JSON Schema regenerates identically.
+    """
+
+    def test_loads_three_plans(self):
+        from pension_model.config_loading import load_plan_config_by_name
+
+        for plan in ("frs", "txtrs", "txtrs-av"):
+            cfg = load_plan_config_by_name(plan)
+            assert cfg.plan_name == plan
+            assert cfg.dr_current > 0
+            assert len(cfg.tier_defs) >= 1
+            assert isinstance(cfg.data, DataSpec)
+
+    def test_documentation_notes_keys_ignored(self):
+        # FRS has design_ratio_group_map_notes and valuation_inputs_notes
+        # at top level. They must not raise.
+        from pension_model.config_loading import load_plan_config_by_name
+
+        cfg = load_plan_config_by_name("frs")
+        # extra=ignore at top level — keys silently dropped, plan loads.
+        assert cfg.design_ratio_group_map.get("admin") == "regular_group"
+
+    def test_json_schema_matches_committed(self):
+        # If the schema generation drifts from the committed file,
+        # the migration plan's "live document for editors" guarantee
+        # is broken. Regenerate plans/_schema/plan_config.schema.json
+        # to fix.
+        import json
+        from pathlib import Path
+
+        from pension_model.config_schema import PlanConfig
+
+        repo_root = Path(__file__).parents[2]
+        committed = json.loads(
+            (repo_root / "plans" / "_schema" / "plan_config.schema.json").read_text()
+        )
+        live = PlanConfig.model_json_schema(by_alias=True)
+        assert live == committed, (
+            "JSON Schema drift. Regenerate with:\n"
+            "  python -c \"import json; from pension_model.config_schema import PlanConfig; "
+            "open('plans/_schema/plan_config.schema.json','w').write("
+            "json.dumps(PlanConfig.model_json_schema(by_alias=True), indent=2, sort_keys=True)+'\\n')\""
+        )

--- a/tests/test_pension_model/test_stage3_loader.py
+++ b/tests/test_pension_model/test_stage3_loader.py
@@ -265,16 +265,14 @@ def test_unknown_retirement_rate_set_raises(frs_config, tmp_path):
     a clear ValueError. Catches typos and broken refactors that today's
     silent-fallback code would absorb without warning.
     """
-    from dataclasses import replace
     import pandas as pd
     from pension_model.core.data_loader import _build_yos_only_decrements
 
-    # Force one tier to declare an unknown rate set. _tier_id_to_retire_rate_set
+    # Force one tier to declare an unknown rate set. tier_id_to_retire_rate_set
     # is a tuple[str, ...] cached on PlanConfig.
-    bogus = replace(
-        frs_config,
-        _tier_id_to_retire_rate_set=("before_2011", "bogus_set", "2011_or_later"),
-    )
+    bogus = frs_config.model_copy(update={
+        "tier_id_to_retire_rate_set": ("before_2011", "bogus_set", "2011_or_later"),
+    })
 
     # A valid term_df shape with the lookup_type column the loader keys on
     term_df = pd.DataFrame({
@@ -314,7 +312,6 @@ def test_overlapping_funding_legs_raises(frs_config):
     """Funding legs whose entry-year ranges overlap raise a clear
     ValueError listing the overlapping leg names.
     """
-    from dataclasses import replace
     from pension_model.config_validation import validate_funding_legs
     from pension_model.schemas import LegDef
 
@@ -324,7 +321,7 @@ def test_overlapping_funding_legs_raises(frs_config):
             LegDef(name="new", entry_year_min=2020),  # overlap 2020-2029
         ],
     })
-    bogus = replace(frs_config, funding=new_funding)
+    bogus = frs_config.model_copy(update={"funding": new_funding})
 
     with pytest.raises(ValueError, match="overlap"):
         validate_funding_legs(bogus)
@@ -334,7 +331,6 @@ def test_gappy_funding_legs_raises(frs_config):
     """Funding legs that don't cover the full entry-year range raise a
     clear ValueError naming the uncovered year.
     """
-    from dataclasses import replace
     from pension_model.config_validation import validate_funding_legs
     from pension_model.schemas import LegDef
 
@@ -344,7 +340,7 @@ def test_gappy_funding_legs_raises(frs_config):
             LegDef(name="new", entry_year_min=2020),  # gap 2010-2019
         ],
     })
-    bogus = replace(frs_config, funding=new_funding)
+    bogus = frs_config.model_copy(update={"funding": new_funding})
 
     with pytest.raises(ValueError, match="not covered"):
         validate_funding_legs(bogus)
@@ -367,7 +363,6 @@ def test_missing_per_class_nra_raises(frs_config):
     'default' fallback raises a clear ValueError. Catches forgetting
     to declare an NRA for one of the plan's classes.
     """
-    from dataclasses import replace
     from pension_model.config_resolvers import get_reduce_factor
 
     # FRS tier_1 uses a per-class NRA map. Build a tier_defs tuple with
@@ -382,7 +377,7 @@ def test_missing_per_class_nra_raises(frs_config):
             new_tier_defs.append(td.model_copy(update={"early_retire_reduction": new_err}))
         else:
             new_tier_defs.append(td)
-    bogus = replace(frs_config, tier_defs=tuple(new_tier_defs))
+    bogus = frs_config.model_copy(update={"tier_defs": tuple(new_tier_defs)})
 
     # 'regular' isn't in the map and no default — should raise.
     with pytest.raises(ValueError, match="no 'default'"):

--- a/tests/test_pension_model/test_vectorized_resolvers_txtrs.py
+++ b/tests/test_pension_model/test_vectorized_resolvers_txtrs.py
@@ -93,11 +93,10 @@ def test_resolve_ben_mult_vec_matches_scalar_txtrs():
 
 
 def test_resolve_reduce_factor_vec_matches_scalar_txtrs():
-    from dataclasses import replace
     from pension_model.core.data_loader import load_reduction_tables
 
     config = load_plan_config_by_name("txtrs")
-    config = replace(config, reduce_tables=load_reduction_tables(config))
+    config = config.model_copy(update={"reduce_tables": load_reduction_tables(config)})
     rows = build_txtrs_grid()
     cn, ey, age, yos = rows_to_arrays(rows)
 


### PR DESCRIPTION
Closes #163. Final PR of the 8-PR pydantic schema migration.

Replaces the `PlanConfig` dataclass with a pydantic `BaseModel`, drops the `raw: dict` escape hatch, generates a JSON Schema for editor support, and types the three remaining small sections.

## Summary

- **New schemas** (`src/pension_model/schemas/`):
  - `data_spec.py` — `DataSpec` (`data_dir`).
  - `mortality.py` — `MortalitySpec` (`base_table` + optional `improvement_scale`). TXTRS-style plans use this; FRS-style plans rely on the per-class `base_table_map` instead.
  - `term_vested.py` — `TermVested` (TXTRS-AV data prep). Typed so prep scripts can reuse the same validation surface.
- **`PlanConfig` rewrite** — `@dataclass(frozen=True)` → pydantic `BaseModel`. Composes every section model. `extra=\"ignore\"` at the top level so documentation `*_notes` keys don't fail strict load (sub-models stay `extra=\"forbid\"`). Field aliases preserve the current Python names (`tier_defs` ⇄ JSON `tiers`, `benefit_mult_defs` ⇄ `benefit_multipliers`, `scenario_name` ⇄ `_scenario_name`). Cross-reference validation runs at parse time via a `model_validator`.
- **Deleted `raw: dict`** — migrated the six remaining `self.raw.*` reads (`resolve_data_dir`, `scenario_name`, `salary_growth_col_map`, `base_table_map`, `design_ratio_group_map`, `mortality_base_table`) to typed fields.
- **`dataclasses.replace` → `model_copy`** in the few callers that mutated configs in tests + the reduce-tables back-fill in `core/data_loader.py`.
- **JSON Schema** — `plans/_schema/plan_config.schema.json` committed (~30 KB). New test guards regeneration drift with a clear remediation message.

## Out of scope (deferred follow-ups)

- **Typed `ScenarioOverrides`.** Scenario merge still flows through `_deep_merge` on raw JSON dicts before pydantic parsing — the *result* is now strictly typed, which is most of the value. A typed-overlay model can come as a follow-up.
- **CSV-input validation** (#162) — pandera/pyarrow for the data-side CSVs. Different layer; tracked separately.

## Test plan

- [x] `make r-match` — 8/8 truth-table cells bit-identical at 1e-10 vs R baseline.
- [x] Full pytest — 462 passed, 2 skipped.
- [x] All three plan configs (FRS, TXTRS, TXTRS-AV) load through the new typed path.
- [x] JSON Schema regenerate-and-diff is clean (committed file matches `model_json_schema(by_alias=True)`).

## Phase

`phase-r-is-truth` — bit-identical migration; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)