### PR TITLE
Phase A robustness: identity checks, output uniformity, top-level strict, compat cleanup

### DIFF
--- a/plans/_schema/plan_config.schema.json
+++ b/plans/_schema/plan_config.schema.json
@@ -1508,7 +1508,8 @@
       "type": "object"
     }
   },
-  "description": "Top-level plan_config.json model.\n\nSection sub-models (`economic`, `funding`, etc.) are validated\nstrictly. The top level itself ignores unknown keys so that\nembedded documentation (``*_notes``, ``source_notes``,\n``_scenario_name``) doesn't fail load. ``frozen=True`` keeps\nconfigs immutable; the few lookup tables computed at load time\nuse ``object.__setattr__`` in :func:`build_plan_config_from_raw`.",
+  "additionalProperties": false,
+  "description": "Top-level plan_config.json model.\n\nStrict at every level: unknown keys at the top *or* inside any\nsub-model fail validation. ``frozen=True`` keeps configs\nimmutable; the few lookup tables computed at load time use\n``object.__setattr__`` in :func:`build_plan_config_from_raw`.\n\nTo document a field, use the typed ``notes`` block:\n\n.. code-block:: json\n\n    \"notes\": {\n        \"design_ratio_group_map\": \"admin maps to regular_group ...\",\n        \"valuation_inputs\": \"AAL figures from 2023 AV Table B-2\"\n    }",
   "properties": {
     "_scenario_name": {
       "anyOf": [
@@ -1585,6 +1586,22 @@
     "funding": {
       "$ref": "#/$defs/Funding"
     },
+    "inapplicable_summary_columns": {
+      "default": [],
+      "items": {
+        "type": "string"
+      },
+      "title": "Inapplicable Summary Columns",
+      "type": "array"
+    },
+    "inapplicable_truth_table_columns": {
+      "default": [],
+      "items": {
+        "type": "string"
+      },
+      "title": "Inapplicable Truth Table Columns",
+      "type": "array"
+    },
     "modeling": {
       "$ref": "#/$defs/Modeling"
     },
@@ -1598,6 +1615,11 @@
         }
       ],
       "default": null
+    },
+    "notes": {
+      "additionalProperties": true,
+      "title": "Notes",
+      "type": "object"
     },
     "plan_description": {
       "default": "",

--- a/plans/frs/config/plan_config.json
+++ b/plans/frs/config/plan_config.json
@@ -1,11 +1,9 @@
 {
   "plan_name": "frs",
   "plan_description": "Florida Retirement System",
-
   "data": {
     "data_dir": "plans/frs/data"
   },
-
   "economic": {
     "dr_current": 0.067,
     "dr_new": 0.067,
@@ -14,13 +12,15 @@
     "pop_growth": 0.0,
     "model_return": 0.067
   },
-
   "benefit": {
     "db_ee_cont_rate": 0.03,
     "db_ee_interest_rate": 0.0,
     "retire_refund_ratio": 1.0,
     "fas_years_default": 5,
-    "benefit_types": ["db", "dc"],
+    "benefit_types": [
+      "db",
+      "dc"
+    ],
     "cola": {
       "tier_1_active": 0.03,
       "tier_1_active_constant": false,
@@ -32,7 +32,6 @@
       "proration_cutoff_year": 2011
     }
   },
-
   "funding": {
     "has_drop": true,
     "drop_reference_class": "regular",
@@ -46,20 +45,24 @@
     "amo_term_growth": 0.03,
     "ava_smoothing": {
       "method": "corridor",
-      "corridor_low": 0.80,
-      "corridor_high": 1.20,
-      "recognition_fraction": 0.20
+      "corridor_low": 0.8,
+      "corridor_high": 1.2,
+      "recognition_fraction": 0.2
     },
     "legs": [
-      {"name": "legacy", "entry_year_max_param": "new_year"},
-      {"name": "new", "entry_year_min_param": "new_year"}
+      {
+        "name": "legacy",
+        "entry_year_max_param": "new_year"
+      },
+      {
+        "name": "new",
+        "entry_year_min_param": "new_year"
+      }
     ]
   },
-
   "decrements": {
     "method": "yos_only"
   },
-
   "ranges": {
     "min_age": 18,
     "max_age": 120,
@@ -69,19 +72,31 @@
     "model_period": 30,
     "max_yos": 70
   },
-
-  "classes": ["regular", "special", "admin", "eco", "eso", "judges", "senior_management"],
-
+  "classes": [
+    "regular",
+    "special",
+    "admin",
+    "eco",
+    "eso",
+    "judges",
+    "senior_management"
+  ],
   "class_groups": {
-    "regular_group": ["regular", "eco", "eso", "judges", "senior_management"],
-    "special_group": ["special", "admin"]
+    "regular_group": [
+      "regular",
+      "eco",
+      "eso",
+      "judges",
+      "senior_management"
+    ],
+    "special_group": [
+      "special",
+      "admin"
+    ]
   },
-
-  "design_ratio_group_map_notes": "Override for DB/DC design ratios only. R's liability model uses 'if (class_name == \"special\")' so only the literal 'special' class gets special-group design ratios; admin (in special_group for tier eligibility) gets regular-group design ratios.",
   "design_ratio_group_map": {
     "admin": "regular_group"
   },
-
   "tiers": [
     {
       "name": "tier_1",
@@ -91,22 +106,41 @@
       "eligibility": {
         "regular_group": {
           "normal": [
-            {"min_yos": 30},
-            {"min_age": 62, "min_yos": 6}
+            {
+              "min_yos": 30
+            },
+            {
+              "min_age": 62,
+              "min_yos": 6
+            }
           ],
           "early": [
-            {"min_age": 58, "min_yos": 6}
+            {
+              "min_age": 58,
+              "min_yos": 6
+            }
           ],
           "vesting_yos": 6
         },
         "special_group": {
           "normal": [
-            {"min_yos": 25},
-            {"min_age": 55, "min_yos": 6},
-            {"min_age": 52, "min_yos": 25}
+            {
+              "min_yos": 25
+            },
+            {
+              "min_age": 55,
+              "min_yos": 6
+            },
+            {
+              "min_age": 52,
+              "min_yos": 25
+            }
           ],
           "early": [
-            {"min_age": 53, "min_yos": 6}
+            {
+              "min_age": 53,
+              "min_yos": 6
+            }
           ],
           "vesting_yos": 6
         }
@@ -130,21 +164,37 @@
       "eligibility": {
         "regular_group": {
           "normal": [
-            {"min_yos": 33},
-            {"min_age": 65, "min_yos": 8}
+            {
+              "min_yos": 33
+            },
+            {
+              "min_age": 65,
+              "min_yos": 8
+            }
           ],
           "early": [
-            {"min_age": 61, "min_yos": 8}
+            {
+              "min_age": 61,
+              "min_yos": 8
+            }
           ],
           "vesting_yos": 8
         },
         "special_group": {
           "normal": [
-            {"min_yos": 30},
-            {"min_age": 60, "min_yos": 8}
+            {
+              "min_yos": 30
+            },
+            {
+              "min_age": 60,
+              "min_yos": 8
+            }
           ],
           "early": [
-            {"min_age": 56, "min_yos": 8}
+            {
+              "min_age": 56,
+              "min_yos": 8
+            }
           ],
           "vesting_yos": 8
         }
@@ -171,75 +221,295 @@
       "retirement_rate_set": "2011_or_later"
     }
   ],
-
   "benefit_multipliers": {
     "regular": {
       "tier_1": {
         "graded": [
-          {"or": [{"min_age": 65, "min_yos": 6}, {"min_yos": 33}], "mult": 0.0168},
-          {"or": [{"min_age": 64, "min_yos": 6}, {"min_yos": 32}], "mult": 0.0165},
-          {"or": [{"min_age": 63, "min_yos": 6}, {"min_yos": 31}], "mult": 0.0163},
-          {"or": [{"min_age": 62, "min_yos": 6}, {"min_yos": 30}], "mult": 0.0160}
+          {
+            "or": [
+              {
+                "min_age": 65,
+                "min_yos": 6
+              },
+              {
+                "min_yos": 33
+              }
+            ],
+            "mult": 0.0168
+          },
+          {
+            "or": [
+              {
+                "min_age": 64,
+                "min_yos": 6
+              },
+              {
+                "min_yos": 32
+              }
+            ],
+            "mult": 0.0165
+          },
+          {
+            "or": [
+              {
+                "min_age": 63,
+                "min_yos": 6
+              },
+              {
+                "min_yos": 31
+              }
+            ],
+            "mult": 0.0163
+          },
+          {
+            "or": [
+              {
+                "min_age": 62,
+                "min_yos": 6
+              },
+              {
+                "min_yos": 30
+              }
+            ],
+            "mult": 0.016
+          }
         ],
-        "early_fallback": 0.0160
+        "early_fallback": 0.016
       },
       "tier_2": {
         "graded": [
-          {"or": [{"min_age": 68, "min_yos": 8}, {"min_yos": 36}], "mult": 0.0168},
-          {"or": [{"min_age": 67, "min_yos": 8}, {"min_yos": 35}], "mult": 0.0165},
-          {"or": [{"min_age": 66, "min_yos": 8}, {"min_yos": 34}], "mult": 0.0163},
-          {"or": [{"min_age": 65, "min_yos": 8}, {"min_yos": 33}], "mult": 0.0160}
+          {
+            "or": [
+              {
+                "min_age": 68,
+                "min_yos": 8
+              },
+              {
+                "min_yos": 36
+              }
+            ],
+            "mult": 0.0168
+          },
+          {
+            "or": [
+              {
+                "min_age": 67,
+                "min_yos": 8
+              },
+              {
+                "min_yos": 35
+              }
+            ],
+            "mult": 0.0165
+          },
+          {
+            "or": [
+              {
+                "min_age": 66,
+                "min_yos": 8
+              },
+              {
+                "min_yos": 34
+              }
+            ],
+            "mult": 0.0163
+          },
+          {
+            "or": [
+              {
+                "min_age": 65,
+                "min_yos": 8
+              },
+              {
+                "min_yos": 33
+              }
+            ],
+            "mult": 0.016
+          }
         ],
-        "early_fallback": 0.0160
+        "early_fallback": 0.016
       },
       "tier_3_same_as": "tier_2"
     },
     "admin": {
       "tier_1": {
         "graded": [
-          {"or": [{"min_age": 58, "min_yos": 6}, {"min_yos": 28}], "mult": 0.0168},
-          {"or": [{"min_age": 57, "min_yos": 6}, {"min_yos": 27}], "mult": 0.0165},
-          {"or": [{"min_age": 56, "min_yos": 6}, {"min_yos": 26}], "mult": 0.0163},
-          {"or": [{"min_age": 55, "min_yos": 6}, {"min_yos": 25}], "mult": 0.0160}
+          {
+            "or": [
+              {
+                "min_age": 58,
+                "min_yos": 6
+              },
+              {
+                "min_yos": 28
+              }
+            ],
+            "mult": 0.0168
+          },
+          {
+            "or": [
+              {
+                "min_age": 57,
+                "min_yos": 6
+              },
+              {
+                "min_yos": 27
+              }
+            ],
+            "mult": 0.0165
+          },
+          {
+            "or": [
+              {
+                "min_age": 56,
+                "min_yos": 6
+              },
+              {
+                "min_yos": 26
+              }
+            ],
+            "mult": 0.0163
+          },
+          {
+            "or": [
+              {
+                "min_age": 55,
+                "min_yos": 6
+              },
+              {
+                "min_yos": 25
+              }
+            ],
+            "mult": 0.016
+          }
         ],
-        "early_fallback": 0.0160
+        "early_fallback": 0.016
       },
       "tier_2": {
         "graded": [
-          {"or": [{"min_age": 63, "min_yos": 8}, {"min_yos": 33}], "mult": 0.0168},
-          {"or": [{"min_age": 62, "min_yos": 8}, {"min_yos": 32}], "mult": 0.0165},
-          {"or": [{"min_age": 61, "min_yos": 8}, {"min_yos": 31}], "mult": 0.0163},
-          {"or": [{"min_age": 60, "min_yos": 8}, {"min_yos": 30}], "mult": 0.0160}
+          {
+            "or": [
+              {
+                "min_age": 63,
+                "min_yos": 8
+              },
+              {
+                "min_yos": 33
+              }
+            ],
+            "mult": 0.0168
+          },
+          {
+            "or": [
+              {
+                "min_age": 62,
+                "min_yos": 8
+              },
+              {
+                "min_yos": 32
+              }
+            ],
+            "mult": 0.0165
+          },
+          {
+            "or": [
+              {
+                "min_age": 61,
+                "min_yos": 8
+              },
+              {
+                "min_yos": 31
+              }
+            ],
+            "mult": 0.0163
+          },
+          {
+            "or": [
+              {
+                "min_age": 60,
+                "min_yos": 8
+              },
+              {
+                "min_yos": 30
+              }
+            ],
+            "mult": 0.016
+          }
         ],
-        "early_fallback": 0.0160
+        "early_fallback": 0.016
       },
       "tier_3": {
         "graded": [
-          {"or": [{"min_age": 63, "min_yos": 8}], "mult": 0.0168},
-          {"or": [{"min_age": 62, "min_yos": 8}], "mult": 0.0165},
-          {"or": [{"min_age": 61, "min_yos": 8}], "mult": 0.0163},
-          {"or": [{"min_age": 60, "min_yos": 8}], "mult": 0.0160}
+          {
+            "or": [
+              {
+                "min_age": 63,
+                "min_yos": 8
+              }
+            ],
+            "mult": 0.0168
+          },
+          {
+            "or": [
+              {
+                "min_age": 62,
+                "min_yos": 8
+              }
+            ],
+            "mult": 0.0165
+          },
+          {
+            "or": [
+              {
+                "min_age": 61,
+                "min_yos": 8
+              }
+            ],
+            "mult": 0.0163
+          },
+          {
+            "or": [
+              {
+                "min_age": 60,
+                "min_yos": 8
+              }
+            ],
+            "mult": 0.016
+          }
         ],
-        "early_fallback": 0.0160
+        "early_fallback": 0.016
       }
     },
     "special": {
-      "all_tiers": {"flat": 0.03, "flat_before_year": {"year": 1974, "mult": 0.02}}
+      "all_tiers": {
+        "flat": 0.03,
+        "flat_before_year": {
+          "year": 1974,
+          "mult": 0.02
+        }
+      }
     },
     "eco": {
-      "all_tiers": {"flat": 0.03}
+      "all_tiers": {
+        "flat": 0.03
+      }
     },
     "eso": {
-      "all_tiers": {"flat": 0.03}
+      "all_tiers": {
+        "flat": 0.03
+      }
     },
     "judges": {
-      "all_tiers": {"flat": 0.0333}
+      "all_tiers": {
+        "flat": 0.0333
+      }
     },
     "senior_management": {
-      "all_tiers": {"flat": 0.02}
+      "all_tiers": {
+        "flat": 0.02
+      }
     }
   },
-
   "plan_design": {
     "cutoff_year": 2018,
     "special_group": {
@@ -253,11 +523,6 @@
       "new": 0.25
     }
   },
-
-  "valuation_inputs_notes": {
-    "ben_payment": "Initial-year pension benefit payments to current retirees. Derived as: per-class ACFR outflow * plan-wide ben_payment_ratio (0.935839). The ratio comes from ACFR totals: pension_payment / (pension_payment + contribution_refunds + disbursement_to_ip + admin_expense) = 11,944,986,866 / 12,763,932,044. See GH issue for investigation of whether this derivation is correct."
-  },
-
   "valuation_inputs": {
     "regular": {
       "ben_payment": 8391759183.371059,
@@ -290,7 +555,11 @@
       "ben_payment": 8836192.922367,
       "retiree_pop": 227,
       "total_active_member": 2075,
-      "headcount_group": ["eco", "eso", "judges"],
+      "headcount_group": [
+        "eco",
+        "eso",
+        "judges"
+      ],
       "er_dc_cont_rate": 0.0994,
       "val_norm_cost": 0.1254,
       "val_aal": 138008000,
@@ -300,7 +569,11 @@
       "ben_payment": 50091724.461199,
       "retiree_pop": 1446,
       "total_active_member": 2075,
-      "headcount_group": ["eco", "eso", "judges"],
+      "headcount_group": [
+        "eco",
+        "eso",
+        "judges"
+      ],
       "er_dc_cont_rate": 0.1195,
       "val_norm_cost": 0.1463,
       "val_aal": 751363000,
@@ -310,7 +583,11 @@
       "ben_payment": 99052955.271665,
       "retiree_pop": 989,
       "total_active_member": 2075,
-      "headcount_group": ["eco", "eso", "judges"],
+      "headcount_group": [
+        "eco",
+        "eso",
+        "judges"
+      ],
       "er_dc_cont_rate": 0.1405,
       "val_norm_cost": 0.1777,
       "val_aal": 1545348000,
@@ -326,20 +603,40 @@
       "val_payroll": 824335420
     }
   },
-
   "modeling": {
     "use_earliest_retire": false,
     "male_mp_forward_shift": 0,
     "age_groups": [
-      {"max_age": 24, "label": "under_25"},
-      {"min_age": 25, "max_age": 29, "label": "25_to_29"},
-      {"min_age": 30, "max_age": 34, "label": "30_to_34"},
-      {"min_age": 35, "max_age": 44, "label": "35_to_44"},
-      {"min_age": 45, "max_age": 54, "label": "45_to_54"},
-      {"min_age": 55, "label": "over_55"}
+      {
+        "max_age": 24,
+        "label": "under_25"
+      },
+      {
+        "min_age": 25,
+        "max_age": 29,
+        "label": "25_to_29"
+      },
+      {
+        "min_age": 30,
+        "max_age": 34,
+        "label": "30_to_34"
+      },
+      {
+        "min_age": 35,
+        "max_age": 44,
+        "label": "35_to_44"
+      },
+      {
+        "min_age": 45,
+        "max_age": 54,
+        "label": "45_to_54"
+      },
+      {
+        "min_age": 55,
+        "label": "over_55"
+      }
     ]
   },
-
   "salary_growth_col_map": {
     "regular": "salary_increase_regular",
     "special": "salary_increase_special_risk",
@@ -349,7 +646,6 @@
     "judges": "salary_increase_judges",
     "senior_management": "salary_increase_senior_management"
   },
-
   "base_table_map": {
     "regular": "regular",
     "special": "safety",
@@ -358,5 +654,11 @@
     "eso": "general",
     "judges": "general",
     "senior_management": "general"
+  },
+  "notes": {
+    "design_ratio_group_map": "Override for DB/DC design ratios only. R's liability model uses 'if (class_name == \"special\")' so only the literal 'special' class gets special-group design ratios; admin (in special_group for tier eligibility) gets regular-group design ratios.",
+    "valuation_inputs": {
+      "ben_payment": "Initial-year pension benefit payments to current retirees. Derived as: per-class ACFR outflow * plan-wide ben_payment_ratio (0.935839). The ratio comes from ACFR totals: pension_payment / (pension_payment + contribution_refunds + disbursement_to_ip + admin_expense) = 11,944,986,866 / 12,763,932,044. See GH issue for investigation of whether this derivation is correct."
+    }
   }
 }

--- a/plans/frs/config/plan_config.json
+++ b/plans/frs/config/plan_config.json
@@ -1,9 +1,11 @@
 {
   "plan_name": "frs",
   "plan_description": "Florida Retirement System",
+
   "data": {
     "data_dir": "plans/frs/data"
   },
+
   "economic": {
     "dr_current": 0.067,
     "dr_new": 0.067,
@@ -12,15 +14,13 @@
     "pop_growth": 0.0,
     "model_return": 0.067
   },
+
   "benefit": {
     "db_ee_cont_rate": 0.03,
     "db_ee_interest_rate": 0.0,
     "retire_refund_ratio": 1.0,
     "fas_years_default": 5,
-    "benefit_types": [
-      "db",
-      "dc"
-    ],
+    "benefit_types": ["db", "dc"],
     "cola": {
       "tier_1_active": 0.03,
       "tier_1_active_constant": false,
@@ -32,6 +32,7 @@
       "proration_cutoff_year": 2011
     }
   },
+
   "funding": {
     "has_drop": true,
     "drop_reference_class": "regular",
@@ -45,24 +46,20 @@
     "amo_term_growth": 0.03,
     "ava_smoothing": {
       "method": "corridor",
-      "corridor_low": 0.8,
-      "corridor_high": 1.2,
-      "recognition_fraction": 0.2
+      "corridor_low": 0.80,
+      "corridor_high": 1.20,
+      "recognition_fraction": 0.20
     },
     "legs": [
-      {
-        "name": "legacy",
-        "entry_year_max_param": "new_year"
-      },
-      {
-        "name": "new",
-        "entry_year_min_param": "new_year"
-      }
+      {"name": "legacy", "entry_year_max_param": "new_year"},
+      {"name": "new", "entry_year_min_param": "new_year"}
     ]
   },
+
   "decrements": {
     "method": "yos_only"
   },
+
   "ranges": {
     "min_age": 18,
     "max_age": 120,
@@ -72,31 +69,18 @@
     "model_period": 30,
     "max_yos": 70
   },
-  "classes": [
-    "regular",
-    "special",
-    "admin",
-    "eco",
-    "eso",
-    "judges",
-    "senior_management"
-  ],
+
+  "classes": ["regular", "special", "admin", "eco", "eso", "judges", "senior_management"],
+
   "class_groups": {
-    "regular_group": [
-      "regular",
-      "eco",
-      "eso",
-      "judges",
-      "senior_management"
-    ],
-    "special_group": [
-      "special",
-      "admin"
-    ]
+    "regular_group": ["regular", "eco", "eso", "judges", "senior_management"],
+    "special_group": ["special", "admin"]
   },
+
   "design_ratio_group_map": {
     "admin": "regular_group"
   },
+
   "tiers": [
     {
       "name": "tier_1",
@@ -106,41 +90,22 @@
       "eligibility": {
         "regular_group": {
           "normal": [
-            {
-              "min_yos": 30
-            },
-            {
-              "min_age": 62,
-              "min_yos": 6
-            }
+            {"min_yos": 30},
+            {"min_age": 62, "min_yos": 6}
           ],
           "early": [
-            {
-              "min_age": 58,
-              "min_yos": 6
-            }
+            {"min_age": 58, "min_yos": 6}
           ],
           "vesting_yos": 6
         },
         "special_group": {
           "normal": [
-            {
-              "min_yos": 25
-            },
-            {
-              "min_age": 55,
-              "min_yos": 6
-            },
-            {
-              "min_age": 52,
-              "min_yos": 25
-            }
+            {"min_yos": 25},
+            {"min_age": 55, "min_yos": 6},
+            {"min_age": 52, "min_yos": 25}
           ],
           "early": [
-            {
-              "min_age": 53,
-              "min_yos": 6
-            }
+            {"min_age": 53, "min_yos": 6}
           ],
           "vesting_yos": 6
         }
@@ -164,37 +129,21 @@
       "eligibility": {
         "regular_group": {
           "normal": [
-            {
-              "min_yos": 33
-            },
-            {
-              "min_age": 65,
-              "min_yos": 8
-            }
+            {"min_yos": 33},
+            {"min_age": 65, "min_yos": 8}
           ],
           "early": [
-            {
-              "min_age": 61,
-              "min_yos": 8
-            }
+            {"min_age": 61, "min_yos": 8}
           ],
           "vesting_yos": 8
         },
         "special_group": {
           "normal": [
-            {
-              "min_yos": 30
-            },
-            {
-              "min_age": 60,
-              "min_yos": 8
-            }
+            {"min_yos": 30},
+            {"min_age": 60, "min_yos": 8}
           ],
           "early": [
-            {
-              "min_age": 56,
-              "min_yos": 8
-            }
+            {"min_age": 56, "min_yos": 8}
           ],
           "vesting_yos": 8
         }
@@ -221,295 +170,75 @@
       "retirement_rate_set": "2011_or_later"
     }
   ],
+
   "benefit_multipliers": {
     "regular": {
       "tier_1": {
         "graded": [
-          {
-            "or": [
-              {
-                "min_age": 65,
-                "min_yos": 6
-              },
-              {
-                "min_yos": 33
-              }
-            ],
-            "mult": 0.0168
-          },
-          {
-            "or": [
-              {
-                "min_age": 64,
-                "min_yos": 6
-              },
-              {
-                "min_yos": 32
-              }
-            ],
-            "mult": 0.0165
-          },
-          {
-            "or": [
-              {
-                "min_age": 63,
-                "min_yos": 6
-              },
-              {
-                "min_yos": 31
-              }
-            ],
-            "mult": 0.0163
-          },
-          {
-            "or": [
-              {
-                "min_age": 62,
-                "min_yos": 6
-              },
-              {
-                "min_yos": 30
-              }
-            ],
-            "mult": 0.016
-          }
+          {"or": [{"min_age": 65, "min_yos": 6}, {"min_yos": 33}], "mult": 0.0168},
+          {"or": [{"min_age": 64, "min_yos": 6}, {"min_yos": 32}], "mult": 0.0165},
+          {"or": [{"min_age": 63, "min_yos": 6}, {"min_yos": 31}], "mult": 0.0163},
+          {"or": [{"min_age": 62, "min_yos": 6}, {"min_yos": 30}], "mult": 0.0160}
         ],
-        "early_fallback": 0.016
+        "early_fallback": 0.0160
       },
       "tier_2": {
         "graded": [
-          {
-            "or": [
-              {
-                "min_age": 68,
-                "min_yos": 8
-              },
-              {
-                "min_yos": 36
-              }
-            ],
-            "mult": 0.0168
-          },
-          {
-            "or": [
-              {
-                "min_age": 67,
-                "min_yos": 8
-              },
-              {
-                "min_yos": 35
-              }
-            ],
-            "mult": 0.0165
-          },
-          {
-            "or": [
-              {
-                "min_age": 66,
-                "min_yos": 8
-              },
-              {
-                "min_yos": 34
-              }
-            ],
-            "mult": 0.0163
-          },
-          {
-            "or": [
-              {
-                "min_age": 65,
-                "min_yos": 8
-              },
-              {
-                "min_yos": 33
-              }
-            ],
-            "mult": 0.016
-          }
+          {"or": [{"min_age": 68, "min_yos": 8}, {"min_yos": 36}], "mult": 0.0168},
+          {"or": [{"min_age": 67, "min_yos": 8}, {"min_yos": 35}], "mult": 0.0165},
+          {"or": [{"min_age": 66, "min_yos": 8}, {"min_yos": 34}], "mult": 0.0163},
+          {"or": [{"min_age": 65, "min_yos": 8}, {"min_yos": 33}], "mult": 0.0160}
         ],
-        "early_fallback": 0.016
+        "early_fallback": 0.0160
       },
       "tier_3_same_as": "tier_2"
     },
     "admin": {
       "tier_1": {
         "graded": [
-          {
-            "or": [
-              {
-                "min_age": 58,
-                "min_yos": 6
-              },
-              {
-                "min_yos": 28
-              }
-            ],
-            "mult": 0.0168
-          },
-          {
-            "or": [
-              {
-                "min_age": 57,
-                "min_yos": 6
-              },
-              {
-                "min_yos": 27
-              }
-            ],
-            "mult": 0.0165
-          },
-          {
-            "or": [
-              {
-                "min_age": 56,
-                "min_yos": 6
-              },
-              {
-                "min_yos": 26
-              }
-            ],
-            "mult": 0.0163
-          },
-          {
-            "or": [
-              {
-                "min_age": 55,
-                "min_yos": 6
-              },
-              {
-                "min_yos": 25
-              }
-            ],
-            "mult": 0.016
-          }
+          {"or": [{"min_age": 58, "min_yos": 6}, {"min_yos": 28}], "mult": 0.0168},
+          {"or": [{"min_age": 57, "min_yos": 6}, {"min_yos": 27}], "mult": 0.0165},
+          {"or": [{"min_age": 56, "min_yos": 6}, {"min_yos": 26}], "mult": 0.0163},
+          {"or": [{"min_age": 55, "min_yos": 6}, {"min_yos": 25}], "mult": 0.0160}
         ],
-        "early_fallback": 0.016
+        "early_fallback": 0.0160
       },
       "tier_2": {
         "graded": [
-          {
-            "or": [
-              {
-                "min_age": 63,
-                "min_yos": 8
-              },
-              {
-                "min_yos": 33
-              }
-            ],
-            "mult": 0.0168
-          },
-          {
-            "or": [
-              {
-                "min_age": 62,
-                "min_yos": 8
-              },
-              {
-                "min_yos": 32
-              }
-            ],
-            "mult": 0.0165
-          },
-          {
-            "or": [
-              {
-                "min_age": 61,
-                "min_yos": 8
-              },
-              {
-                "min_yos": 31
-              }
-            ],
-            "mult": 0.0163
-          },
-          {
-            "or": [
-              {
-                "min_age": 60,
-                "min_yos": 8
-              },
-              {
-                "min_yos": 30
-              }
-            ],
-            "mult": 0.016
-          }
+          {"or": [{"min_age": 63, "min_yos": 8}, {"min_yos": 33}], "mult": 0.0168},
+          {"or": [{"min_age": 62, "min_yos": 8}, {"min_yos": 32}], "mult": 0.0165},
+          {"or": [{"min_age": 61, "min_yos": 8}, {"min_yos": 31}], "mult": 0.0163},
+          {"or": [{"min_age": 60, "min_yos": 8}, {"min_yos": 30}], "mult": 0.0160}
         ],
-        "early_fallback": 0.016
+        "early_fallback": 0.0160
       },
       "tier_3": {
         "graded": [
-          {
-            "or": [
-              {
-                "min_age": 63,
-                "min_yos": 8
-              }
-            ],
-            "mult": 0.0168
-          },
-          {
-            "or": [
-              {
-                "min_age": 62,
-                "min_yos": 8
-              }
-            ],
-            "mult": 0.0165
-          },
-          {
-            "or": [
-              {
-                "min_age": 61,
-                "min_yos": 8
-              }
-            ],
-            "mult": 0.0163
-          },
-          {
-            "or": [
-              {
-                "min_age": 60,
-                "min_yos": 8
-              }
-            ],
-            "mult": 0.016
-          }
+          {"or": [{"min_age": 63, "min_yos": 8}], "mult": 0.0168},
+          {"or": [{"min_age": 62, "min_yos": 8}], "mult": 0.0165},
+          {"or": [{"min_age": 61, "min_yos": 8}], "mult": 0.0163},
+          {"or": [{"min_age": 60, "min_yos": 8}], "mult": 0.0160}
         ],
-        "early_fallback": 0.016
+        "early_fallback": 0.0160
       }
     },
     "special": {
-      "all_tiers": {
-        "flat": 0.03,
-        "flat_before_year": {
-          "year": 1974,
-          "mult": 0.02
-        }
-      }
+      "all_tiers": {"flat": 0.03, "flat_before_year": {"year": 1974, "mult": 0.02}}
     },
     "eco": {
-      "all_tiers": {
-        "flat": 0.03
-      }
+      "all_tiers": {"flat": 0.03}
     },
     "eso": {
-      "all_tiers": {
-        "flat": 0.03
-      }
+      "all_tiers": {"flat": 0.03}
     },
     "judges": {
-      "all_tiers": {
-        "flat": 0.0333
-      }
+      "all_tiers": {"flat": 0.0333}
     },
     "senior_management": {
-      "all_tiers": {
-        "flat": 0.02
-      }
+      "all_tiers": {"flat": 0.02}
     }
   },
+
   "plan_design": {
     "cutoff_year": 2018,
     "special_group": {
@@ -523,6 +252,14 @@
       "new": 0.25
     }
   },
+
+  "notes": {
+    "design_ratio_group_map": "Override for DB/DC design ratios only. R's liability model uses 'if (class_name == \"special\")' so only the literal 'special' class gets special-group design ratios; admin (in special_group for tier eligibility) gets regular-group design ratios.",
+    "valuation_inputs": {
+      "ben_payment": "Initial-year pension benefit payments to current retirees. Derived as: per-class ACFR outflow * plan-wide ben_payment_ratio (0.935839). The ratio comes from ACFR totals: pension_payment / (pension_payment + contribution_refunds + disbursement_to_ip + admin_expense) = 11,944,986,866 / 12,763,932,044. See GH issue for investigation of whether this derivation is correct."
+    }
+  },
+
   "valuation_inputs": {
     "regular": {
       "ben_payment": 8391759183.371059,
@@ -555,11 +292,7 @@
       "ben_payment": 8836192.922367,
       "retiree_pop": 227,
       "total_active_member": 2075,
-      "headcount_group": [
-        "eco",
-        "eso",
-        "judges"
-      ],
+      "headcount_group": ["eco", "eso", "judges"],
       "er_dc_cont_rate": 0.0994,
       "val_norm_cost": 0.1254,
       "val_aal": 138008000,
@@ -569,11 +302,7 @@
       "ben_payment": 50091724.461199,
       "retiree_pop": 1446,
       "total_active_member": 2075,
-      "headcount_group": [
-        "eco",
-        "eso",
-        "judges"
-      ],
+      "headcount_group": ["eco", "eso", "judges"],
       "er_dc_cont_rate": 0.1195,
       "val_norm_cost": 0.1463,
       "val_aal": 751363000,
@@ -583,11 +312,7 @@
       "ben_payment": 99052955.271665,
       "retiree_pop": 989,
       "total_active_member": 2075,
-      "headcount_group": [
-        "eco",
-        "eso",
-        "judges"
-      ],
+      "headcount_group": ["eco", "eso", "judges"],
       "er_dc_cont_rate": 0.1405,
       "val_norm_cost": 0.1777,
       "val_aal": 1545348000,
@@ -603,40 +328,20 @@
       "val_payroll": 824335420
     }
   },
+
   "modeling": {
     "use_earliest_retire": false,
     "male_mp_forward_shift": 0,
     "age_groups": [
-      {
-        "max_age": 24,
-        "label": "under_25"
-      },
-      {
-        "min_age": 25,
-        "max_age": 29,
-        "label": "25_to_29"
-      },
-      {
-        "min_age": 30,
-        "max_age": 34,
-        "label": "30_to_34"
-      },
-      {
-        "min_age": 35,
-        "max_age": 44,
-        "label": "35_to_44"
-      },
-      {
-        "min_age": 45,
-        "max_age": 54,
-        "label": "45_to_54"
-      },
-      {
-        "min_age": 55,
-        "label": "over_55"
-      }
+      {"max_age": 24, "label": "under_25"},
+      {"min_age": 25, "max_age": 29, "label": "25_to_29"},
+      {"min_age": 30, "max_age": 34, "label": "30_to_34"},
+      {"min_age": 35, "max_age": 44, "label": "35_to_44"},
+      {"min_age": 45, "max_age": 54, "label": "45_to_54"},
+      {"min_age": 55, "label": "over_55"}
     ]
   },
+
   "salary_growth_col_map": {
     "regular": "salary_increase_regular",
     "special": "salary_increase_special_risk",
@@ -646,6 +351,7 @@
     "judges": "salary_increase_judges",
     "senior_management": "salary_increase_senior_management"
   },
+
   "base_table_map": {
     "regular": "regular",
     "special": "safety",
@@ -654,11 +360,5 @@
     "eso": "general",
     "judges": "general",
     "senior_management": "general"
-  },
-  "notes": {
-    "design_ratio_group_map": "Override for DB/DC design ratios only. R's liability model uses 'if (class_name == \"special\")' so only the literal 'special' class gets special-group design ratios; admin (in special_group for tier eligibility) gets regular-group design ratios.",
-    "valuation_inputs": {
-      "ben_payment": "Initial-year pension benefit payments to current retirees. Derived as: per-class ACFR outflow * plan-wide ben_payment_ratio (0.935839). The ratio comes from ACFR totals: pension_payment / (pension_payment + contribution_refunds + disbursement_to_ip + admin_expense) = 11,944,986,866 / 12,763,932,044. See GH issue for investigation of whether this derivation is correct."
-    }
   }
 }

--- a/plans/txtrs-av/config/plan_config.json
+++ b/plans/txtrs-av/config/plan_config.json
@@ -1,11 +1,9 @@
 {
   "plan_name": "txtrs-av",
   "plan_description": "Teacher Retirement System of Texas (AV-first)",
-
   "data": {
     "data_dir": "plans/txtrs-av/data"
   },
-
   "economic": {
     "dr_current": 0.07,
     "dr_new": 0.07,
@@ -13,14 +11,15 @@
     "payroll_growth": 0.029,
     "model_return": 0.07
   },
-
   "benefit": {
     "db_ee_cont_rate": 0.0825,
     "db_ee_interest_rate": 0.02,
     "fas_years_default": 5,
     "fas_years_grandfathered": 3,
     "min_benefit_monthly": 150,
-    "benefit_types": ["db"],
+    "benefit_types": [
+      "db"
+    ],
     "cola": {
       "tier_1_active": 0.0,
       "tier_2_active": 0.0,
@@ -32,7 +31,6 @@
       "proration_cutoff_year": null
     }
   },
-
   "funding": {
     "contribution_strategy": "statutory",
     "policy": "statutory",
@@ -47,43 +45,62 @@
     },
     "statutory_rates": {
       "ee_rate_schedule": [
-        {"from_year": 2024, "rate": 0.0825}
+        {
+          "from_year": 2024,
+          "rate": 0.0825
+        }
       ],
       "er_rate_components": [
         {
           "name": "er_stat_base_rate",
           "payroll_share": 1.0,
           "schedule": [
-            {"from_year": 2024, "rate": 0.0825}
+            {
+              "from_year": 2024,
+              "rate": 0.0825
+            }
           ]
         },
         {
           "name": "public_edu_surcharge_rate",
           "payroll_share": 0.588,
           "schedule": [
-            {"from_year": 2024, "rate": 0.019},
-            {"from_year": 2025, "rate": 0.02}
+            {
+              "from_year": 2024,
+              "rate": 0.019
+            },
+            {
+              "from_year": 2025,
+              "rate": 0.02
+            }
           ]
         },
         {
           "name": "er_stat_extra_rate",
           "payroll_share": 1.0,
           "schedule": [
-            {"from_year": 2024, "rate": 0.0}
+            {
+              "from_year": 2024,
+              "rate": 0.0
+            }
           ]
         }
       ]
     },
     "legs": [
-      {"name": "legacy", "entry_year_max_param": "new_year"},
-      {"name": "new", "entry_year_min_param": "new_year"}
+      {
+        "name": "legacy",
+        "entry_year_max_param": "new_year"
+      },
+      {
+        "name": "new",
+        "entry_year_min_param": "new_year"
+      }
     ]
   },
-
   "decrements": {
     "method": "years_from_nr"
   },
-
   "ranges": {
     "min_age": 20,
     "max_age": 120,
@@ -93,20 +110,20 @@
     "model_period": 30,
     "max_yos": 70
   },
-
   "term_vested": {
     "avg_deferral_years": 12,
     "avg_payout_years": 25,
     "method": "deferred_annuity",
     "notes": "Parameters for the shared deferred-annuity term-vested cashflow method. avg_deferral_years approximates the gap between average current age of term-vested members and the assumed distribution age; avg_payout_years approximates remaining life expectancy at the distribution age. Initial values are reasonable defaults; refine from valuation demographics when available. Used only by data prep (scripts/build/build_av_term_vested_cashflow.py) to produce data/funding/current_term_vested_cashflow.csv; the runtime reads the CSV and does not consult this section."
   },
-
-  "classes": ["all"],
-
+  "classes": [
+    "all"
+  ],
   "class_groups": {
-    "default": ["all"]
+    "default": [
+      "all"
+    ]
   },
-
   "tiers": [
     {
       "name": "grandfathered",
@@ -114,30 +131,65 @@
       "grandfathered_params": {
         "cutoff_year": 2005,
         "conditions": [
-          {"min_age_at_cutoff": 50},
-          {"rule_of_at_cutoff": 70},
-          {"min_yos_at_cutoff": 25}
+          {
+            "min_age_at_cutoff": 50
+          },
+          {
+            "rule_of_at_cutoff": 70
+          },
+          {
+            "min_yos_at_cutoff": 25
+          }
         ]
       },
       "fas_years": 3,
       "eligibility": {
         "default": {
           "normal": [
-            {"min_age": 65, "min_yos": 5},
-            {"rule_of": 80, "min_yos": 5}
+            {
+              "min_age": 65,
+              "min_yos": 5
+            },
+            {
+              "rule_of": 80,
+              "min_yos": 5
+            }
           ],
           "early": [
-            {"min_age": 55, "min_yos": 5},
-            {"min_yos": 30}
+            {
+              "min_age": 55,
+              "min_yos": 5
+            },
+            {
+              "min_yos": 30
+            }
           ],
           "vesting_yos": 5
         }
       },
       "early_retire_reduction": {
         "rules": [
-          {"condition": {"min_yos": 30}, "formula": "linear", "rate_per_year": 0.02, "nra": 50},
-          {"condition": {"min_yos": 20, "grandfathered": true}, "formula": "table", "table_key": "reduced_gft"},
-          {"condition": {}, "formula": "table", "table_key": "reduced_others"}
+          {
+            "condition": {
+              "min_yos": 30
+            },
+            "formula": "linear",
+            "rate_per_year": 0.02,
+            "nra": 50
+          },
+          {
+            "condition": {
+              "min_yos": 20,
+              "grandfathered": true
+            },
+            "formula": "table",
+            "table_key": "reduced_gft"
+          },
+          {
+            "condition": {},
+            "formula": "table",
+            "table_key": "reduced_others"
+          }
         ]
       },
       "cola_key": "tier_1_active",
@@ -151,20 +203,42 @@
       "eligibility": {
         "default": {
           "normal": [
-            {"min_age": 65, "min_yos": 5},
-            {"rule_of": 80, "min_yos": 5}
+            {
+              "min_age": 65,
+              "min_yos": 5
+            },
+            {
+              "rule_of": 80,
+              "min_yos": 5
+            }
           ],
           "early": [
-            {"min_age": 55, "min_yos": 5},
-            {"min_yos": 30}
+            {
+              "min_age": 55,
+              "min_yos": 5
+            },
+            {
+              "min_yos": 30
+            }
           ],
           "vesting_yos": 5
         }
       },
       "early_retire_reduction": {
         "rules": [
-          {"condition": {"min_yos": 30}, "formula": "linear", "rate_per_year": 0.02, "nra": 50},
-          {"condition": {}, "formula": "table", "table_key": "reduced_others"}
+          {
+            "condition": {
+              "min_yos": 30
+            },
+            "formula": "linear",
+            "rate_per_year": 0.02,
+            "nra": 50
+          },
+          {
+            "condition": {},
+            "formula": "table",
+            "table_key": "reduced_others"
+          }
         ]
       },
       "cola_key": "tier_2_active",
@@ -179,21 +253,54 @@
       "eligibility": {
         "default": {
           "normal": [
-            {"min_age": 65, "min_yos": 5},
-            {"rule_of": 80, "min_age": 60, "min_yos": 5}
+            {
+              "min_age": 65,
+              "min_yos": 5
+            },
+            {
+              "rule_of": 80,
+              "min_age": 60,
+              "min_yos": 5
+            }
           ],
           "early": [
-            {"min_age": 55, "min_yos": 5},
-            {"min_yos": 30},
-            {"rule_of": 80, "min_yos": 5}
+            {
+              "min_age": 55,
+              "min_yos": 5
+            },
+            {
+              "min_yos": 30
+            },
+            {
+              "rule_of": 80,
+              "min_yos": 5
+            }
           ],
           "vesting_yos": 5
         }
       },
       "early_retire_reduction": {
         "rules": [
-          {"condition": {"or": [{"rule_of": 80}, {"min_yos": 30}]}, "formula": "linear", "rate_per_year": 0.05, "nra": 60},
-          {"condition": {}, "formula": "table", "table_key": "reduced_others"}
+          {
+            "condition": {
+              "or": [
+                {
+                  "rule_of": 80
+                },
+                {
+                  "min_yos": 30
+                }
+              ]
+            },
+            "formula": "linear",
+            "rate_per_year": 0.05,
+            "nra": 60
+          },
+          {
+            "condition": {},
+            "formula": "table",
+            "table_key": "reduced_others"
+          }
         ]
       },
       "cola_key": "tier_3_active",
@@ -207,39 +314,71 @@
       "eligibility": {
         "default": {
           "normal": [
-            {"min_age": 65, "min_yos": 5},
-            {"rule_of": 80, "min_age": 62, "min_yos": 5}
+            {
+              "min_age": 65,
+              "min_yos": 5
+            },
+            {
+              "rule_of": 80,
+              "min_age": 62,
+              "min_yos": 5
+            }
           ],
           "early": [
-            {"min_age": 55, "min_yos": 5},
-            {"min_yos": 30},
-            {"rule_of": 80, "min_yos": 5}
+            {
+              "min_age": 55,
+              "min_yos": 5
+            },
+            {
+              "min_yos": 30
+            },
+            {
+              "rule_of": 80,
+              "min_yos": 5
+            }
           ],
           "vesting_yos": 5
         }
       },
       "early_retire_reduction": {
         "rules": [
-          {"condition": {"or": [{"rule_of": 80}, {"min_yos": 30}]}, "formula": "linear", "rate_per_year": 0.05, "nra": 62},
-          {"condition": {}, "formula": "table", "table_key": "reduced_others"}
+          {
+            "condition": {
+              "or": [
+                {
+                  "rule_of": 80
+                },
+                {
+                  "min_yos": 30
+                }
+              ]
+            },
+            "formula": "linear",
+            "rate_per_year": 0.05,
+            "nra": 62
+          },
+          {
+            "condition": {},
+            "formula": "table",
+            "table_key": "reduced_others"
+          }
         ]
       },
       "cola_key": "tier_4_active",
       "retirement_rate_set": "all"
     }
   ],
-
   "benefit_multipliers": {
     "all": {
-      "all_tiers": {"flat": 0.023}
+      "all_tiers": {
+        "flat": 0.023
+      }
     }
   },
-
   "modeling": {
     "male_mp_forward_shift": 2,
     "entrant_salary_at_start_year": true
   },
-
   "plan_design": {
     "cutoff_year": null,
     "default": {
@@ -247,7 +386,6 @@
       "new_db": 1.0
     }
   },
-
   "valuation_inputs": {
     "all": {
       "ben_payment": 15258219146,
@@ -259,24 +397,24 @@
       "val_payroll": 61388248000
     }
   },
-
   "mortality": {
     "base_table": "txtrs_av_av_first",
     "improvement_scale": "ump_2021_immediate"
   },
-
-  "source_notes": {
-    "purpose": "First-cut AV-first txtrs-av runtime config.",
-    "scope_rule": "This file is built from valuation-supported plan shape and valuation-linked runtime needs, not by copying txtrs runtime semantics wholesale.",
-    "omitted_runtime_legacy_fields": [
-      "retire_refund_ratio",
-      "use_earliest_retire",
-      "cash_balance",
-      "dc",
-      "calibration"
-    ],
-    "tier_encoding_note": "The valuation distinguishes members vested by August 31, 2014 from those not vested by that date. The current runtime cannot encode that status test directly, so this first cut approximates it with entry_year 2008-2009 versus 2010+.",
-    "mortality_note": "Active and retiree mortality files are still pending. The labels here name the intended txtrs-av AV-first mortality path rather than the older txtrs compatibility path.",
-    "funding_note": "Current-year valuation anchors are source-backed. The gain/loss smoothing method and 4-year recognition period remain runtime settings that should be revisited if the valuation's exact operational smoothing language is later captured more precisely."
+  "notes": {
+    "source_notes": {
+      "purpose": "First-cut AV-first txtrs-av runtime config.",
+      "scope_rule": "This file is built from valuation-supported plan shape and valuation-linked runtime needs, not by copying txtrs runtime semantics wholesale.",
+      "omitted_runtime_legacy_fields": [
+        "retire_refund_ratio",
+        "use_earliest_retire",
+        "cash_balance",
+        "dc",
+        "calibration"
+      ],
+      "tier_encoding_note": "The valuation distinguishes members vested by August 31, 2014 from those not vested by that date. The current runtime cannot encode that status test directly, so this first cut approximates it with entry_year 2008-2009 versus 2010+.",
+      "mortality_note": "Active and retiree mortality files are still pending. The labels here name the intended txtrs-av AV-first mortality path rather than the older txtrs compatibility path.",
+      "funding_note": "Current-year valuation anchors are source-backed. The gain/loss smoothing method and 4-year recognition period remain runtime settings that should be revisited if the valuation's exact operational smoothing language is later captured more precisely."
+    }
   }
 }

--- a/plans/txtrs-av/config/plan_config.json
+++ b/plans/txtrs-av/config/plan_config.json
@@ -1,9 +1,11 @@
 {
   "plan_name": "txtrs-av",
   "plan_description": "Teacher Retirement System of Texas (AV-first)",
+
   "data": {
     "data_dir": "plans/txtrs-av/data"
   },
+
   "economic": {
     "dr_current": 0.07,
     "dr_new": 0.07,
@@ -11,15 +13,14 @@
     "payroll_growth": 0.029,
     "model_return": 0.07
   },
+
   "benefit": {
     "db_ee_cont_rate": 0.0825,
     "db_ee_interest_rate": 0.02,
     "fas_years_default": 5,
     "fas_years_grandfathered": 3,
     "min_benefit_monthly": 150,
-    "benefit_types": [
-      "db"
-    ],
+    "benefit_types": ["db"],
     "cola": {
       "tier_1_active": 0.0,
       "tier_2_active": 0.0,
@@ -31,6 +32,7 @@
       "proration_cutoff_year": null
     }
   },
+
   "funding": {
     "contribution_strategy": "statutory",
     "policy": "statutory",
@@ -45,62 +47,43 @@
     },
     "statutory_rates": {
       "ee_rate_schedule": [
-        {
-          "from_year": 2024,
-          "rate": 0.0825
-        }
+        {"from_year": 2024, "rate": 0.0825}
       ],
       "er_rate_components": [
         {
           "name": "er_stat_base_rate",
           "payroll_share": 1.0,
           "schedule": [
-            {
-              "from_year": 2024,
-              "rate": 0.0825
-            }
+            {"from_year": 2024, "rate": 0.0825}
           ]
         },
         {
           "name": "public_edu_surcharge_rate",
           "payroll_share": 0.588,
           "schedule": [
-            {
-              "from_year": 2024,
-              "rate": 0.019
-            },
-            {
-              "from_year": 2025,
-              "rate": 0.02
-            }
+            {"from_year": 2024, "rate": 0.019},
+            {"from_year": 2025, "rate": 0.02}
           ]
         },
         {
           "name": "er_stat_extra_rate",
           "payroll_share": 1.0,
           "schedule": [
-            {
-              "from_year": 2024,
-              "rate": 0.0
-            }
+            {"from_year": 2024, "rate": 0.0}
           ]
         }
       ]
     },
     "legs": [
-      {
-        "name": "legacy",
-        "entry_year_max_param": "new_year"
-      },
-      {
-        "name": "new",
-        "entry_year_min_param": "new_year"
-      }
+      {"name": "legacy", "entry_year_max_param": "new_year"},
+      {"name": "new", "entry_year_min_param": "new_year"}
     ]
   },
+
   "decrements": {
     "method": "years_from_nr"
   },
+
   "ranges": {
     "min_age": 20,
     "max_age": 120,
@@ -110,20 +93,20 @@
     "model_period": 30,
     "max_yos": 70
   },
+
   "term_vested": {
     "avg_deferral_years": 12,
     "avg_payout_years": 25,
     "method": "deferred_annuity",
     "notes": "Parameters for the shared deferred-annuity term-vested cashflow method. avg_deferral_years approximates the gap between average current age of term-vested members and the assumed distribution age; avg_payout_years approximates remaining life expectancy at the distribution age. Initial values are reasonable defaults; refine from valuation demographics when available. Used only by data prep (scripts/build/build_av_term_vested_cashflow.py) to produce data/funding/current_term_vested_cashflow.csv; the runtime reads the CSV and does not consult this section."
   },
-  "classes": [
-    "all"
-  ],
+
+  "classes": ["all"],
+
   "class_groups": {
-    "default": [
-      "all"
-    ]
+    "default": ["all"]
   },
+
   "tiers": [
     {
       "name": "grandfathered",
@@ -131,65 +114,30 @@
       "grandfathered_params": {
         "cutoff_year": 2005,
         "conditions": [
-          {
-            "min_age_at_cutoff": 50
-          },
-          {
-            "rule_of_at_cutoff": 70
-          },
-          {
-            "min_yos_at_cutoff": 25
-          }
+          {"min_age_at_cutoff": 50},
+          {"rule_of_at_cutoff": 70},
+          {"min_yos_at_cutoff": 25}
         ]
       },
       "fas_years": 3,
       "eligibility": {
         "default": {
           "normal": [
-            {
-              "min_age": 65,
-              "min_yos": 5
-            },
-            {
-              "rule_of": 80,
-              "min_yos": 5
-            }
+            {"min_age": 65, "min_yos": 5},
+            {"rule_of": 80, "min_yos": 5}
           ],
           "early": [
-            {
-              "min_age": 55,
-              "min_yos": 5
-            },
-            {
-              "min_yos": 30
-            }
+            {"min_age": 55, "min_yos": 5},
+            {"min_yos": 30}
           ],
           "vesting_yos": 5
         }
       },
       "early_retire_reduction": {
         "rules": [
-          {
-            "condition": {
-              "min_yos": 30
-            },
-            "formula": "linear",
-            "rate_per_year": 0.02,
-            "nra": 50
-          },
-          {
-            "condition": {
-              "min_yos": 20,
-              "grandfathered": true
-            },
-            "formula": "table",
-            "table_key": "reduced_gft"
-          },
-          {
-            "condition": {},
-            "formula": "table",
-            "table_key": "reduced_others"
-          }
+          {"condition": {"min_yos": 30}, "formula": "linear", "rate_per_year": 0.02, "nra": 50},
+          {"condition": {"min_yos": 20, "grandfathered": true}, "formula": "table", "table_key": "reduced_gft"},
+          {"condition": {}, "formula": "table", "table_key": "reduced_others"}
         ]
       },
       "cola_key": "tier_1_active",
@@ -203,42 +151,20 @@
       "eligibility": {
         "default": {
           "normal": [
-            {
-              "min_age": 65,
-              "min_yos": 5
-            },
-            {
-              "rule_of": 80,
-              "min_yos": 5
-            }
+            {"min_age": 65, "min_yos": 5},
+            {"rule_of": 80, "min_yos": 5}
           ],
           "early": [
-            {
-              "min_age": 55,
-              "min_yos": 5
-            },
-            {
-              "min_yos": 30
-            }
+            {"min_age": 55, "min_yos": 5},
+            {"min_yos": 30}
           ],
           "vesting_yos": 5
         }
       },
       "early_retire_reduction": {
         "rules": [
-          {
-            "condition": {
-              "min_yos": 30
-            },
-            "formula": "linear",
-            "rate_per_year": 0.02,
-            "nra": 50
-          },
-          {
-            "condition": {},
-            "formula": "table",
-            "table_key": "reduced_others"
-          }
+          {"condition": {"min_yos": 30}, "formula": "linear", "rate_per_year": 0.02, "nra": 50},
+          {"condition": {}, "formula": "table", "table_key": "reduced_others"}
         ]
       },
       "cola_key": "tier_2_active",
@@ -253,54 +179,21 @@
       "eligibility": {
         "default": {
           "normal": [
-            {
-              "min_age": 65,
-              "min_yos": 5
-            },
-            {
-              "rule_of": 80,
-              "min_age": 60,
-              "min_yos": 5
-            }
+            {"min_age": 65, "min_yos": 5},
+            {"rule_of": 80, "min_age": 60, "min_yos": 5}
           ],
           "early": [
-            {
-              "min_age": 55,
-              "min_yos": 5
-            },
-            {
-              "min_yos": 30
-            },
-            {
-              "rule_of": 80,
-              "min_yos": 5
-            }
+            {"min_age": 55, "min_yos": 5},
+            {"min_yos": 30},
+            {"rule_of": 80, "min_yos": 5}
           ],
           "vesting_yos": 5
         }
       },
       "early_retire_reduction": {
         "rules": [
-          {
-            "condition": {
-              "or": [
-                {
-                  "rule_of": 80
-                },
-                {
-                  "min_yos": 30
-                }
-              ]
-            },
-            "formula": "linear",
-            "rate_per_year": 0.05,
-            "nra": 60
-          },
-          {
-            "condition": {},
-            "formula": "table",
-            "table_key": "reduced_others"
-          }
+          {"condition": {"or": [{"rule_of": 80}, {"min_yos": 30}]}, "formula": "linear", "rate_per_year": 0.05, "nra": 60},
+          {"condition": {}, "formula": "table", "table_key": "reduced_others"}
         ]
       },
       "cola_key": "tier_3_active",
@@ -314,71 +207,39 @@
       "eligibility": {
         "default": {
           "normal": [
-            {
-              "min_age": 65,
-              "min_yos": 5
-            },
-            {
-              "rule_of": 80,
-              "min_age": 62,
-              "min_yos": 5
-            }
+            {"min_age": 65, "min_yos": 5},
+            {"rule_of": 80, "min_age": 62, "min_yos": 5}
           ],
           "early": [
-            {
-              "min_age": 55,
-              "min_yos": 5
-            },
-            {
-              "min_yos": 30
-            },
-            {
-              "rule_of": 80,
-              "min_yos": 5
-            }
+            {"min_age": 55, "min_yos": 5},
+            {"min_yos": 30},
+            {"rule_of": 80, "min_yos": 5}
           ],
           "vesting_yos": 5
         }
       },
       "early_retire_reduction": {
         "rules": [
-          {
-            "condition": {
-              "or": [
-                {
-                  "rule_of": 80
-                },
-                {
-                  "min_yos": 30
-                }
-              ]
-            },
-            "formula": "linear",
-            "rate_per_year": 0.05,
-            "nra": 62
-          },
-          {
-            "condition": {},
-            "formula": "table",
-            "table_key": "reduced_others"
-          }
+          {"condition": {"or": [{"rule_of": 80}, {"min_yos": 30}]}, "formula": "linear", "rate_per_year": 0.05, "nra": 62},
+          {"condition": {}, "formula": "table", "table_key": "reduced_others"}
         ]
       },
       "cola_key": "tier_4_active",
       "retirement_rate_set": "all"
     }
   ],
+
   "benefit_multipliers": {
     "all": {
-      "all_tiers": {
-        "flat": 0.023
-      }
+      "all_tiers": {"flat": 0.023}
     }
   },
+
   "modeling": {
     "male_mp_forward_shift": 2,
     "entrant_salary_at_start_year": true
   },
+
   "plan_design": {
     "cutoff_year": null,
     "default": {
@@ -386,6 +247,7 @@
       "new_db": 1.0
     }
   },
+
   "valuation_inputs": {
     "all": {
       "ben_payment": 15258219146,
@@ -397,10 +259,12 @@
       "val_payroll": 61388248000
     }
   },
+
   "mortality": {
     "base_table": "txtrs_av_av_first",
     "improvement_scale": "ump_2021_immediate"
   },
+
   "notes": {
     "source_notes": {
       "purpose": "First-cut AV-first txtrs-av runtime config.",

--- a/src/pension_model/cli.py
+++ b/src/pension_model/cli.py
@@ -227,6 +227,17 @@ def _emit_truth_table(plan_name, liability, funding, constants, output_dir):
         )
 
         df = build_python_truth_table(plan_name, liability, funding, constants)
+
+        from pension_model.output_uniformity import assert_output_uniformity
+        from pension_model.truth_table import TRUTH_TABLE_COLUMNS
+        assert_output_uniformity(
+            df,
+            canonical_columns=TRUTH_TABLE_COLUMNS,
+            inapplicable=constants.inapplicable_truth_table_columns,
+            plan_name=plan_name,
+            output_name="truth_table",
+        )
+
         scenario = getattr(constants, "scenario_name", None)
 
         def _sheet_token(value):
@@ -281,7 +292,7 @@ def _emit_truth_table(plan_name, liability, funding, constants, output_dir):
 # Pipeline executor
 # ---------------------------------------------------------------------------
 
-def _execute_pipeline(constants):
+def _execute_pipeline(constants, *, check_identities: bool = False):
     """Run liability + funding pipeline for any plan.
 
     Returns (liability_dict, funding_dict, liability_stacked).
@@ -329,7 +340,10 @@ def _execute_pipeline(constants):
     funding_dir = constants.resolve_data_dir() / "funding"
     funding_inputs = load_funding_inputs(funding_dir)
 
-    funding = run_funding_model(liability, funding_inputs, constants)
+    funding = run_funding_model(
+        liability, funding_inputs, constants,
+        check_identities=check_identities,
+    )
 
     return liability, funding, liability_stacked
 
@@ -352,7 +366,10 @@ def _run_plan(constants, args):
 
     t0 = time.time()
     print_parameters(constants)
-    liability, funding, liability_stacked = _execute_pipeline(constants)
+    liability, funding, liability_stacked = _execute_pipeline(
+        constants,
+        check_identities=getattr(args, "check_identities", False),
+    )
     elapsed = time.time() - t0
     print(f"  Pipeline complete: {elapsed:.0f}s")
 
@@ -362,6 +379,16 @@ def _run_plan(constants, args):
     else:
         output_dir = OUTPUT_BASE / plan_name
     summary = build_plan_summary(plan_name, liability, funding, constants)
+
+    from pension_model.output_uniformity import assert_output_uniformity
+    assert_output_uniformity(
+        summary,
+        canonical_columns=SUMMARY_COLUMNS,
+        inapplicable=constants.inapplicable_summary_columns,
+        plan_name=plan_name,
+        output_name="summary",
+    )
+
     print_summary_table(summary)
     _write_outputs(summary, liability_stacked, output_dir)
 
@@ -672,6 +699,8 @@ def main():
                        help="Write R-vs-Python truth table to CSV and Excel")
     run_p.add_argument("--scenario", type=str, default=None,
                        help="Path to scenario JSON file (overrides baseline assumptions)")
+    run_p.add_argument("--check-identities", action="store_true",
+                       help="Verify MVA, AAL, and NC-dollar identities on funding output")
 
     cal = subparsers.add_parser("calibrate", help="Compute calibration factors")
     cal.add_argument("plan_name", choices=discovered or None,

--- a/src/pension_model/config_compat.py
+++ b/src/pension_model/config_compat.py
@@ -1,6 +1,0 @@
-"""Compatibility adapters layered on top of ``PlanConfig``.
-
-After the pydantic schema migration this module is empty; kept as
-an import-stable home in case future helpers belong here. See
-``scratch/pydantic_migration_plan.md`` for the migration history.
-"""

--- a/src/pension_model/config_loading.py
+++ b/src/pension_model/config_loading.py
@@ -30,6 +30,57 @@ from pension_model.schemas import (
 log = logging.getLogger(__name__)
 
 
+# Post-load fields populated by the loader, not present in
+# plan_config.json source. Excluded from the unknown-key check.
+_LOADER_POPULATED_FIELDS = frozenset({
+    "calibration",
+    "reduce_tables",
+    "class_to_group",
+    "tier_name_to_id",
+    "tier_id_to_name",
+    "tier_id_to_cola_key",
+    "tier_id_to_fas_years",
+    "tier_id_to_dr_key",
+    "tier_id_to_retire_rate_set",
+    "scenario_name",
+})
+
+
+def _expected_top_level_keys() -> set[str]:
+    """Top-level keys accepted in plan_config.json.
+
+    Reads ``PlanConfig.model_fields``; uses each field's JSON alias
+    where defined (e.g. ``benefit_multipliers``, ``tiers``).
+    """
+    keys: set[str] = set()
+    for name, field in PlanConfig.model_fields.items():
+        if name in _LOADER_POPULATED_FIELDS:
+            continue
+        keys.add(field.alias or name)
+    return keys
+
+
+def check_unknown_top_level_keys(raw: dict) -> None:
+    """Reject top-level plan_config.json keys not in :class:`PlanConfig`.
+
+    Pydantic's ``extra="forbid"`` cannot catch these on its own because
+    :func:`load_plan_config` cherry-picks named keys from ``raw`` rather
+    than passing the whole dict through ``PlanConfig.model_validate``.
+    Without this check, a typo at the top level (or a stale ``*_notes``
+    key) would load silently. Free-text documentation belongs in the
+    typed ``notes`` block.
+    """
+    unknown = set(raw.keys()) - _expected_top_level_keys()
+    if unknown:
+        expected = sorted(_expected_top_level_keys())
+        raise ValueError(
+            f"Unknown top-level key(s) in plan_config.json: "
+            f"{sorted(unknown)}. "
+            f"Expected one of: {expected}. "
+            f"Free-text documentation goes in the `notes` block."
+        )
+
+
 def _deep_merge(base: dict, overrides: dict) -> dict:
     """Recursively merge overrides into base dict (returns a new dict)."""
     result = dict(base)
@@ -163,6 +214,8 @@ def load_plan_config(
     with open(config_path) as f:
         raw = json.load(f)
 
+    check_unknown_top_level_keys(raw)
+
     baseline_dr_current = raw["economic"]["dr_current"]
     baseline_model_return = raw["economic"].get(
         "model_return", baseline_dr_current
@@ -270,6 +323,13 @@ def load_plan_config(
         salary_growth_col_map=raw.get("salary_growth_col_map", {}),
         base_table_map=raw.get("base_table_map", {}),
         design_ratio_group_map=raw.get("design_ratio_group_map", {}),
+        inapplicable_summary_columns=tuple(
+            raw.get("inapplicable_summary_columns", ())
+        ),
+        inapplicable_truth_table_columns=tuple(
+            raw.get("inapplicable_truth_table_columns", ())
+        ),
+        notes=raw.get("notes", {}),
         calibration=calibration,
         class_to_group=class_to_group,
         tier_name_to_id=tier_name_to_id,

--- a/src/pension_model/config_resolvers_vectorized.py
+++ b/src/pension_model/config_resolvers_vectorized.py
@@ -48,11 +48,11 @@ def _encode_class_group_values(
     """
     class_codes, class_labels = _encode_class_name_values(class_name)
     group_labels = tuple(
-        dict.fromkeys(config._class_to_group.get(class_value, "default") for class_value in class_labels)
+        dict.fromkeys(config.class_to_group.get(class_value, "default") for class_value in class_labels)
     )
     group_to_code = {group_label: i for i, group_label in enumerate(group_labels)}
     class_group_codes = np.array(
-        [group_to_code[config._class_to_group.get(class_value, "default")] for class_value in class_labels],
+        [group_to_code[config.class_to_group.get(class_value, "default")] for class_value in class_labels],
         dtype=np.int16,
     )
     return class_group_codes[class_codes], group_labels
@@ -229,7 +229,7 @@ def resolve_ben_mult_vec(
         class_name, tier_id, n_tiers
     ):
         rules = config.resolve_ben_mult(
-            class_name_value, config._tier_id_to_name[tier_index]
+            class_name_value, config.tier_id_to_name[tier_index]
         )
         if rules is None:
             continue
@@ -297,7 +297,7 @@ def resolve_reduce_factor_vec(
 
         sub_age = dist_age[idx_arr]
         sub_yos = yos[idx_arr]
-        tier_name = config._tier_id_to_name[tier_index]
+        tier_name = config.tier_id_to_name[tier_index]
 
         if reduction.is_flat:
             nra = reduction.lookup_nra(class_name_value, config.plan_name, tier_name)

--- a/src/pension_model/config_schema.py
+++ b/src/pension_model/config_schema.py
@@ -1,13 +1,14 @@
 """Plan config schema and status constants.
 
-The top-level :class:`PlanConfig` is now a pydantic ``BaseModel``
-that composes every section schema. Strict (``extra="forbid"``) is
-the rule on sub-models; the top-level uses ``extra="ignore"`` so
-plain documentation keys (``*_notes``, ``source_notes``) embedded
-in plan_config.json don't fail validation. Required sections —
-``economic``, ``ranges``, ``decrements``, ``funding``, ``benefit`` —
-are still required, so a typo at the top level surfaces as a
-"missing required field" error, not a silent drop.
+The top-level :class:`PlanConfig` is a pydantic ``BaseModel`` composed
+of every section schema. Strict (``extra="forbid"``) applies at every
+level — top-level *and* sub-models — so a typo at any depth fails
+load with a clear "extra fields not permitted" error.
+
+Plain-text documentation belongs in the typed ``notes`` block
+(``notes: {section_name: free-text-or-dict}``). Top-level ``*_notes``
+keys are not accepted; if you need to document a section, put the
+content inside ``notes`` instead.
 """
 
 from __future__ import annotations
@@ -48,16 +49,23 @@ NORM = 3
 class PlanConfig(BaseModel):
     """Top-level plan_config.json model.
 
-    Section sub-models (`economic`, `funding`, etc.) are validated
-    strictly. The top level itself ignores unknown keys so that
-    embedded documentation (``*_notes``, ``source_notes``,
-    ``_scenario_name``) doesn't fail load. ``frozen=True`` keeps
-    configs immutable; the few lookup tables computed at load time
-    use ``object.__setattr__`` in :func:`build_plan_config_from_raw`.
+    Strict at every level: unknown keys at the top *or* inside any
+    sub-model fail validation. ``frozen=True`` keeps configs
+    immutable; the few lookup tables computed at load time use
+    ``object.__setattr__`` in :func:`build_plan_config_from_raw`.
+
+    To document a field, use the typed ``notes`` block:
+
+    .. code-block:: json
+
+        "notes": {
+            "design_ratio_group_map": "admin maps to regular_group ...",
+            "valuation_inputs": "AAL figures from 2023 AV Table B-2"
+        }
     """
 
     model_config = ConfigDict(
-        extra="ignore",
+        extra="forbid",
         frozen=True,
         populate_by_name=True,
         arbitrary_types_allowed=True,
@@ -90,6 +98,17 @@ class PlanConfig(BaseModel):
     salary_growth_col_map: Dict[str, str] = Field(default_factory=dict)
     base_table_map: Dict[str, str] = Field(default_factory=dict)
     design_ratio_group_map: Dict[str, str] = Field(default_factory=dict)
+
+    # Output-uniformity declaration: columns in the canonical summary
+    # and truth-table outputs that are structurally inapplicable to
+    # this plan (e.g., AAL on a pure DC plan). Today both reference
+    # plans populate every column, so this is empty; it exists so a
+    # future plan can be honest about what it does and does not
+    # produce, and the runtime can assert the rest are populated.
+    inapplicable_summary_columns: Tuple[str, ...] = ()
+    inapplicable_truth_table_columns: Tuple[str, ...] = ()
+
+    notes: Dict[str, Any] = Field(default_factory=dict)
 
     scenario_name: Optional[str] = Field(default=None, alias="_scenario_name")
 
@@ -453,37 +472,3 @@ class PlanConfig(BaseModel):
     def validate_data_files(self) -> list:
         from pension_model.config_validation import validate_data_files
         return validate_data_files(self)
-
-    # ------------------------------------------------------------------
-    # Underscore-name aliases for legacy resolver code that still reads
-    # ``config._class_to_group`` etc. Defined as @property so they
-    # don't conflict with pydantic's field-name expectations.
-    # ------------------------------------------------------------------
-
-    @property
-    def _class_to_group(self) -> Dict[str, str]:
-        return self.class_to_group
-
-    @property
-    def _tier_name_to_id(self) -> Dict[str, int]:
-        return self.tier_name_to_id
-
-    @property
-    def _tier_id_to_name(self) -> Tuple[str, ...]:
-        return self.tier_id_to_name
-
-    @property
-    def _tier_id_to_cola_key(self) -> Tuple[str, ...]:
-        return self.tier_id_to_cola_key
-
-    @property
-    def _tier_id_to_fas_years(self) -> Tuple[int, ...]:
-        return self.tier_id_to_fas_years
-
-    @property
-    def _tier_id_to_dr_key(self) -> Tuple[str, ...]:
-        return self.tier_id_to_dr_key
-
-    @property
-    def _tier_id_to_retire_rate_set(self) -> Tuple[str, ...]:
-        return self.tier_id_to_retire_rate_set

--- a/src/pension_model/core/benefit_tables.py
+++ b/src/pension_model/core/benefit_tables.py
@@ -337,7 +337,7 @@ def build_salary_benefit_table(
     )
 
     # FAS period: direct lookup from tier_id
-    fas_by_tier = np.array(constants._tier_id_to_fas_years, dtype=np.int64)
+    fas_by_tier = np.array(constants.tier_id_to_fas_years, dtype=np.int64)
     df["fas_period"] = fas_by_tier[df["tier_id"].values]
 
     # Drop rows with NaN salary (entry_age not in profile)
@@ -450,7 +450,7 @@ def build_separation_rate_table(
         normal_retire_rate_by_set: Mapping {rate_set_name: DataFrame[age, normal_retire_rate]}.
         early_retire_rate_by_set: Mapping {rate_set_name: DataFrame[age, early_retire_rate]}.
             Each plan tier resolves to one of these keys via
-            ``constants._tier_id_to_retire_rate_set``.
+            ``constants.tier_id_to_retire_rate_set``.
         entrant_profile: Entrant profile with entry_age column.
         class_name: Membership class name.
         constants: PlanConfig.
@@ -549,13 +549,13 @@ def build_separation_rate_table(
     df["ret_status"] = rs_arr
 
     # Separation rate depends on tier_id and ret_status. Each plan
-    # tier maps to a named rate set via _tier_id_to_retire_rate_set
+    # tier maps to a named rate set via tier_id_to_retire_rate_set
     # (e.g., FRS tier_3 → "2011_or_later"). Vested and non-vested rows
     # fall through to the withdrawal rate.
     is_norm = rs_arr == NORM
     is_early = rs_arr == EARLY
     rate_set_by_tid = np.array(
-        constants._tier_id_to_retire_rate_set, dtype=object
+        constants.tier_id_to_retire_rate_set, dtype=object
     )
     rate_set_per_row = rate_set_by_tid[tid_arr]
     sep_rate = df["term_rate"].values.copy()
@@ -1384,7 +1384,7 @@ def build_benefit_val_table(
     sep_kind_arr = _resolve_sep_kind_vec(ret_status_arr)
     dr_by_tier_id = np.array(
         [_resolve_econ_rate(econ, k, constants.plan_name)
-         for k in constants._tier_id_to_dr_key],
+         for k in constants.tier_id_to_dr_key],
         dtype=np.float64,
     )
     dr_arr = dr_by_tier_id[sbt["tier_id"].to_numpy()]

--- a/src/pension_model/core/data_loader.py
+++ b/src/pension_model/core/data_loader.py
@@ -345,7 +345,7 @@ def _build_yos_only_decrements(
     # retirement_rate_set in plan_config.json (defaults to the tier's
     # own name).
     csv_rate_sets = list(ret_df["rate_set"].unique())
-    declared_sets = set(constants._tier_id_to_retire_rate_set)
+    declared_sets = set(constants.tier_id_to_retire_rate_set)
     missing = declared_sets - set(csv_rate_sets)
     if missing:
         raise ValueError(

--- a/src/pension_model/core/funding_model.py
+++ b/src/pension_model/core/funding_model.py
@@ -121,6 +121,10 @@ def run_funding_model(
     liability_results: dict,
     funding_inputs: dict,
     constants,
+    *,
+    check_identities: bool = False,
+    identity_tol_rel: float = 1e-9,
+    identity_tol_abs: float = 1e-3,
 ) -> dict:
     """Run the funding model for any plan.
 
@@ -128,9 +132,34 @@ def run_funding_model(
     method, contribution policy, and capability flags are dispatched
     inside via the resolved :class:`FundingContext`.
 
+    Parameters
+    ----------
+    check_identities:
+        If true, verify the MVA roll, AAL roll, and NC-dollar identities
+        on the resulting funding frames after the year loop completes.
+        Off by default; zero cost on normal runs.
+
     Returns:
         Dict mapping class_name -> funding DataFrame, plus an
         aggregate frame keyed by ``constants.plan_name`` and an
         optional ``"drop"`` frame for plans with ``has_drop=true``.
     """
-    return _compute_funding(liability_results, funding_inputs, constants)
+    funding = _compute_funding(liability_results, funding_inputs, constants)
+
+    if check_identities:
+        from pension_model.core._funding_setup import resolve_funding_context
+        from pension_model.core.identity_checks import check_funding_identities
+
+        ctx = resolve_funding_context(constants, funding_inputs)
+        check_funding_identities(
+            funding,
+            dr_current=ctx.dr_current,
+            dr_new=ctx.dr_new,
+            ret_scen=ctx.ret_scen,
+            has_cb=ctx.has_cb,
+            skip_classes={"drop"} if ctx.has_drop else set(),
+            tol_rel=identity_tol_rel,
+            tol_abs=identity_tol_abs,
+        )
+
+    return funding

--- a/src/pension_model/core/identity_checks.py
+++ b/src/pension_model/core/identity_checks.py
@@ -1,0 +1,250 @@
+"""Runtime assertion of funding-model identities.
+
+The funding model's correctness depends on three identities holding to
+floating-point precision (per ``meta-docs/pension_math.md``):
+
+* **MVA roll-forward** —
+  :func:`pension_model.core._funding_helpers._mva_rollforward`
+  ``mva[i] = mva[i-1] * (1 + roa) + net_cf[i] * (1 + roa) ** 0.5``
+* **AAL roll-forward** —
+  :func:`pension_model.core._funding_helpers._aal_rollforward`
+  ``aal[i] = aal[i-1] * (1 + dr) + (nc - ben - refund) * (1 + dr) ** 0.5 + liab_gl``
+* **Normal-cost dollar identity** —
+  ``nc_dollar = nc_rate * payroll`` per leg.
+
+These identities are computed inline in
+:mod:`pension_model.core._funding_phases` but never asserted. A bug
+that breaks one (column rename, indexing slip, off-by-one) silently
+produces numbers R also doesn't have, so the R-baseline test is no
+longer load-bearing for that bug.
+
+This module recomputes each identity from the funding frames and
+raises :class:`IdentityCheckError` on the first violation above
+tolerance. Off by default (zero cost on normal runs); enabled via the
+``--check-identities`` CLI flag, which sets
+:attr:`FundingContext.check_identities`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Mapping, Optional
+
+import numpy as np
+import pandas as pd
+
+from pension_model.core._funding_helpers import (
+    _aal_rollforward,
+    _mva_rollforward,
+)
+
+
+@dataclass
+class IdentityViolation:
+    """One residual that exceeded tolerance."""
+    year_index: int
+    class_name: str
+    leg: str            # "legacy" or "new"
+    identity: str       # "mva_rollforward", "aal_rollforward", "nc_dollar"
+    expected: float
+    actual: float
+    residual: float
+
+
+class IdentityCheckError(AssertionError):
+    """A funding-model identity failed to hold to tolerance."""
+
+    def __init__(self, violations: list[IdentityViolation]):
+        self.violations = violations
+        first = violations[0]
+        n = len(violations)
+        msg_lines = [
+            f"{n} identity violation(s); first failure:",
+            f"  year_index={first.year_index} class={first.class_name} "
+            f"leg={first.leg} identity={first.identity}",
+            f"  expected={first.expected!r}",
+            f"  actual=  {first.actual!r}",
+            f"  residual={first.residual!r}",
+        ]
+        if n > 1:
+            msg_lines.append(
+                f"  (and {n - 1} more — see ``IdentityCheckError.violations``)"
+            )
+        super().__init__("\n".join(msg_lines))
+
+
+def _within_tol(residual: float, reference: float, tol_rel: float, tol_abs: float) -> bool:
+    return (
+        abs(residual) <= tol_abs
+        or abs(residual) / max(1.0, abs(reference)) <= tol_rel
+    )
+
+
+def _check_mva_leg(
+    f: pd.DataFrame, leg: str, ret_scen: pd.Series, class_name: str,
+    tol_rel: float, tol_abs: float,
+) -> Iterable[IdentityViolation]:
+    mva_col = f"mva_{leg}"
+    cf_col = f"net_cf_{leg}"
+    if mva_col not in f.columns or cf_col not in f.columns:
+        return
+    years = f["year"].to_numpy()
+    mva = f[mva_col].to_numpy()
+    cf = f[cf_col].to_numpy()
+    for i in range(1, len(f)):
+        roa = float(ret_scen.loc[int(years[i])])
+        expected = _mva_rollforward(mva[i - 1], cf[i], roa)
+        actual = mva[i]
+        residual = actual - expected
+        if not _within_tol(residual, expected, tol_rel, tol_abs):
+            yield IdentityViolation(
+                year_index=i, class_name=class_name, leg=leg,
+                identity="mva_rollforward",
+                expected=expected, actual=actual, residual=residual,
+            )
+
+
+def _check_aal_leg(
+    f: pd.DataFrame, leg: str, dr: float, class_name: str,
+    tol_rel: float, tol_abs: float,
+) -> Iterable[IdentityViolation]:
+    aal_col = f"aal_{leg}"
+    nc_col = f"nc_{leg}"
+    ben_col = f"ben_payment_{leg}"
+    refund_col = f"refund_{leg}"
+    gl_col = f"liability_gain_loss_{leg}"
+    needed = [aal_col, nc_col, ben_col, refund_col, gl_col]
+    if not all(c in f.columns for c in needed):
+        return
+    aal = f[aal_col].to_numpy()
+    nc = f[nc_col].to_numpy()
+    ben = f[ben_col].to_numpy()
+    refund = f[refund_col].to_numpy()
+    gl = f[gl_col].to_numpy()
+    for i in range(1, len(f)):
+        expected = _aal_rollforward(
+            aal_prev=aal[i - 1], nc=nc[i], ben=ben[i],
+            refund=refund[i], liab_gl=gl[i], dr=dr,
+        )
+        actual = aal[i]
+        residual = actual - expected
+        if not _within_tol(residual, expected, tol_rel, tol_abs):
+            yield IdentityViolation(
+                year_index=i, class_name=class_name, leg=leg,
+                identity="aal_rollforward",
+                expected=expected, actual=actual, residual=residual,
+            )
+
+
+def _check_nc_dollar(
+    f: pd.DataFrame, class_name: str, has_cb: bool,
+    tol_rel: float, tol_abs: float,
+) -> Iterable[IdentityViolation]:
+    """``nc = nc_rate × payroll`` per leg.
+
+    For ``new``, when the plan has a cash-balance leg, NC is the sum of
+    the DB and CB contributions:
+    ``nc_new = nc_rate_db_new * payroll_db_new + nc_rate_cb_new * payroll_cb_new``.
+    """
+    if {"nc_legacy", "nc_rate_db_legacy", "payroll_db_legacy"} <= set(f.columns):
+        legacy_expected = (
+            f["nc_rate_db_legacy"].to_numpy() * f["payroll_db_legacy"].to_numpy()
+        )
+        legacy_actual = f["nc_legacy"].to_numpy()
+        for i in range(1, len(f)):
+            residual = legacy_actual[i] - legacy_expected[i]
+            if not _within_tol(residual, legacy_expected[i], tol_rel, tol_abs):
+                yield IdentityViolation(
+                    year_index=i, class_name=class_name, leg="legacy",
+                    identity="nc_dollar",
+                    expected=float(legacy_expected[i]),
+                    actual=float(legacy_actual[i]),
+                    residual=float(residual),
+                )
+
+    if {"nc_new", "nc_rate_db_new", "payroll_db_new"} <= set(f.columns):
+        new_expected = (
+            f["nc_rate_db_new"].to_numpy() * f["payroll_db_new"].to_numpy()
+        )
+        if has_cb and {"nc_rate_cb_new", "payroll_cb_new"} <= set(f.columns):
+            new_expected = new_expected + (
+                f["nc_rate_cb_new"].to_numpy() * f["payroll_cb_new"].to_numpy()
+            )
+        new_actual = f["nc_new"].to_numpy()
+        for i in range(1, len(f)):
+            residual = new_actual[i] - new_expected[i]
+            if not _within_tol(residual, new_expected[i], tol_rel, tol_abs):
+                yield IdentityViolation(
+                    year_index=i, class_name=class_name, leg="new",
+                    identity="nc_dollar",
+                    expected=float(new_expected[i]),
+                    actual=float(new_actual[i]),
+                    residual=float(residual),
+                )
+
+
+def check_funding_identities(
+    funding: Mapping[str, pd.DataFrame],
+    *,
+    dr_current: float,
+    dr_new: float,
+    ret_scen: pd.Series,
+    has_cb: bool,
+    skip_classes: Optional[set[str]] = None,
+    tol_rel: float = 1e-9,
+    tol_abs: float = 1e-3,
+) -> None:
+    """Recompute MVA, AAL, NC identities; raise on first violation.
+
+    Parameters
+    ----------
+    funding:
+        Dict of class-keyed funding frames returned by
+        :func:`pension_model.core.funding_model.run_funding_model`.
+    dr_current, dr_new:
+        Discount rates used for the legacy and new legs.
+    ret_scen:
+        Series of asset returns by calendar year.
+    has_cb:
+        Whether the plan has a cash-balance leg (affects NC dollar
+        composition for the ``new`` leg).
+    skip_classes:
+        Frame names to skip — e.g. ``{"drop"}`` for plans whose DROP
+        overlay reallocates AVA across legs in a way that leaves the
+        per-class identities intact but the synthetic frame's
+        rollforward semantics different. The aggregate frame is
+        always checked.
+    tol_rel:
+        Relative tolerance, applied as
+        ``|residual| / max(1, |reference|)``.
+    tol_abs:
+        Absolute floor (dollars) for early-year cases where AAL or
+        MVA is small.
+
+    Raises
+    ------
+    IdentityCheckError
+        On the first violation; ``.violations`` carries the full list
+        found before the raise.
+    """
+    skip = skip_classes or set()
+    violations: list[IdentityViolation] = []
+
+    for class_name, frame in funding.items():
+        if class_name in skip:
+            continue
+        if "year" not in frame.columns:
+            continue
+        for leg, dr in (("legacy", dr_current), ("new", dr_new)):
+            violations.extend(
+                _check_mva_leg(frame, leg, ret_scen, class_name, tol_rel, tol_abs)
+            )
+            violations.extend(
+                _check_aal_leg(frame, leg, dr, class_name, tol_rel, tol_abs)
+            )
+        violations.extend(
+            _check_nc_dollar(frame, class_name, has_cb, tol_rel, tol_abs)
+        )
+
+    if violations:
+        raise IdentityCheckError(violations)

--- a/src/pension_model/output_uniformity.py
+++ b/src/pension_model/output_uniformity.py
@@ -1,0 +1,120 @@
+"""Output uniformity assertions.
+
+Per ``meta-docs/repo_goals.md``: "all plans produce the same columns in
+the same order; inapplicable values are NA." Today the canonical column
+lists (``cli.SUMMARY_COLUMNS``, ``truth_table.TRUTH_TABLE_COLUMNS``)
+declare those columns, but nothing fails if a plan silently fails to
+populate one — ``cli._safe`` fills missing columns with ``NaN``.
+
+This module enforces the contract:
+
+* Every canonical column must be present in the output.
+* Every column not declared inapplicable on the plan must have no NaN
+  values across the projection horizon.
+* Every column declared inapplicable must be entirely NaN (catches the
+  inverse error of populating a column the plan claims it doesn't have).
+
+Plans declare structural exceptions on :class:`PlanConfig` via the
+``inapplicable_summary_columns`` and ``inapplicable_truth_table_columns``
+fields. Today both reference plans (FRS, TXTRS) declare neither and
+populate every column.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable, Sequence
+
+import pandas as pd
+
+
+class OutputUniformityError(AssertionError):
+    """Canonical-output column failed the uniformity contract."""
+
+
+def _missing_columns(df: pd.DataFrame, expected: Sequence[str]) -> list[str]:
+    return [c for c in expected if c not in df.columns]
+
+
+def _columns_with_any_nan(
+    df: pd.DataFrame, columns: Iterable[str]
+) -> dict[str, list[int]]:
+    """Return ``{column: [row_indices_with_nan]}`` for columns containing NaN."""
+    out: dict[str, list[int]] = {}
+    for col in columns:
+        mask = df[col].isna()
+        if mask.any():
+            out[col] = mask.to_numpy().nonzero()[0].tolist()
+    return out
+
+
+def _columns_not_all_nan(
+    df: pd.DataFrame, columns: Iterable[str]
+) -> list[str]:
+    return [col for col in columns if not df[col].isna().all()]
+
+
+def assert_output_uniformity(
+    df: pd.DataFrame,
+    canonical_columns: Sequence[str],
+    inapplicable: Sequence[str],
+    *,
+    plan_name: str,
+    output_name: str,
+) -> None:
+    """Assert that ``df`` matches the canonical column contract.
+
+    Parameters
+    ----------
+    df:
+        Output frame to check.
+    canonical_columns:
+        The list of columns the contract requires.
+    inapplicable:
+        Columns the plan declares structurally inapplicable.
+    plan_name:
+        Plan name, included in error messages.
+    output_name:
+        Human-readable label for the artifact (e.g. ``"summary"``).
+
+    Raises
+    ------
+    OutputUniformityError
+        If any required column is missing, populated columns have NaN
+        values, or columns declared inapplicable are populated.
+    """
+    missing = _missing_columns(df, canonical_columns)
+    if missing:
+        raise OutputUniformityError(
+            f"[{plan_name} {output_name}] missing canonical columns: "
+            f"{missing}"
+        )
+
+    inapplicable_set = set(inapplicable)
+    unknown_inapplicable = inapplicable_set - set(canonical_columns)
+    if unknown_inapplicable:
+        raise OutputUniformityError(
+            f"[{plan_name} {output_name}] inapplicable list names "
+            f"non-canonical columns: {sorted(unknown_inapplicable)}"
+        )
+
+    required = [c for c in canonical_columns if c not in inapplicable_set]
+    nan_offenders = _columns_with_any_nan(df, required)
+    if nan_offenders:
+        details = ", ".join(
+            f"{col} (rows {rows[:5]}{'...' if len(rows) > 5 else ''})"
+            for col, rows in nan_offenders.items()
+        )
+        raise OutputUniformityError(
+            f"[{plan_name} {output_name}] required columns contain NaN: "
+            f"{details}. If a column is structurally inapplicable to this "
+            f"plan, declare it in inapplicable_{output_name}_columns."
+        )
+
+    populated_inapplicable = _columns_not_all_nan(df, inapplicable)
+    if populated_inapplicable:
+        raise OutputUniformityError(
+            f"[{plan_name} {output_name}] columns declared inapplicable "
+            f"but populated: {populated_inapplicable}. Either remove them "
+            f"from inapplicable_{output_name}_columns or stop populating "
+            f"them."
+        )

--- a/src/pension_model/schemas/valuation_inputs.py
+++ b/src/pension_model/schemas/valuation_inputs.py
@@ -50,9 +50,7 @@ class ValuationInputs(StrictModel):
 class ClassData(StrictModel):
     """Per-class merged view of valuation_inputs + calibration.
 
-    Replaces the ``SimpleNamespace`` from
-    ``config_compat.build_class_data_namespace``. Same access pattern
-    (e.g. ``config.class_data[cn].nc_cal``) but type-checked.
+    Access via ``config.class_data[cn].nc_cal`` etc.
     """
 
     ben_payment: float

--- a/tests/test_pension_model/_vectorized_resolver_test_support.py
+++ b/tests/test_pension_model/_vectorized_resolver_test_support.py
@@ -27,7 +27,7 @@ def vec_tier_components(config, cn, ey, age, yos, entry_age=None):
 
     tier_id, ret_status = resolve_tiers_vec(config, cn, ey, age, yos, entry_age)
     tier_names = np.array(
-        [config._tier_id_to_name[t] for t in tier_id], dtype=object
+        [config.tier_id_to_name[t] for t in tier_id], dtype=object
     )
     statuses = np.array(
         [_STATUS_INT_TO_STR[s] for s in ret_status], dtype=object

--- a/tests/test_pension_model/test_config_top_level_strict.py
+++ b/tests/test_pension_model/test_config_top_level_strict.py
@@ -1,0 +1,90 @@
+"""Top-level PlanConfig must reject unknown keys.
+
+Phase A robustness gate. Before this change, ``PlanConfig`` used
+``extra="ignore"`` at the top level, so a typo like ``valuation_inputs_notes``
+loaded silently. The pydantic schema now uses ``extra="forbid"`` and the
+loader runs an explicit unknown-key check. Documentation belongs in the
+typed ``notes`` block.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from pension_model.config_loading import (
+    check_unknown_top_level_keys,
+    load_plan_config,
+    load_plan_config_by_name,
+)
+
+
+pytestmark = [pytest.mark.unit]
+
+
+def _load_raw(plan_name: str) -> dict:
+    repo_root = Path(__file__).resolve().parents[2]
+    path = repo_root / "plans" / plan_name / "config" / "plan_config.json"
+    return json.loads(path.read_text())
+
+
+def test_top_level_typo_is_rejected():
+    """A typo'd top-level section name must fail load."""
+    raw = _load_raw("frs")
+    raw["economics"] = raw.pop("economic")
+
+    with pytest.raises(ValueError) as excinfo:
+        check_unknown_top_level_keys(raw)
+
+    assert "economics" in str(excinfo.value)
+
+
+def test_unknown_top_level_notes_key_is_rejected():
+    """Old-style ``*_notes`` top-level keys are rejected; documentation
+    moves into the typed ``notes`` block instead."""
+    raw = _load_raw("txtrs")
+    raw["valuation_inputs_notes"] = "stale documentation key"
+
+    with pytest.raises(ValueError) as excinfo:
+        check_unknown_top_level_keys(raw)
+
+    assert "valuation_inputs_notes" in str(excinfo.value)
+
+
+def test_loader_rejects_unknown_top_level_key(tmp_path):
+    """The full loader path also rejects unknown top-level keys."""
+    raw = _load_raw("txtrs")
+    raw["bogus_key"] = 42
+    cfg_path = tmp_path / "plan_config.json"
+    cfg_path.write_text(json.dumps(raw))
+
+    with pytest.raises(ValueError) as excinfo:
+        load_plan_config(cfg_path)
+
+    assert "bogus_key" in str(excinfo.value)
+
+
+def test_typed_notes_block_loads_via_full_loader(tmp_path):
+    """The ``notes`` block accepts arbitrary key/value documentation."""
+    raw = _load_raw("txtrs")
+    raw["notes"] = {
+        "design_ratio_group_map": "free-text explanation",
+        "valuation_inputs": {"source": "2023 AV", "page": 42},
+    }
+    cfg_path = tmp_path / "plan_config.json"
+    cfg_path.write_text(json.dumps(raw))
+
+    config = load_plan_config(cfg_path)
+
+    assert config.notes["design_ratio_group_map"] == "free-text explanation"
+    assert config.notes["valuation_inputs"]["page"] == 42
+
+
+def test_frs_loads_with_migrated_notes():
+    """FRS config carries documentation in the ``notes`` block."""
+    config = load_plan_config_by_name("frs")
+
+    assert "design_ratio_group_map" in config.notes
+    assert "valuation_inputs" in config.notes

--- a/tests/test_pension_model/test_identity_checks.py
+++ b/tests/test_pension_model/test_identity_checks.py
@@ -1,0 +1,137 @@
+"""Funding identity assertion tests.
+
+Two passing checks (FRS and TXTRS as run today) plus three synthetic
+break tests that verify the checker raises with a clear message when
+each identity is violated.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pension_model.config_loading import load_plan_config_by_name
+from pension_model.core._funding_setup import resolve_funding_context
+from pension_model.core.funding_model import (
+    load_funding_inputs,
+    run_funding_model,
+)
+from pension_model.core.identity_checks import (
+    IdentityCheckError,
+    check_funding_identities,
+)
+from pension_model.core.pipeline import run_plan_pipeline
+
+
+pytestmark = [pytest.mark.integration]
+
+
+def _run_to_funding(plan_name: str):
+    """Load plan, run liability + funding, return (funding, ctx)."""
+    constants = load_plan_config_by_name(plan_name)
+    liability = run_plan_pipeline(constants, progress=False)
+    funding_inputs = load_funding_inputs(constants.resolve_data_dir() / "funding")
+    funding = run_funding_model(liability, funding_inputs, constants)
+    ctx = resolve_funding_context(constants, funding_inputs)
+    return funding, ctx
+
+
+@pytest.fixture(scope="module")
+def txtrs_funding():
+    return _run_to_funding("txtrs")
+
+
+@pytest.fixture(scope="module")
+def frs_funding():
+    return _run_to_funding("frs")
+
+
+def test_txtrs_identities_pass(txtrs_funding):
+    funding, ctx = txtrs_funding
+    check_funding_identities(
+        funding,
+        dr_current=ctx.dr_current,
+        dr_new=ctx.dr_new,
+        ret_scen=ctx.ret_scen,
+        has_cb=ctx.has_cb,
+        skip_classes={"drop"} if ctx.has_drop else set(),
+    )
+
+
+def test_frs_identities_pass(frs_funding):
+    funding, ctx = frs_funding
+    check_funding_identities(
+        funding,
+        dr_current=ctx.dr_current,
+        dr_new=ctx.dr_new,
+        ret_scen=ctx.ret_scen,
+        has_cb=ctx.has_cb,
+        skip_classes={"drop"} if ctx.has_drop else set(),
+    )
+
+
+def _perturb_copy(funding, class_name: str, column: str, row_index: int, delta: float):
+    """Return a deep-copied funding dict with one cell perturbed."""
+    perturbed = {cn: df.copy() for cn, df in funding.items()}
+    perturbed[class_name].loc[row_index, column] = (
+        perturbed[class_name].loc[row_index, column] + delta
+    )
+    return perturbed
+
+
+def test_mva_break_is_caught(txtrs_funding):
+    funding, ctx = txtrs_funding
+    class_name = next(iter(funding))
+    perturbed = _perturb_copy(funding, class_name, "mva_legacy", 5, 1e6)
+
+    with pytest.raises(IdentityCheckError) as excinfo:
+        check_funding_identities(
+            perturbed,
+            dr_current=ctx.dr_current, dr_new=ctx.dr_new,
+            ret_scen=ctx.ret_scen, has_cb=ctx.has_cb,
+            skip_classes={"drop"} if ctx.has_drop else set(),
+        )
+
+    msg = str(excinfo.value)
+    assert "mva_rollforward" in msg
+    # Perturbing row 5 breaks both year 5's check (actual vs expected)
+    # and year 6's check (next year's expected uses perturbed value as
+    # mva_prev). Either is acceptable evidence the check fired.
+    violation_years = {v.year_index for v in excinfo.value.violations}
+    assert {5, 6} & violation_years
+
+
+def test_aal_break_is_caught(txtrs_funding):
+    funding, ctx = txtrs_funding
+    class_name = next(iter(funding))
+    perturbed = _perturb_copy(funding, class_name, "aal_legacy", 7, 1e7)
+
+    with pytest.raises(IdentityCheckError) as excinfo:
+        check_funding_identities(
+            perturbed,
+            dr_current=ctx.dr_current, dr_new=ctx.dr_new,
+            ret_scen=ctx.ret_scen, has_cb=ctx.has_cb,
+            skip_classes={"drop"} if ctx.has_drop else set(),
+        )
+
+    msg = str(excinfo.value)
+    assert "aal_rollforward" in msg
+
+
+def test_nc_dollar_break_is_caught(txtrs_funding):
+    funding, ctx = txtrs_funding
+    class_name = next(iter(funding))
+    perturbed = _perturb_copy(funding, class_name, "nc_legacy", 3, 5e5)
+
+    with pytest.raises(IdentityCheckError) as excinfo:
+        check_funding_identities(
+            perturbed,
+            dr_current=ctx.dr_current, dr_new=ctx.dr_new,
+            ret_scen=ctx.ret_scen, has_cb=ctx.has_cb,
+            skip_classes={"drop"} if ctx.has_drop else set(),
+        )
+
+    msg = str(excinfo.value)
+    # NC dollar bug shows up first as an NC-dollar violation (perturbed
+    # NC[3] no longer matches nc_rate × payroll), and downstream as an
+    # AAL violation (next year's AAL roll uses the perturbed NC).
+    assert "nc_dollar" in msg or "aal_rollforward" in msg

--- a/tests/test_pension_model/test_output_uniformity.py
+++ b/tests/test_pension_model/test_output_uniformity.py
@@ -1,0 +1,94 @@
+"""Output uniformity contract tests.
+
+The runtime asserts that every plan populates every canonical column
+in summary.csv and the truth table — except those a plan explicitly
+declares structurally inapplicable.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from pension_model.output_uniformity import (
+    OutputUniformityError,
+    assert_output_uniformity,
+)
+
+
+pytestmark = [pytest.mark.unit]
+
+
+CANONICAL = ["plan", "year", "aal", "mva"]
+
+
+def _good_frame():
+    return pd.DataFrame({
+        "plan": ["frs"] * 3,
+        "year": [2024, 2025, 2026],
+        "aal": [1.0, 2.0, 3.0],
+        "mva": [4.0, 5.0, 6.0],
+    })
+
+
+def test_passes_when_all_columns_populated():
+    df = _good_frame()
+    assert_output_uniformity(
+        df, CANONICAL, inapplicable=(),
+        plan_name="frs", output_name="summary",
+    )
+
+
+def test_missing_canonical_column_caught():
+    df = _good_frame().drop(columns=["aal"])
+    with pytest.raises(OutputUniformityError) as excinfo:
+        assert_output_uniformity(
+            df, CANONICAL, inapplicable=(),
+            plan_name="frs", output_name="summary",
+        )
+    assert "missing canonical columns" in str(excinfo.value)
+    assert "aal" in str(excinfo.value)
+
+
+def test_nan_in_required_column_caught():
+    df = _good_frame()
+    df.loc[1, "aal"] = np.nan
+    with pytest.raises(OutputUniformityError) as excinfo:
+        assert_output_uniformity(
+            df, CANONICAL, inapplicable=(),
+            plan_name="frs", output_name="summary",
+        )
+    msg = str(excinfo.value)
+    assert "aal" in msg
+    assert "rows [1]" in msg
+
+
+def test_nan_allowed_when_column_declared_inapplicable():
+    df = _good_frame()
+    df["aal"] = np.nan
+    assert_output_uniformity(
+        df, CANONICAL, inapplicable=("aal",),
+        plan_name="dc_only_plan", output_name="summary",
+    )
+
+
+def test_inapplicable_column_must_be_all_nan():
+    df = _good_frame()
+    df.loc[0, "aal"] = np.nan  # one NaN, rest populated
+    with pytest.raises(OutputUniformityError) as excinfo:
+        assert_output_uniformity(
+            df, CANONICAL, inapplicable=("aal",),
+            plan_name="dc_only_plan", output_name="summary",
+        )
+    assert "declared inapplicable but populated" in str(excinfo.value)
+
+
+def test_inapplicable_must_be_in_canonical_list():
+    df = _good_frame()
+    with pytest.raises(OutputUniformityError) as excinfo:
+        assert_output_uniformity(
+            df, CANONICAL, inapplicable=("not_a_real_column",),
+            plan_name="frs", output_name="summary",
+        )
+    assert "non-canonical" in str(excinfo.value)

--- a/tests/test_pension_model/test_plan_config_frs.py
+++ b/tests/test_pension_model/test_plan_config_frs.py
@@ -35,9 +35,9 @@ class TestPlanConfigLoad:
         assert acfr["nc_cal"] != 1.0
 
     def test_frs_tier_lookups(self, frs_config):
-        assert frs_config._tier_name_to_id == {"tier_1": 0, "tier_2": 1, "tier_3": 2}
-        assert frs_config._tier_id_to_name == ("tier_1", "tier_2", "tier_3")
-        assert frs_config._tier_id_to_fas_years == (5, 8, 8)
+        assert frs_config.tier_name_to_id == {"tier_1": 0, "tier_2": 1, "tier_3": 2}
+        assert frs_config.tier_id_to_name == ("tier_1", "tier_2", "tier_3")
+        assert frs_config.tier_id_to_fas_years == (5, 8, 8)
 
 
 class TestBaselineDrCurrentSnapshot:


### PR DESCRIPTION
## Summary

Bundles four small, independently testable changes that strictly improve robustness without changing FRS or TXTRS numbers. R-baseline truth-table tests and bit-identical funding snapshots pass unchanged.

Design doc: [`scratch/phase_a_robustness_pr_design.md`](scratch/phase_a_robustness_pr_design.md)

| Item | Summary |
|------|---------|
| A-1 | `--check-identities` mode — runtime assertion of MVA, AAL, NC-dollar identities |
| A-2 | Output uniformity — enforce that summary and truth-table columns are populated, with explicit per-plan inapplicable lists |
| A-7 | Top-level `PlanConfig` strict — `extra="forbid"` + explicit unknown-key check + typed `notes:` block |
| A-8 | Delete vestigial compat surface — empty `config_compat.py` and the seven `_`-prefixed legacy property aliases |

## What changed

**A-1 — Funding identity checks.** New `core/identity_checks.py` recomputes the MVA roll-forward, AAL roll-forward, and NC-dollar identities directly from the funding frames using the same helpers (`_aal_rollforward`, `_mva_rollforward`) the year loop uses. Off by default (zero cost); enabled via `pension-model run <plan> --check-identities` or `run_funding_model(..., check_identities=True)`. Tolerance: relative `1e-9` with absolute floor `1e-3`. Both reference plans pass cleanly.

**A-2 — Output uniformity.** New `output_uniformity.py` enforces that `cli.SUMMARY_COLUMNS` and `truth_table.TRUTH_TABLE_COLUMNS` are present and populated. Plans that need to opt out of a column declare it in `inapplicable_summary_columns` or `inapplicable_truth_table_columns` on `PlanConfig`; FRS and TXTRS opt out of nothing. Catches the silent-NaN-fill failure mode in `cli._safe`.

**A-7 — Top-level strict.** `PlanConfig.model_config` moves from `extra="ignore"` to `extra="forbid"`. Pydantic alone can't catch typos for keys the loader doesn't pass through, so the loader runs an explicit `check_unknown_top_level_keys(raw)` against `PlanConfig.model_fields`. Documentation moves into a typed `notes:` block. Migrated:
- FRS: `design_ratio_group_map_notes`, `valuation_inputs_notes` → `notes`
- txtrs-av: `source_notes` → `notes`

The committed JSON schema artifact (`plans/_schema/plan_config.schema.json`) is regenerated.

**A-8 — Delete compat surface.** Removes the seven `_`-prefixed `@property` aliases on `PlanConfig` (left over from the pydantic migration) and the empty `config_compat.py`. Eight call sites in resolvers, `data_loader`, and `benefit_tables` drop the underscore. Pure rename — no semantic change.

## Verification

| Gate | Result |
|------|--------|
| `pytest -q` | 486 passed, 2 intentionally skipped (up from 470) |
| Bit-identical funding snapshots | unchanged |
| R-baseline truth-table tests (1e-10 rel) | unchanged |
| `pension-model run frs --no-test --check-identities --truth-table` | clean, no violations |
| `pension-model run txtrs --no-test --check-identities --truth-table` | clean, no violations |

Tests added: `test_identity_checks` (5), `test_output_uniformity` (6), `test_config_top_level_strict` (5).

## Performance

The core projection is unaffected.

- A-1 is off by default; on, it adds milliseconds (vectorized recompute over `n_classes × n_years × n_legs` cells).
- A-2 is one `pd.isna` pass over a ~50 × 15 frame plus the truth table — microseconds.
- A-7 adds one set-difference at config load — under 100 µs.
- A-8 trades `@property` lookups for direct attribute access — micro-speedup, lost in noise.

## Test plan

- [ ] `pytest -q` from a clean checkout
- [ ] `pension-model run frs --no-test --check-identities --truth-table`
- [ ] `pension-model run txtrs --no-test --check-identities --truth-table`
- [ ] Spot-check `output/frs/summary.csv` and `output/txtrs/summary.csv` against prior runs (no number changes expected)
- [ ] Confirm `plans/frs/config/plan_config.json` and `plans/txtrs-av/config/plan_config.json` only differ from `main` in the `notes:` migration

## Notes

- Per repo procedures, this PR is opened for review only — no merge without explicit owner permission.
- DROP frames are skipped in the per-class identity check (`skip_classes={"drop"}`) because the AVA reallocation logic in `_funding_phases.py:127-156` is a cross-leg transfer; the per-class MVA/AAL identities still hold for non-DROP frames and the aggregate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)