### PR TITLE
Phase A.3 lint cleanup: enable ruff and black pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,14 +5,6 @@
 #
 # Hooks run automatically on `git commit`; run on the whole repo with
 # `pre-commit run --all-files`.
-#
-# This file intentionally enables only file-hygiene hooks. The repo's
-# existing ruff/black/mypy configuration in pyproject.toml describes
-# the intended style, but the codebase has accumulated drift that a
-# blanket `ruff --fix` + `black` pass would touch ~60 files.
-# That cleanup belongs in its own focused PR (tracked as Phase A.3).
-# Once it lands, uncomment the ruff/black/mypy blocks below and
-# rerun `pre-commit run --all-files`.
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -31,21 +23,13 @@ repos:
         args: ["--maxkb=2000"]
       - id: check-merge-conflict
 
-  # TODO (Phase A.3): enable ruff once the existing lint findings are
-  # cleaned up. Most are auto-fixable (UP045, I001, F401); ~30 require
-  # manual edits (E402 module-level import order, F821 string-quoted
-  # type annotations).
-  #
-  # - repo: https://github.com/astral-sh/ruff-pre-commit
-  #   rev: v0.7.4
-  #   hooks:
-  #     - id: ruff
-  #       args: [--fix]
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.7.4
+    hooks:
+      - id: ruff
+        args: [--fix]
 
-  # TODO (Phase A.3): enable black once the existing formatting drift
-  # is resolved (~60 files would be reformatted today).
-  #
-  # - repo: https://github.com/psf/black-pre-commit-mirror
-  #   rev: 24.10.0
-  #   hooks:
-  #     - id: black
+  - repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 24.10.0
+    hooks:
+      - id: black

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,12 @@ target-version = ['py311']
 
 [tool.ruff]
 line-length = 100
+# scripts/ holds one-off build / extract / diagnostic utilities; they
+# don't run in the runtime model and frequently embed long inline
+# data strings that don't lint cleanly. Exclude them from ruff.
+extend-exclude = ["scripts"]
+
+[tool.ruff.lint]
 select = [
     "E",   # pycodestyle errors
     "W",   # pycodestyle warnings
@@ -77,7 +83,7 @@ select = [
 ]
 ignore = []
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401"]
 
 [tool.mypy]

--- a/scripts/build/build_av_term_vested_cashflow.py
+++ b/scripts/build/build_av_term_vested_cashflow.py
@@ -37,7 +37,6 @@ from pension_model.core.pipeline_current import _npv
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from term_vested_deferred_annuity import deferred_annuity_stream
 
-
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 
 

--- a/scripts/build/build_frs_term_vested_cashflow.py
+++ b/scripts/build/build_frs_term_vested_cashflow.py
@@ -36,7 +36,6 @@ import pandas as pd
 
 from pension_model.core.pipeline_current import _get_pmt, _npv, _recur_grow3
 
-
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 PLAN_DIR = PROJECT_ROOT / "plans" / "frs"
 CONFIG_PATH = PLAN_DIR / "config" / "plan_config.json"
@@ -59,9 +58,7 @@ def build_class_stream(
     """
     if pvfb_term_current == 0:
         return [0.0] * amo_period
-    first_payment = _get_pmt(
-        cashflow_rate, payroll_growth, amo_period, pvfb_term_current, t=1
-    )
+    first_payment = _get_pmt(cashflow_rate, payroll_growth, amo_period, pvfb_term_current, t=1)
     return list(_recur_grow3(first_payment, payroll_growth, amo_period))
 
 

--- a/scripts/build/build_r_truth_tables.py
+++ b/scripts/build/build_r_truth_tables.py
@@ -18,16 +18,16 @@ Usage:
     python scripts/build_r_truth_tables.py
 """
 
-from pathlib import Path
 import sys
+from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent.parent
 sys.path.insert(0, str(ROOT / "src"))
 
 from pension_model.truth_table import (  # noqa: E402
     build_r_truth_table,
-    upsert_sheet_to_excel,
     format_truth_table_for_log,
+    upsert_sheet_to_excel,
     write_diff_sheet_with_formulas,
 )
 
@@ -63,9 +63,7 @@ def main():
     # *_Py sheets so they update automatically whenever the pipeline rewrites
     # the Py sheet.
     print("\nWriting diff sheets (live formulas: Py - R)")
-    write_diff_sheet_with_formulas(
-        out_path, "frs_diff", "frs_R", "frs_Py", n_rows=len(frs_r)
-    )
+    write_diff_sheet_with_formulas(out_path, "frs_diff", "frs_R", "frs_Py", n_rows=len(frs_r))
     write_diff_sheet_with_formulas(
         out_path, "txtrs_diff", "txtrs_R", "txtrs_Py", n_rows=len(txtrs_r)
     )

--- a/scripts/build/build_txtrs_av_from_av.py
+++ b/scripts/build/build_txtrs_av_from_av.py
@@ -19,13 +19,11 @@ This script intentionally avoids using existing txtrs runtime files as inputs.
 
 from __future__ import annotations
 
-from io import StringIO
-from pathlib import Path
 import re
 import subprocess
+from pathlib import Path
 
 import pandas as pd
-
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 PDF_PATH = PROJECT_ROOT / "prep" / "txtrs-av" / "sources" / "Texas TRS Valuation 2024.pdf"
@@ -50,19 +48,19 @@ RUNTIME_RETIREE_MAX_AGE = 120
 # runtime tail.
 LIFE_ANNUITY_BAND_TO_RUNTIME: dict[str, tuple[int, int]] = {
     "Up to 35": (55, 59),
-    "35-40":    (55, 59),
-    "40-44":    (55, 59),
-    "45-49":    (55, 59),
-    "50-54":    (55, 59),
-    "55-59":    (55, 59),
-    "60-64":    (60, 64),
-    "65-69":    (65, 69),
-    "70-74":    (70, 74),
-    "75-79":    (75, 79),
-    "80-84":    (80, 84),
-    "85-89":    (85, 89),
-    "90-94":    (90, 94),
-    "95-99":    (95, 99),
+    "35-40": (55, 59),
+    "40-44": (55, 59),
+    "45-49": (55, 59),
+    "50-54": (55, 59),
+    "55-59": (55, 59),
+    "60-64": (60, 64),
+    "65-69": (65, 69),
+    "70-74": (70, 74),
+    "75-79": (75, 79),
+    "80-84": (80, 84),
+    "85-89": (85, 89),
+    "90-94": (90, 94),
+    "95-99": (95, 99),
     "100 & up": (100, RUNTIME_RETIREE_MAX_AGE),
 }
 
@@ -160,14 +158,18 @@ def _parse_table17() -> tuple[pd.DataFrame, pd.DataFrame]:
     for band_label, age in AGE_MAP.items():
         count_line = _extract_matching_line(lines, rf"^\s*{re.escape(band_label)}\s")
         count_payload = re.sub(rf"^\s*{re.escape(band_label)}\s*", "", count_line)
-        count_vals = [int(token.replace(",", "")) for token in re.findall(r"\d[\d,]*", count_payload)]
+        count_vals = [
+            int(token.replace(",", "")) for token in re.findall(r"\d[\d,]*", count_payload)
+        ]
         if len(count_vals) < 6:
             raise ValueError(f"Unexpected count row for {band_label}: {count_line}")
         count_vals = count_vals[:-1]
 
         salary_line_idx = lines.index(count_line) + 1
         salary_line = lines[salary_line_idx]
-        salary_vals = [float(token.replace(",", "")) for token in re.findall(r"\$([\d,]+)", salary_line)]
+        salary_vals = [
+            float(token.replace(",", "")) for token in re.findall(r"\$([\d,]+)", salary_line)
+        ]
         if len(salary_vals) < 6:
             raise ValueError(f"Unexpected salary row for {band_label}: {salary_line}")
         salary_vals = salary_vals[:-1]
@@ -177,12 +179,16 @@ def _parse_table17() -> tuple[pd.DataFrame, pd.DataFrame]:
         early_counts = count_vals[:4]
         early_salaries = salary_vals[:4]
         collapsed_count = sum(early_counts)
-        collapsed_salary = sum(c * s for c, s in zip(early_counts, early_salaries)) / collapsed_count
+        collapsed_salary = (
+            sum(c * s for c, s in zip(early_counts, early_salaries, strict=False)) / collapsed_count
+        )
 
         count_rows.append({"age": age, "yos": 2, "count": collapsed_count})
         salary_rows.append({"age": age, "yos": 2, "salary": collapsed_salary})
 
-        for yos, count_val, salary_val in zip(later_yos, count_vals[4:], salary_vals[4:]):
+        for yos, count_val, salary_val in zip(
+            later_yos, count_vals[4:], salary_vals[4:], strict=False
+        ):
             if count_val == 0:
                 continue
             count_rows.append({"age": age, "yos": yos, "count": count_val})
@@ -307,7 +313,7 @@ def _parse_reduction_tables() -> tuple[pd.DataFrame, pd.DataFrame]:
             continue
         yos_label, *pct_vals = match.groups()
         yos = 30 if yos_label == "30 or more" else int(yos_label)
-        for age, pct_val in zip(range(55, 61), pct_vals):
+        for age, pct_val in zip(range(55, 61), pct_vals, strict=False):
             gft_rows.append(
                 {
                     "age": age,
@@ -319,7 +325,7 @@ def _parse_reduction_tables() -> tuple[pd.DataFrame, pd.DataFrame]:
 
     others_line = _extract_matching_line(lines, r"^\s*43%\s+46%\s+50%\s+55%")
     other_pcts = [int(token) for token in re.findall(r"(\d+)%", others_line)]
-    for age, pct_val in zip(range(55, 66), other_pcts):
+    for age, pct_val in zip(range(55, 66), other_pcts, strict=False):
         others_rows.append({"age": age, "reduce_factor": pct_val / 100.0, "tier": "others"})
 
     gft = pd.DataFrame(gft_rows).sort_values(["age", "yos"]).reset_index(drop=True)
@@ -390,11 +396,15 @@ def _parse_termination_rates() -> pd.DataFrame:
 def _parse_retirement_rates() -> pd.DataFrame:
     text = _pdf_page_text(PDF_PATH, RETIREMENT_PDF_PAGE)
     lines = text.splitlines()
-    normal_rates: dict[int, float] = {age: 0.0 for age in range(45, 121)}
-    early_rates: dict[int, float] = {age: 0.0 for age in range(45, 121)}
+    normal_rates: dict[int, float] = dict.fromkeys(range(45, 121), 0.0)
+    early_rates: dict[int, float] = dict.fromkeys(range(45, 121), 0.0)
 
-    single_age_normal = re.compile(r"^\s*(5[0-9]|6[0-4])\s+([0-9]+\.[0-9]+)\s+([0-9]+\.[0-9]+)\s+(4[5-9]|5[0-9])\s+([0-9]+\.[0-9]+)\s*$")
-    band_with_early = re.compile(r"^\s*(65-69|70-74|75\+)\s+([0-9]+\.[0-9]+)\s+([0-9]+\.[0-9]+)\s+(6[0-2])\s+([0-9]+\.[0-9]+)\s*$")
+    single_age_normal = re.compile(
+        r"^\s*(5[0-9]|6[0-4])\s+([0-9]+\.[0-9]+)\s+([0-9]+\.[0-9]+)\s+(4[5-9]|5[0-9])\s+([0-9]+\.[0-9]+)\s*$"
+    )
+    band_with_early = re.compile(
+        r"^\s*(65-69|70-74|75\+)\s+([0-9]+\.[0-9]+)\s+([0-9]+\.[0-9]+)\s+(6[0-2])\s+([0-9]+\.[0-9]+)\s*$"
+    )
     early_only = re.compile(r"^\s*(6[0-4])\s+([0-9]+\.[0-9]+)\s*$")
     continuation_early = re.compile(r"^\s+(6[3-4])\s+([0-9]+\.[0-9]+)\s*$")
 
@@ -435,9 +445,13 @@ def _parse_retirement_rates() -> pd.DataFrame:
 
     rows: list[dict] = []
     for age in range(45, 121):
-        rows.append({"age": age, "tier": "all", "retire_type": "early", "retire_rate": early_rates[age]})
+        rows.append(
+            {"age": age, "tier": "all", "retire_type": "early", "retire_rate": early_rates[age]}
+        )
     for age in range(45, 121):
-        rows.append({"age": age, "tier": "all", "retire_type": "normal", "retire_rate": normal_rates[age]})
+        rows.append(
+            {"age": age, "tier": "all", "retire_type": "normal", "retire_rate": normal_rates[age]}
+        )
     return pd.DataFrame(rows)
 
 
@@ -465,7 +479,9 @@ def _parse_init_funding() -> pd.DataFrame:
     remaining_tokens = re.findall(r"\(?[\d,]+\)?", remaining_2023_line)
     if len(remaining_tokens) < 5:
         raise ValueError(f"Unexpected Table 4 2023 deferral row: {remaining_2023_line}")
-    remaining_after_valuation = -float(remaining_tokens[-1].replace("(", "").replace(")", "").replace(",", ""))
+    remaining_after_valuation = -float(
+        remaining_tokens[-1].replace("(", "").replace(")", "").replace(",", "")
+    )
 
     total_ual_ava = total_aal - total_ava
     total_ual_mva = total_aal - total_mva
@@ -558,12 +574,14 @@ def _build_retiree_distribution() -> pd.DataFrame:
         per_age_total = agg["annual"] / n_ages
         per_age_avg = agg["annual"] / agg["count"]
         for age in range(lo, hi + 1):
-            rows.append({
-                "age": age,
-                "count": per_age_count,
-                "avg_benefit": per_age_avg,
-                "total_benefit": per_age_total,
-            })
+            rows.append(
+                {
+                    "age": age,
+                    "count": per_age_count,
+                    "avg_benefit": per_age_avg,
+                    "total_benefit": per_age_total,
+                }
+            )
 
     return pd.DataFrame(rows).sort_values("age").reset_index(drop=True)
 

--- a/scripts/build/build_txtrs_av_mortality.py
+++ b/scripts/build/build_txtrs_av_mortality.py
@@ -35,7 +35,6 @@ from pathlib import Path
 import openpyxl
 import pandas as pd
 
-
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 
 PUB_PATH = PROJECT_ROOT / "prep" / "common" / "sources" / "soa_pub2010_amount_mort_rates.xlsx"
@@ -210,11 +209,7 @@ def build_improvement_scale(ultimate: pd.DataFrame) -> pd.DataFrame:
         imp = float(r["improvement"])
         for year in range(SCALE_YEAR_MIN, SCALE_YEAR_MAX + 1):
             rows.append({"age": age, "year": year, "gender": gender, "improvement": imp})
-    return (
-        pd.DataFrame(rows)
-        .sort_values(["gender", "age", "year"])
-        .reset_index(drop=True)
-    )
+    return pd.DataFrame(rows).sort_values(["gender", "age", "year"]).reset_index(drop=True)
 
 
 def _write_csv(df: pd.DataFrame, path: Path) -> None:

--- a/scripts/build/build_txtrs_term_vested_cashflow.py
+++ b/scripts/build/build_txtrs_term_vested_cashflow.py
@@ -37,7 +37,6 @@ import pandas as pd
 
 from pension_model.core.pipeline_current import _npv
 
-
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 PLAN_DIR = PROJECT_ROOT / "plans" / "txtrs"
 CONFIG_PATH = PLAN_DIR / "config" / "plan_config.json"
@@ -62,9 +61,7 @@ def build_class_stream(
     mid = amo_period / 2
     spread = amo_period / 5
     seq = np.arange(1, amo_period + 1)
-    weights = (1 / (spread * np.sqrt(2 * np.pi))) * np.exp(
-        -0.5 * ((seq - mid) / spread) ** 2
-    )
+    weights = (1 / (spread * np.sqrt(2 * np.pi))) * np.exp(-0.5 * ((seq - mid) / spread) ** 2)
     ann_ratio = weights / weights[0]
     first_payment = pvfb_term_current / _npv(cashflow_rate, ann_ratio)
     return list(first_payment * ann_ratio)

--- a/scripts/build/convert_frs_to_stage3.py
+++ b/scripts/build/convert_frs_to_stage3.py
@@ -18,6 +18,7 @@ Run from project root:
 """
 import sys
 from pathlib import Path
+
 import numpy as np
 import pandas as pd
 
@@ -78,14 +79,16 @@ def convert_salary_growth():
     # Check if all classes have the same growth rates
     cols = [col_map[c] for c in CLASSES]
     values = src[cols].values
-    all_same = all(np.allclose(values[:, 0], values[:, i], equal_nan=True) for i in range(1, len(cols)))
+    all_same = all(
+        np.allclose(values[:, 0], values[:, i], equal_nan=True) for i in range(1, len(cols))
+    )
 
     if all_same:
         # Single file for all classes
         out = src[["yos"]].copy()
         out["salary_increase"] = src[col_map["regular"]]
         out.to_csv(OUT / "demographics" / "salary_growth.csv", index=False)
-        print("  salary_growth.csv (shared): {} rows".format(len(out)))
+        print(f"  salary_growth.csv (shared): {len(out)} rows")
     else:
         # Separate files per class
         for cls in CLASSES:
@@ -99,12 +102,14 @@ def convert_retiree_distribution():
     """Convert retiree distribution to standard columns."""
     print("Converting retiree distribution...")
     src = pd.read_csv(BASELINE / "retiree_distribution.csv")
-    out = pd.DataFrame({
-        "age": src["age"],
-        "count": src["n_retire"],
-        "avg_benefit": src["avg_ben"],
-        "total_benefit": src["total_ben"],
-    })
+    out = pd.DataFrame(
+        {
+            "age": src["age"],
+            "count": src["n_retire"],
+            "avg_benefit": src["avg_ben"],
+            "total_benefit": src["total_ben"],
+        }
+    )
     out.to_csv(OUT / "demographics" / "retiree_distribution.csv", index=False)
     print(f"  retiree_distribution.csv: {len(out)} rows")
 
@@ -148,12 +153,14 @@ def convert_termination_rates():
                     continue
                 lo, hi = age_group_ranges[col]
                 for age in range(lo, hi + 1):
-                    rows.append({
-                        "lookup_type": "yos",
-                        "age": age,
-                        "lookup_value": yos,
-                        "term_rate": rate,
-                    })
+                    rows.append(
+                        {
+                            "lookup_type": "yos",
+                            "age": age,
+                            "lookup_value": yos,
+                            "term_rate": rate,
+                        }
+                    )
 
         out = pd.DataFrame(rows).sort_values(["age", "lookup_value"]).reset_index(drop=True)
         out_path = OUT / "decrements" / f"{sep_cls}_termination_rates.csv"
@@ -175,8 +182,10 @@ def convert_retirement_rates():
         rows = []
         for tier_num in [1, 2]:
             tier_name = f"tier_{tier_num}"
-            for retire_type, prefix in [("normal", "normal_retire_rate"),
-                                         ("early", "early_retire_rate")]:
+            for retire_type, prefix in [
+                ("normal", "normal_retire_rate"),
+                ("early", "early_retire_rate"),
+            ]:
                 fname = f"{sep_cls}_{prefix}_tier{tier_num}.csv"
                 fpath = BASELINE / "decrement_tables" / fname
                 if not fpath.exists():
@@ -187,12 +196,14 @@ def convert_retirement_rates():
                 for _, row in src.iterrows():
                     rate = row[rate_col]
                     if pd.notna(rate):
-                        rows.append({
-                            "age": int(row["age"]),
-                            "tier": tier_name,
-                            "retire_type": retire_type,
-                            "retire_rate": rate,
-                        })
+                        rows.append(
+                            {
+                                "age": int(row["age"]),
+                                "tier": tier_name,
+                                "retire_type": retire_type,
+                                "retire_rate": rate,
+                            }
+                        )
 
         out = pd.DataFrame(rows).sort_values(["tier", "retire_type", "age"]).reset_index(drop=True)
         out_path = OUT / "decrements" / f"{sep_cls}_retirement_rates.csv"
@@ -235,23 +246,29 @@ def convert_mortality():
         for _, row in df.iterrows():
             age = int(row["age"])
             for gender in ["female", "male"]:
-                for member_type, col_prefix in [("employee", "employee"),
-                                                 ("retiree", "healthy_retiree")]:
+                for member_type, col_prefix in [
+                    ("employee", "employee"),
+                    ("retiree", "healthy_retiree"),
+                ]:
                     col = f"{col_prefix}_{gender}"
                     qx = row.get(col)
                     if pd.notna(qx):
-                        mort_rows.append({
-                            "age": age,
-                            "gender": gender,
-                            "member_type": member_type,
-                            "table": table_label,
-                            "qx": qx,
-                        })
+                        mort_rows.append(
+                            {
+                                "age": age,
+                                "gender": gender,
+                                "member_type": member_type,
+                                "table": table_label,
+                                "qx": qx,
+                            }
+                        )
 
     if mort_rows:
-        mort_df = pd.DataFrame(mort_rows).sort_values(
-            ["table", "gender", "member_type", "age"]
-        ).reset_index(drop=True)
+        mort_df = (
+            pd.DataFrame(mort_rows)
+            .sort_values(["table", "gender", "member_type", "age"])
+            .reset_index(drop=True)
+        )
         mort_df.to_csv(OUT / "mortality" / "base_rates.csv", index=False)
         print(f"  base_rates.csv: {len(mort_df)} rows")
 
@@ -276,17 +293,19 @@ def convert_mortality():
             for yr_col in year_cols:
                 imp = row[yr_col]
                 if pd.notna(imp):
-                    imp_rows.append({
-                        "age": age,
-                        "year": int(yr_col),
-                        "gender": gender_label,
-                        "improvement": imp,
-                    })
+                    imp_rows.append(
+                        {
+                            "age": age,
+                            "year": int(yr_col),
+                            "gender": gender_label,
+                            "improvement": imp,
+                        }
+                    )
 
     if imp_rows:
-        imp_df = pd.DataFrame(imp_rows).sort_values(
-            ["gender", "age", "year"]
-        ).reset_index(drop=True)
+        imp_df = (
+            pd.DataFrame(imp_rows).sort_values(["gender", "age", "year"]).reset_index(drop=True)
+        )
         imp_df.to_csv(OUT / "mortality" / "improvement_scale.csv", index=False)
         print(f"  improvement_scale.csv: {len(imp_df)} rows")
 
@@ -300,11 +319,13 @@ def convert_funding():
     if amort_src.exists():
         src = pd.read_csv(amort_src)
         # Standardize column names
-        out = src.rename(columns={
-            "class": "class",
-            "amo_period": "amo_period",
-            "amo_balance": "amo_balance",
-        })
+        out = src.rename(
+            columns={
+                "class": "class",
+                "amo_period": "amo_period",
+                "amo_balance": "amo_balance",
+            }
+        )
         # Keep only the columns we need
         keep_cols = ["class", "amo_period", "amo_balance"]
         extra = [c for c in out.columns if c in ["date"]]
@@ -312,8 +333,9 @@ def convert_funding():
         out.to_csv(OUT / "funding" / "amort_layers.csv", index=False)
         print(f"  amort_layers.csv: {len(out)} rows")
 
+
 def main():
-    print(f"Converting FRS data to stage 3 format")
+    print("Converting FRS data to stage 3 format")
     print(f"  Source: {BASELINE}")
     print(f"  Output: {OUT}")
     print()

--- a/scripts/build/convert_txtrs_to_stage3.py
+++ b/scripts/build/convert_txtrs_to_stage3.py
@@ -17,7 +17,7 @@ Run from project root:
 """
 import sys
 from pathlib import Path
-import numpy as np
+
 import pandas as pd
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
@@ -75,11 +75,13 @@ def convert_entrant_profile():
     # Add entrant_dist column
     ep["entrant_dist"] = ep["count"] / ep["count"].sum()
     # Rename to standard column names
-    out = pd.DataFrame({
-        "entry_age": ep["entry_age"],
-        "start_salary": ep["start_sal"],
-        "entrant_dist": ep["entrant_dist"],
-    })
+    out = pd.DataFrame(
+        {
+            "entry_age": ep["entry_age"],
+            "start_salary": ep["start_sal"],
+            "entrant_dist": ep["entrant_dist"],
+        }
+    )
     out.to_csv(OUT / "demographics" / "entrant_profile.csv", index=False)
     print(f"  entrant_profile.csv: {len(out)} rows")
 
@@ -91,12 +93,14 @@ def convert_retiree_distribution():
 
     xlsx_path = RAW_DIR / "TxTRS_BM_Inputs.xlsx"
     rd = load_txtrs_retiree_distribution(xlsx_path)
-    out = pd.DataFrame({
-        "age": rd["age"],
-        "count": rd["n_retire"],
-        "avg_benefit": rd["avg_ben"],
-        "total_benefit": rd["total_ben"],
-    })
+    out = pd.DataFrame(
+        {
+            "age": rd["age"],
+            "count": rd["n_retire"],
+            "avg_benefit": rd["avg_ben"],
+            "total_benefit": rd["total_ben"],
+        }
+    )
     out.to_csv(OUT / "demographics" / "retiree_distribution.csv", index=False)
     print(f"  retiree_distribution.csv: {len(out)} rows")
 
@@ -117,21 +121,25 @@ def convert_termination_rates():
     rows = []
     # Before 10: lookup_type = "yos", lookup_value = YOS
     for _, row in before10.iterrows():
-        rows.append({
-            "lookup_type": "yos",
-            "age": "",
-            "lookup_value": int(row["yos"]),
-            "term_rate": row["term_rate"],
-        })
+        rows.append(
+            {
+                "lookup_type": "yos",
+                "age": "",
+                "lookup_value": int(row["yos"]),
+                "term_rate": row["term_rate"],
+            }
+        )
 
     # After 10: lookup_type = "years_from_nr", lookup_value = years from NR
     for _, row in after10.iterrows():
-        rows.append({
-            "lookup_type": "years_from_nr",
-            "age": "",
-            "lookup_value": int(row["years_from_nr"]),
-            "term_rate": row["term_rate"],
-        })
+        rows.append(
+            {
+                "lookup_type": "years_from_nr",
+                "age": "",
+                "lookup_value": int(row["years_from_nr"]),
+                "term_rate": row["term_rate"],
+            }
+        )
 
     out = pd.DataFrame(rows)
     out.to_csv(OUT / "decrements" / "termination_rates.csv", index=False)
@@ -153,19 +161,23 @@ def convert_retirement_rates():
     for _, row in rr.iterrows():
         age = int(row["age"])
         if row["normal_rate"] > 0 or True:  # Include all ages for completeness
-            rows.append({
-                "age": age,
-                "tier": "all",
-                "retire_type": "normal",
-                "retire_rate": row["normal_rate"],
-            })
+            rows.append(
+                {
+                    "age": age,
+                    "tier": "all",
+                    "retire_type": "normal",
+                    "retire_rate": row["normal_rate"],
+                }
+            )
         if row["reduced_rate"] > 0 or True:
-            rows.append({
-                "age": age,
-                "tier": "all",
-                "retire_type": "early",
-                "retire_rate": row["reduced_rate"],
-            })
+            rows.append(
+                {
+                    "age": age,
+                    "tier": "all",
+                    "retire_type": "early",
+                    "retire_rate": row["reduced_rate"],
+                }
+            )
 
     out = pd.DataFrame(rows).sort_values(["retire_type", "age"]).reset_index(drop=True)
     out.to_csv(OUT / "decrements" / "retirement_rates.csv", index=False)
@@ -188,9 +200,7 @@ def convert_reduction_tables():
     gft = tables["reduced_gft"]
     gft_long = gft.melt(id_vars="yos", var_name="age_col", value_name="reduce_factor")
     # Extract age from column name like "age_55" or "55"
-    gft_long["age"] = gft_long["age_col"].apply(
-        lambda x: int(str(x).replace("age_", "").strip())
-    )
+    gft_long["age"] = gft_long["age_col"].apply(lambda x: int(str(x).replace("age_", "").strip()))
     gft_long = gft_long[["age", "yos", "reduce_factor"]].dropna()
     gft_long["tier"] = "grandfathered"
     gft_long.to_csv(OUT / "decrements" / "reduction_gft.csv", index=False)
@@ -224,25 +234,31 @@ def convert_mortality():
         for _, row in df.iterrows():
             age = int(row["age"])
             for gender in ["female", "male"]:
-                for member_type, col_prefix in [("employee", "employee"),
-                                                 ("retiree", "healthy_retiree")]:
+                for member_type, col_prefix in [
+                    ("employee", "employee"),
+                    ("retiree", "healthy_retiree"),
+                ]:
                     col = f"{col_prefix}_{gender}"
                     qx = row.get(col)
                     if pd.notna(qx):
-                        mort_rows.append({
-                            "age": age,
-                            "gender": gender,
-                            "member_type": member_type,
-                            "table": "teacher_below_median",
-                            "qx": qx,
-                        })
+                        mort_rows.append(
+                            {
+                                "age": age,
+                                "gender": gender,
+                                "member_type": member_type,
+                                "table": "teacher_below_median",
+                                "qx": qx,
+                            }
+                        )
     except Exception as e:
         print(f"  WARNING: Could not read PubT-2010(B): {e}")
 
     if mort_rows:
-        mort_df = pd.DataFrame(mort_rows).sort_values(
-            ["table", "gender", "member_type", "age"]
-        ).reset_index(drop=True)
+        mort_df = (
+            pd.DataFrame(mort_rows)
+            .sort_values(["table", "gender", "member_type", "age"])
+            .reset_index(drop=True)
+        )
         mort_df.to_csv(OUT / "mortality" / "base_rates.csv", index=False)
         print(f"  base_rates.csv: {len(mort_df)} rows")
 
@@ -266,17 +282,19 @@ def convert_mortality():
             for yr_col in year_cols:
                 imp = row[yr_col]
                 if pd.notna(imp):
-                    imp_rows.append({
-                        "age": age,
-                        "year": int(yr_col),
-                        "gender": gender_label,
-                        "improvement": imp,
-                    })
+                    imp_rows.append(
+                        {
+                            "age": age,
+                            "year": int(yr_col),
+                            "gender": gender_label,
+                            "improvement": imp,
+                        }
+                    )
 
     if imp_rows:
-        imp_df = pd.DataFrame(imp_rows).sort_values(
-            ["gender", "age", "year"]
-        ).reset_index(drop=True)
+        imp_df = (
+            pd.DataFrame(imp_rows).sort_values(["gender", "age", "year"]).reset_index(drop=True)
+        )
         imp_df.to_csv(OUT / "mortality" / "improvement_scale.csv", index=False)
         print(f"  improvement_scale.csv: {len(imp_df)} rows")
 
@@ -299,7 +317,7 @@ def convert_funding():
 
 
 def main():
-    print(f"Converting TRS data to stage 3 format")
+    print("Converting TRS data to stage 3 format")
     print(f"  Source: {RAW_DIR}")
     print(f"  Output: {OUT}")
     print()

--- a/scripts/build/decrement_builder.py
+++ b/scripts/build/decrement_builder.py
@@ -9,10 +9,10 @@ Raw inputs:
   - Reports/extracted inputs/: retirement and DROP entry xlsx files
 """
 
-import numpy as np
-import pandas as pd
 from pathlib import Path
 
+import numpy as np
+import pandas as pd
 
 # Class → search text mapping for retirement/DROP tables
 _RETIRE_CLASS_MAP = {
@@ -22,7 +22,11 @@ _RETIRE_CLASS_MAP = {
     "eco": {"drop": "other", "normal": "eco_eso_jud", "early": "eco_eso_jud"},
     "eso": {"drop": "other", "normal": "eco_eso_jud", "early": "eco_eso_jud"},
     "judges": {"drop": "other", "normal": "eco_eso_jud", "early": "eco_eso_jud"},
-    "senior_management": {"drop": "other", "normal": "senior_management", "early": "senior_management"},
+    "senior_management": {
+        "drop": "other",
+        "normal": "senior_management",
+        "early": "senior_management",
+    },
 }
 
 # Withdrawal rate sheet names by class
@@ -61,13 +65,13 @@ def _clean_retire_rate_table(raw: pd.DataFrame, col_names: list) -> pd.DataFrame
             break
 
     # Slice to body
-    body = raw.iloc[age_row + 1:last_na].copy()
+    body = raw.iloc[age_row + 1 : last_na].copy()
     body = body.dropna(axis=1, how="all").reset_index(drop=True)
 
     # Apply column names
     if len(body.columns) != len(col_names):
         # Trim or pad columns
-        body = body.iloc[:, :len(col_names)]
+        body = body.iloc[:, : len(col_names)]
     body.columns = col_names
 
     # Handle "70-79" row: expand to individual ages
@@ -78,7 +82,7 @@ def _clean_retire_rate_table(raw: pd.DataFrame, col_names: list) -> pd.DataFrame
         row_data["age"] = "70"
         extra = pd.DataFrame([row_data.to_dict()] * 10)
         extra["age"] = [str(a) for a in range(70, 80)]
-        body = pd.concat([body.iloc[:idx], extra, body.iloc[idx + 1:]], ignore_index=True)
+        body = pd.concat([body.iloc[:idx], extra, body.iloc[idx + 1 :]], ignore_index=True)
 
     body["age"] = pd.to_numeric(body["age"].astype(str).str.strip(), errors="coerce")
     for c in body.columns:
@@ -116,7 +120,9 @@ def _read_withdrawal_table(excel_path: Path, sheet_name: str, max_yos: int = 70)
 
 
 def build_withdrawal_rate_table(
-    excel_path: Path, class_name: str, max_yos: int = 70,
+    excel_path: Path,
+    class_name: str,
+    max_yos: int = 70,
 ) -> pd.DataFrame:
     """
     Build gender-averaged withdrawal rate table for a class.
@@ -137,7 +143,9 @@ def build_withdrawal_rate_table(
 
 
 def build_retirement_rate_tables(
-    frs_inputs_path: Path, extracted_inputs_dir: Path, class_name: str,
+    frs_inputs_path: Path,
+    extracted_inputs_dir: Path,
+    class_name: str,
 ) -> dict:
     """
     Build per-class normal and early retirement rate tables.
@@ -152,29 +160,58 @@ def build_retirement_rate_tables(
     mapping = _RETIRE_CLASS_MAP[class_name]
 
     # Column name templates
-    drop_col_names = ["age", "regular_inst_female", "regular_inst_male",
-                      "regular_non_inst_female", "regular_non_inst_male",
-                      "special_risk_non_leo_female", "special_risk_non_leo_male",
-                      "special_risk_leo_female", "special_risk_leo_male",
-                      "other_female", "other_male"]
+    drop_col_names = [
+        "age",
+        "regular_inst_female",
+        "regular_inst_male",
+        "regular_non_inst_female",
+        "regular_non_inst_male",
+        "special_risk_non_leo_female",
+        "special_risk_non_leo_male",
+        "special_risk_leo_female",
+        "special_risk_leo_male",
+        "other_female",
+        "other_male",
+    ]
 
-    normal_col_names = ["age", "regular_inst_female", "regular_inst_male",
-                        "regular_non_inst_female", "regular_non_inst_male",
-                        "special_risk_female", "special_risk_male",
-                        "eco_eso_jud_female", "eco_eso_jud_male",
-                        "senior_management_female", "senior_management_male"]
+    normal_col_names = [
+        "age",
+        "regular_inst_female",
+        "regular_inst_male",
+        "regular_non_inst_female",
+        "regular_non_inst_male",
+        "special_risk_female",
+        "special_risk_male",
+        "eco_eso_jud_female",
+        "eco_eso_jud_male",
+        "senior_management_female",
+        "senior_management_male",
+    ]
 
-    early_col_names = ["age", "regular_non_inst_female", "regular_non_inst_male",
-                       "special_risk_female", "special_risk_male",
-                       "eco_eso_jud_female", "eco_eso_jud_male",
-                       "senior_management_female", "senior_management_male"]
+    early_col_names = [
+        "age",
+        "regular_non_inst_female",
+        "regular_non_inst_male",
+        "special_risk_female",
+        "special_risk_male",
+        "eco_eso_jud_female",
+        "eco_eso_jud_male",
+        "senior_management_female",
+        "senior_management_male",
+    ]
 
     result = {}
     for tier_num in [1, 2]:
         # Read raw tables
-        drop_raw = pd.read_excel(extracted_inputs_dir / f"drop entry tier {tier_num}.xlsx", header=None)
-        normal_raw = pd.read_excel(extracted_inputs_dir / f"normal retirement tier {tier_num}.xlsx", header=None)
-        early_raw = pd.read_excel(extracted_inputs_dir / f"early retirement tier {tier_num}.xlsx", header=None)
+        drop_raw = pd.read_excel(
+            extracted_inputs_dir / f"drop entry tier {tier_num}.xlsx", header=None
+        )
+        normal_raw = pd.read_excel(
+            extracted_inputs_dir / f"normal retirement tier {tier_num}.xlsx", header=None
+        )
+        early_raw = pd.read_excel(
+            extracted_inputs_dir / f"early retirement tier {tier_num}.xlsx", header=None
+        )
 
         drop_table = _clean_retire_rate_table(drop_raw, drop_col_names)
         normal_table = _clean_retire_rate_table(normal_raw, normal_col_names)
@@ -193,7 +230,11 @@ def build_retirement_rate_tables(
         if mapping["drop"] == "special":
             # R pre-averages LEO and non-LEO into single female/male columns
             sr_cols_f = [c for c in drop_table.columns if "special_risk" in c and "female" in c]
-            sr_cols_m = [c for c in drop_table.columns if "special_risk" in c and "male" in c and "female" not in c]
+            sr_cols_m = [
+                c
+                for c in drop_table.columns
+                if "special_risk" in c and "male" in c and "female" not in c
+            ]
             drop_table["special_risk_female"] = drop_table[sr_cols_f].mean(axis=1)
             drop_table["special_risk_male"] = drop_table[sr_cols_m].mean(axis=1)
             # Use ONLY the averaged columns, not the originals

--- a/scripts/build/estimate_txtrs_av_retiree_mortality.py
+++ b/scripts/build/estimate_txtrs_av_retiree_mortality.py
@@ -31,10 +31,10 @@ Outputs:
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from pathlib import Path
 import math
 import sys
+from dataclasses import dataclass
+from pathlib import Path
 
 import numpy as np
 import pandas as pd
@@ -50,17 +50,28 @@ from pension_model.core.mortality_builder import (
     _read_mp_table,
 )
 
-
 PUB_PATH = PROJECT_ROOT / "prep" / "common" / "sources" / "soa_pub2010_amount_mort_rates.xlsx"
 MP_PATH = PROJECT_ROOT / "prep" / "common" / "sources" / "soa_mp2021_rates.xlsx"
 CHECKPOINTS_PATH = (
-    PROJECT_ROOT / "prep" / "txtrs-av" / "reference_tables" / "retiree_mortality_sample_checkpoints.csv"
+    PROJECT_ROOT
+    / "prep"
+    / "txtrs-av"
+    / "reference_tables"
+    / "retiree_mortality_sample_checkpoints.csv"
 )
 OUT_BASE = (
-    PROJECT_ROOT / "prep" / "txtrs-av" / "reference_tables" / "estimated_retiree_mortality_base_2021.csv"
+    PROJECT_ROOT
+    / "prep"
+    / "txtrs-av"
+    / "reference_tables"
+    / "estimated_retiree_mortality_base_2021.csv"
 )
 OUT_VALIDATION = (
-    PROJECT_ROOT / "prep" / "txtrs-av" / "reference_tables" / "estimated_retiree_mortality_validation.csv"
+    PROJECT_ROOT
+    / "prep"
+    / "txtrs-av"
+    / "reference_tables"
+    / "estimated_retiree_mortality_validation.csv"
 )
 OUT_SUMMARY = (
     PROJECT_ROOT
@@ -70,10 +81,18 @@ OUT_SUMMARY = (
     / "estimated_retiree_mortality_validation_summary.csv"
 )
 OUT_PLOT_2021 = (
-    PROJECT_ROOT / "prep" / "txtrs-av" / "reference_tables" / "estimated_retiree_mortality_fit_2021.svg"
+    PROJECT_ROOT
+    / "prep"
+    / "txtrs-av"
+    / "reference_tables"
+    / "estimated_retiree_mortality_fit_2021.svg"
 )
 OUT_PLOT_VALIDATION = (
-    PROJECT_ROOT / "prep" / "txtrs-av" / "reference_tables" / "estimated_retiree_mortality_validation.svg"
+    PROJECT_ROOT
+    / "prep"
+    / "txtrs-av"
+    / "reference_tables"
+    / "estimated_retiree_mortality_validation.svg"
 )
 OUT_PLOT_TXTRS_COMPARE = (
     PROJECT_ROOT
@@ -83,7 +102,9 @@ OUT_PLOT_TXTRS_COMPARE = (
     / "estimated_retiree_mortality_vs_txtrs_runtime.svg"
 )
 TXTRS_BASE_RATES = PROJECT_ROOT / "plans" / "txtrs" / "data" / "mortality" / "base_rates.csv"
-TXTRS_IMPROVEMENT = PROJECT_ROOT / "plans" / "txtrs" / "data" / "mortality" / "improvement_scale.csv"
+TXTRS_IMPROVEMENT = (
+    PROJECT_ROOT / "plans" / "txtrs" / "data" / "mortality" / "improvement_scale.csv"
+)
 
 
 @dataclass(frozen=True)
@@ -126,7 +147,9 @@ def _load_mp_ultimate() -> pd.DataFrame:
     return out[(out["age"] >= CFG.min_age) & (out["age"] <= CFG.max_age)].reset_index(drop=True)
 
 
-def _project_with_immediate_convergence(base_qx: pd.Series, annual_improvement: pd.Series, years: int) -> pd.Series:
+def _project_with_immediate_convergence(
+    base_qx: pd.Series, annual_improvement: pd.Series, years: int
+) -> pd.Series:
     return base_qx * np.power(1.0 - annual_improvement, years)
 
 
@@ -184,12 +207,7 @@ def _pchip_interpolate(x: np.ndarray, y: np.ndarray, x_new: np.ndarray) -> np.nd
         h10 = t**3 - 2 * t**2 + t
         h01 = -2 * t**3 + 3 * t**2
         h11 = t**3 - t**2
-        result[i] = (
-            h00 * y[j]
-            + h10 * h * d[j]
-            + h01 * y[j + 1]
-            + h11 * h * d[j + 1]
-        )
+        result[i] = h00 * y[j] + h10 * h * d[j] + h01 * y[j + 1] + h11 * h * d[j + 1]
     return result
 
 
@@ -264,7 +282,9 @@ def _build_base_2021_estimate() -> pd.DataFrame:
         anchor_qx = np.concatenate(
             [
                 out.loc[out["age"] == CFG.min_age, ref_col].to_numpy(dtype=float),
-                out.loc[out["age"] == CFG.min_age + CFG.reference_knot_step, ref_col].to_numpy(dtype=float),
+                out.loc[out["age"] == CFG.min_age + CFG.reference_knot_step, ref_col].to_numpy(
+                    dtype=float
+                ),
                 np.maximum(joined["qx"].to_numpy(dtype=float), CFG.anchor_floor),
             ]
         )
@@ -323,7 +343,11 @@ def _build_validation(base_2021: pd.DataFrame) -> tuple[pd.DataFrame, pd.DataFra
             }
         )
 
-    detail = pd.DataFrame(rows).sort_values(["source_id", "rate_year", "gender", "age"]).reset_index(drop=True)
+    detail = (
+        pd.DataFrame(rows)
+        .sort_values(["source_id", "rate_year", "gender", "age"])
+        .reset_index(drop=True)
+    )
     summary = (
         detail.groupby(["source_id", "rate_year", "gender"], as_index=False)
         .agg(
@@ -359,7 +383,9 @@ def _build_txtrs_runtime_curves(target_year: int) -> pd.DataFrame:
         female_mp, "female", CFG.base_year, CFG.min_age, CFG.max_age, max(target_year, 2154)
     )
     male_factor = male_final[male_final["year"] == target_year][["age", "male_mp_cumprod_adj"]]
-    female_factor = female_final[female_final["year"] == target_year][["age", "female_mp_cumprod_adj"]]
+    female_factor = female_final[female_final["year"] == target_year][
+        ["age", "female_mp_cumprod_adj"]
+    ]
 
     out = base.merge(male_factor, on="age", how="left").merge(female_factor, on="age", how="left")
     out = out[(out["age"] >= CFG.min_age) & (out["age"] <= CFG.max_age)].copy()
@@ -368,7 +394,9 @@ def _build_txtrs_runtime_curves(target_year: int) -> pd.DataFrame:
     return out[["age", "male_qx", "female_qx"]].reset_index(drop=True)
 
 
-def _svg_line(points: list[tuple[float, float]], color: str, width: float = 2.0, dash: str | None = None) -> str:
+def _svg_line(
+    points: list[tuple[float, float]], color: str, width: float = 2.0, dash: str | None = None
+) -> str:
     coords = " ".join(f"{x:.2f},{y:.2f}" for x, y in points)
     dash_attr = f' stroke-dasharray="{dash}"' if dash else ""
     return (
@@ -416,7 +444,9 @@ def _plot_fit_2021(base_2021: pd.DataFrame) -> None:
     min_log = -4.5
     max_log = 0.0
 
-    body = ['<text x="40" y="35" font-size="24" font-family="monospace">TXTRS-AV healthy retiree mortality fit, 2021</text>']
+    body = [
+        '<text x="40" y="35" font-size="24" font-family="monospace">TXTRS-AV healthy retiree mortality fit, 2021</text>'
+    ]
     body.append(
         '<text x="40" y="58" font-size="14" font-family="monospace">Solid teal = exploratory txtrs-av estimate. Dashed gray = smoothed projected PubT-2010(B) teacher healthy-retiree reference. Orange points = published 2021 TRS checkpoints. Y-axis is log10(qx).</text>'
     )
@@ -424,30 +454,40 @@ def _plot_fit_2021(base_2021: pd.DataFrame) -> None:
     for i, gender in enumerate(("male", "female")):
         x0 = x_margin + i * (panel_w + 80)
         y0 = top
-        body.append(f'<rect x="{x0}" y="{y0}" width="{panel_w}" height="{panel_h}" fill="none" stroke="#333" stroke-width="1"/>')
+        body.append(
+            f'<rect x="{x0}" y="{y0}" width="{panel_w}" height="{panel_h}" fill="none" stroke="#333" stroke-width="1"/>'
+        )
         body.append(
             f'<text x="{x0}" y="{y0 - 15}" font-size="18" font-family="monospace">{gender.title()}</text>'
         )
 
         for age_tick in range(20, 121, 10):
             x = _map_age(age_tick, x0, panel_w)
-            body.append(f'<line x1="{x:.2f}" y1="{y0}" x2="{x:.2f}" y2="{y0 + panel_h}" stroke="#eee" stroke-width="1"/>')
+            body.append(
+                f'<line x1="{x:.2f}" y1="{y0}" x2="{x:.2f}" y2="{y0 + panel_h}" stroke="#eee" stroke-width="1"/>'
+            )
             body.append(
                 f'<text x="{x - 10:.2f}" y="{y0 + panel_h + 20}" font-size="12" font-family="monospace">{age_tick}</text>'
             )
         for q_tick in (1e-4, 1e-3, 1e-2, 1e-1, 1.0):
             y = _map_qx(q_tick, y0, panel_h, min_log, max_log)
-            body.append(f'<line x1="{x0}" y1="{y:.2f}" x2="{x0 + panel_w}" y2="{y:.2f}" stroke="#eee" stroke-width="1"/>')
+            body.append(
+                f'<line x1="{x0}" y1="{y:.2f}" x2="{x0 + panel_w}" y2="{y:.2f}" stroke="#eee" stroke-width="1"/>'
+            )
             body.append(
                 f'<text x="{x0 - 60}" y="{y + 4:.2f}" font-size="12" font-family="monospace">{q_tick:.0e}</text>'
             )
 
         ref_col = f"ref_2021_{gender}_qx_smoothed"
         est_col = f"estimated_2021_{gender}_qx"
-        ref_pts = [(_map_age(a, x0, panel_w), _map_qx(q, y0, panel_h, min_log, max_log))
-                   for a, q in zip(base_2021["age"], base_2021[ref_col])]
-        est_pts = [(_map_age(a, x0, panel_w), _map_qx(q, y0, panel_h, min_log, max_log))
-                   for a, q in zip(base_2021["age"], base_2021[est_col])]
+        ref_pts = [
+            (_map_age(a, x0, panel_w), _map_qx(q, y0, panel_h, min_log, max_log))
+            for a, q in zip(base_2021["age"], base_2021[ref_col], strict=False)
+        ]
+        est_pts = [
+            (_map_age(a, x0, panel_w), _map_qx(q, y0, panel_h, min_log, max_log))
+            for a, q in zip(base_2021["age"], base_2021[est_col], strict=False)
+        ]
         body.append(_svg_line(ref_pts, "#999999", width=2.0, dash="6 4"))
         body.append(_svg_line(est_pts, "#005f73", width=2.5))
 
@@ -460,11 +500,19 @@ def _plot_fit_2021(base_2021: pd.DataFrame) -> None:
     legend_x = 80
     legend_y = 630
     body.append(_svg_line([(legend_x, legend_y), (legend_x + 35, legend_y)], "#005f73", width=2.5))
-    body.append('<text x="125" y="634" font-size="13" font-family="monospace">solid teal: exploratory txtrs-av estimated 2021 healthy-retiree curve</text>')
-    body.append(_svg_line([(legend_x, 658), (legend_x + 35, 658)], "#999999", width=2.0, dash="6 4"))
-    body.append('<text x="125" y="662" font-size="13" font-family="monospace">dashed gray: smoothed projected PubT-2010(B) teacher healthy-retiree reference</text>')
+    body.append(
+        '<text x="125" y="634" font-size="13" font-family="monospace">solid teal: exploratory txtrs-av estimated 2021 healthy-retiree curve</text>'
+    )
+    body.append(
+        _svg_line([(legend_x, 658), (legend_x + 35, 658)], "#999999", width=2.0, dash="6 4")
+    )
+    body.append(
+        '<text x="125" y="662" font-size="13" font-family="monospace">dashed gray: smoothed projected PubT-2010(B) teacher healthy-retiree reference</text>'
+    )
     body.append(_svg_circle(760, legend_y, "#bb3e03", radius=4.0))
-    body.append('<text x="775" y="634" font-size="13" font-family="monospace">orange points: published 2021 TRS healthy-retiree checkpoints</text>')
+    body.append(
+        '<text x="775" y="634" font-size="13" font-family="monospace">orange points: published 2021 TRS healthy-retiree checkpoints</text>'
+    )
 
     _write_svg(OUT_PLOT_2021, "".join(body), width=width, height=height)
 
@@ -472,11 +520,20 @@ def _plot_fit_2021(base_2021: pd.DataFrame) -> None:
 def _plot_validation(base_2021: pd.DataFrame) -> None:
     checkpoints = pd.read_csv(CHECKPOINTS_PATH)
     projection_years = [2021, 2023, 2051, 2053]
-    projections = {year: (_project_from_estimated_2021(base_2021, year) if year != 2021 else pd.DataFrame({
-        "age": base_2021["age"],
-        "male_qx": base_2021["estimated_2021_male_qx"],
-        "female_qx": base_2021["estimated_2021_female_qx"],
-    })) for year in projection_years}
+    projections = {
+        year: (
+            _project_from_estimated_2021(base_2021, year)
+            if year != 2021
+            else pd.DataFrame(
+                {
+                    "age": base_2021["age"],
+                    "male_qx": base_2021["estimated_2021_male_qx"],
+                    "female_qx": base_2021["estimated_2021_female_qx"],
+                }
+            )
+        )
+        for year in projection_years
+    }
 
     width = 1200
     height = 900
@@ -487,7 +544,9 @@ def _plot_validation(base_2021: pd.DataFrame) -> None:
     min_log = -4.5
     max_log = 0.0
 
-    body = ['<text x="40" y="35" font-size="24" font-family="monospace">TXTRS-AV healthy retiree mortality validation</text>']
+    body = [
+        '<text x="40" y="35" font-size="24" font-family="monospace">TXTRS-AV healthy retiree mortality validation</text>'
+    ]
     body.append(
         '<text x="40" y="58" font-size="14" font-family="monospace">Each colored line is the projected txtrs-av estimate for that year. Matching colored points are the published TRS checkpoints. Y-axis is log10(qx).</text>'
     )
@@ -499,23 +558,33 @@ def _plot_validation(base_2021: pd.DataFrame) -> None:
         x0 = lefts[col]
         for row_idx, years_pair in enumerate(((2021, 2023), (2051, 2053))):
             y0 = tops[row_idx]
-            body.append(f'<rect x="{x0}" y="{y0}" width="{panel_w}" height="{panel_h}" fill="none" stroke="#333" stroke-width="1"/>')
+            body.append(
+                f'<rect x="{x0}" y="{y0}" width="{panel_w}" height="{panel_h}" fill="none" stroke="#333" stroke-width="1"/>'
+            )
             body.append(
                 f'<text x="{x0}" y="{y0 - 15}" font-size="18" font-family="monospace">{gender.title()} projected estimate and checkpoints: {" / ".join(str(y) for y in years_pair)}</text>'
             )
             for age_tick in range(20, 121, 10):
                 x = _map_age(age_tick, x0, panel_w)
-                body.append(f'<line x1="{x:.2f}" y1="{y0}" x2="{x:.2f}" y2="{y0 + panel_h}" stroke="#eee" stroke-width="1"/>')
+                body.append(
+                    f'<line x1="{x:.2f}" y1="{y0}" x2="{x:.2f}" y2="{y0 + panel_h}" stroke="#eee" stroke-width="1"/>'
+                )
             for q_tick in (1e-4, 1e-3, 1e-2, 1e-1, 1.0):
                 y = _map_qx(q_tick, y0, panel_h, min_log, max_log)
-                body.append(f'<line x1="{x0}" y1="{y:.2f}" x2="{x0 + panel_w}" y2="{y:.2f}" stroke="#eee" stroke-width="1"/>')
+                body.append(
+                    f'<line x1="{x0}" y1="{y:.2f}" x2="{x0 + panel_w}" y2="{y:.2f}" stroke="#eee" stroke-width="1"/>'
+                )
 
             for year in years_pair:
                 proj = projections[year]
-                pts = [(_map_age(a, x0, panel_w), _map_qx(q, y0, panel_h, min_log, max_log))
-                       for a, q in zip(proj["age"], proj[f"{gender}_qx"])]
+                pts = [
+                    (_map_age(a, x0, panel_w), _map_qx(q, y0, panel_h, min_log, max_log))
+                    for a, q in zip(proj["age"], proj[f"{gender}_qx"], strict=False)
+                ]
                 body.append(_svg_line(pts, colors[year], width=2.3))
-                gpts = checkpoints[(checkpoints["gender"] == gender) & (checkpoints["rate_year"] == year)]
+                gpts = checkpoints[
+                    (checkpoints["gender"] == gender) & (checkpoints["rate_year"] == year)
+                ]
                 for _, pt in gpts.iterrows():
                     body.append(
                         _svg_circle(
@@ -530,7 +599,13 @@ def _plot_validation(base_2021: pd.DataFrame) -> None:
     legend_y = 860
     offset = 0
     for year in projection_years:
-        body.append(_svg_line([(legend_x + offset, legend_y), (legend_x + offset + 30, legend_y)], colors[year], width=2.5))
+        body.append(
+            _svg_line(
+                [(legend_x + offset, legend_y), (legend_x + offset + 30, legend_y)],
+                colors[year],
+                width=2.5,
+            )
+        )
         body.append(_svg_circle(legend_x + offset + 15, legend_y, colors[year], radius=3.8))
         body.append(
             f'<text x="{legend_x + offset + 40}" y="{legend_y + 4}" font-size="13" font-family="monospace">{year}: line = estimated curve, points = published checkpoints</text>'
@@ -571,7 +646,9 @@ def _plot_txtrs_comparison(base_2021: pd.DataFrame) -> None:
         2023: "#0a9396",
     }
 
-    body = ['<text x="40" y="35" font-size="24" font-family="monospace">TXTRS-AV estimate vs current txtrs runtime retiree mortality</text>']
+    body = [
+        '<text x="40" y="35" font-size="24" font-family="monospace">TXTRS-AV estimate vs current txtrs runtime retiree mortality</text>'
+    ]
     body.append(
         '<text x="40" y="58" font-size="14" font-family="monospace">Solid teal = exploratory txtrs-av estimate. Dashed red = current txtrs runtime retiree mortality. Points = published TRS checkpoints for that year. Y-axis is log10(qx).</text>'
     )
@@ -580,23 +657,33 @@ def _plot_txtrs_comparison(base_2021: pd.DataFrame) -> None:
         x0 = lefts[gender_idx]
         for row_idx, year in enumerate(years):
             y0 = tops[row_idx]
-            body.append(f'<rect x="{x0}" y="{y0}" width="{panel_w}" height="{panel_h}" fill="none" stroke="#333" stroke-width="1"/>')
+            body.append(
+                f'<rect x="{x0}" y="{y0}" width="{panel_w}" height="{panel_h}" fill="none" stroke="#333" stroke-width="1"/>'
+            )
             body.append(
                 f'<text x="{x0}" y="{y0 - 15}" font-size="18" font-family="monospace">{gender.title()} {year}</text>'
             )
             for age_tick in range(20, 121, 10):
                 x = _map_age(age_tick, x0, panel_w)
-                body.append(f'<line x1="{x:.2f}" y1="{y0}" x2="{x:.2f}" y2="{y0 + panel_h}" stroke="#eee" stroke-width="1"/>')
+                body.append(
+                    f'<line x1="{x:.2f}" y1="{y0}" x2="{x:.2f}" y2="{y0 + panel_h}" stroke="#eee" stroke-width="1"/>'
+                )
             for q_tick in (1e-4, 1e-3, 1e-2, 1e-1, 1.0):
                 y = _map_qx(q_tick, y0, panel_h, min_log, max_log)
-                body.append(f'<line x1="{x0}" y1="{y:.2f}" x2="{x0 + panel_w}" y2="{y:.2f}" stroke="#eee" stroke-width="1"/>')
+                body.append(
+                    f'<line x1="{x0}" y1="{y:.2f}" x2="{x0 + panel_w}" y2="{y:.2f}" stroke="#eee" stroke-width="1"/>'
+                )
 
             est = estimated[year]
             tx = txtrs_runtime[year]
-            est_pts = [(_map_age(a, x0, panel_w), _map_qx(q, y0, panel_h, min_log, max_log))
-                       for a, q in zip(est["age"], est[f"{gender}_qx"])]
-            tx_pts = [(_map_age(a, x0, panel_w), _map_qx(q, y0, panel_h, min_log, max_log))
-                      for a, q in zip(tx["age"], tx[f"{gender}_qx"])]
+            est_pts = [
+                (_map_age(a, x0, panel_w), _map_qx(q, y0, panel_h, min_log, max_log))
+                for a, q in zip(est["age"], est[f"{gender}_qx"], strict=False)
+            ]
+            tx_pts = [
+                (_map_age(a, x0, panel_w), _map_qx(q, y0, panel_h, min_log, max_log))
+                for a, q in zip(tx["age"], tx[f"{gender}_qx"], strict=False)
+            ]
             body.append(_svg_line(est_pts, colors["estimate"], width=2.5))
             body.append(_svg_line(tx_pts, colors["txtrs"], width=2.0, dash="7 4"))
 
@@ -617,13 +704,23 @@ def _plot_txtrs_comparison(base_2021: pd.DataFrame) -> None:
 
     legend_y = 860
     body.append(_svg_line([(80, legend_y), (110, legend_y)], colors["estimate"], width=2.5))
-    body.append('<text x="120" y="864" font-size="13" font-family="monospace">solid teal: exploratory txtrs-av estimate</text>')
-    body.append(_svg_line([(430, legend_y), (460, legend_y)], colors["txtrs"], width=2.0, dash="7 4"))
-    body.append('<text x="470" y="864" font-size="13" font-family="monospace">dashed red: current txtrs runtime retiree mortality</text>')
+    body.append(
+        '<text x="120" y="864" font-size="13" font-family="monospace">solid teal: exploratory txtrs-av estimate</text>'
+    )
+    body.append(
+        _svg_line([(430, legend_y), (460, legend_y)], colors["txtrs"], width=2.0, dash="7 4")
+    )
+    body.append(
+        '<text x="470" y="864" font-size="13" font-family="monospace">dashed red: current txtrs runtime retiree mortality</text>'
+    )
     body.append(_svg_circle(820, legend_y, colors[2021], radius=3.8))
-    body.append('<text x="835" y="864" font-size="13" font-family="monospace">points: published 2021 checkpoint</text>')
+    body.append(
+        '<text x="835" y="864" font-size="13" font-family="monospace">points: published 2021 checkpoint</text>'
+    )
     body.append(_svg_circle(820, 888, colors[2023], radius=3.8))
-    body.append('<text x="835" y="892" font-size="13" font-family="monospace">points: published 2023 checkpoint</text>')
+    body.append(
+        '<text x="835" y="892" font-size="13" font-family="monospace">points: published 2023 checkpoint</text>'
+    )
 
     _write_svg(OUT_PLOT_TXTRS_COMPARE, "".join(body), width=width, height=height)
 

--- a/scripts/build/generate_entrant_profiles.py
+++ b/scripts/build/generate_entrant_profiles.py
@@ -1,6 +1,9 @@
 """Generate entrant profile files from workforce data to match R model."""
-import pandas as pd
+
 from pathlib import Path
+
+import pandas as pd
+
 
 def generate_entrant_profiles():
     """Generate entrant profile files for all classes."""
@@ -17,24 +20,24 @@ def generate_entrant_profiles():
         wf_df = pd.read_csv(wf_file)
 
         # Filter to most recent entry year
-        max_entry_year = wf_df['year'].max()
-        recent_wf = wf_df[wf_df['year'] == max_entry_year]
+        max_entry_year = wf_df["year"].max()
+        recent_wf = wf_df[wf_df["year"] == max_entry_year]
 
         # Calculate entry_age from age - yos
         recent_wf = recent_wf.copy()
-        recent_wf['entry_age_calc'] = recent_wf['age'] - recent_wf['entry_age']
+        recent_wf["entry_age_calc"] = recent_wf["age"] - recent_wf["entry_age"]
 
         # Group by entry_age and get count
-        entrant_profile = recent_wf.groupby('entry_age_calc').agg(
-            count=('n_active', 'sum')
-        ).reset_index()
+        entrant_profile = (
+            recent_wf.groupby("entry_age_calc").agg(count=("n_active", "sum")).reset_index()
+        )
 
         # Calculate distribution
-        total_count = entrant_profile['count'].sum()
-        entrant_profile['entrant_dist'] = entrant_profile['count'] / total_count
+        total_count = entrant_profile["count"].sum()
+        entrant_profile["entrant_dist"] = entrant_profile["count"] / total_count
 
         # Rename column to match expected format
-        entrant_profile = entrant_profile.rename(columns={'entry_age_calc': 'entry_age'})
+        entrant_profile = entrant_profile.rename(columns={"entry_age_calc": "entry_age"})
 
         # Save to file
         output_file = baseline_dir / f"{class_name}_entrant_profile.csv"

--- a/scripts/build/generate_separation_tables.py
+++ b/scripts/build/generate_separation_tables.py
@@ -8,10 +8,9 @@ The R model creates combined separation tables that:
 This script generates these tables as CSV files for each class.
 """
 
-import pandas as pd
-import numpy as np
 from pathlib import Path
-from typing import Dict, Optional, Tuple
+
+import pandas as pd
 
 
 def get_tier(entry_year: int, age: int, yos: int, class_name: str, new_year: int = 2024) -> str:
@@ -109,7 +108,9 @@ def load_withdrawal_table(class_name: str, decrement_dir: Path) -> pd.DataFrame:
         # Average male and female rates
         # Tables have yos, age, withdrawal_rate columns
         combined = male_df.copy()
-        combined['withdrawal_rate'] = (male_df['withdrawal_rate'] + female_df['withdrawal_rate']) / 2
+        combined["withdrawal_rate"] = (
+            male_df["withdrawal_rate"] + female_df["withdrawal_rate"]
+        ) / 2
         return combined
     else:
         raise FileNotFoundError(f"Withdrawal table not found for {class_name}")
@@ -131,7 +132,7 @@ RETIREMENT_CLASS_MAP = {
 }
 
 
-def load_retirement_tables(decrement_dir: Path) -> Dict[str, Dict[str, pd.DataFrame]]:
+def load_retirement_tables(decrement_dir: Path) -> dict[str, dict[str, pd.DataFrame]]:
     """
     Load retirement rate tables for both tiers, organized by class.
 
@@ -146,10 +147,11 @@ def load_retirement_tables(decrement_dir: Path) -> Dict[str, Dict[str, pd.DataFr
     # Organize by class
     class_tables = {}
     for class_name, table_classes in RETIREMENT_CLASS_MAP.items():
+
         def get_class_rates(df, table_classes):
-            filtered = df[df['class_name'].isin(table_classes)]
+            filtered = df[df["class_name"].isin(table_classes)]
             # Group by age and average the retirement_rate
-            return filtered.groupby('age')['retirement_rate'].mean().reset_index()
+            return filtered.groupby("age")["retirement_rate"].mean().reset_index()
 
         class_tables[class_name] = {
             "normal_t1": get_class_rates(normal_t1_raw, table_classes),
@@ -184,34 +186,34 @@ def get_withdrawal_rate(withdrawal_df: pd.DataFrame, age: int, yos: int) -> floa
 
     # The withdrawal table has yos, age, withdrawal_rate columns
     # Filter to find matching row
-    matching = withdrawal_df[(withdrawal_df['yos'] == yos) & (withdrawal_df['age'] == age)]
+    matching = withdrawal_df[(withdrawal_df["yos"] == yos) & (withdrawal_df["age"] == age)]
 
     if len(matching) == 0:
         return 0.0
 
-    return float(matching['withdrawal_rate'].iloc[0])
+    return float(matching["withdrawal_rate"].iloc[0])
 
 
 def get_retirement_rate(retirement_df: pd.DataFrame, age: int) -> float:
     """Get retirement rate for given age from processed table."""
-    if 'age' not in retirement_df.columns or 'retirement_rate' not in retirement_df.columns:
+    if "age" not in retirement_df.columns or "retirement_rate" not in retirement_df.columns:
         return 0.0
 
-    row = retirement_df[retirement_df['age'] == age]
+    row = retirement_df[retirement_df["age"] == age]
     if len(row) == 0:
         return 0.0
-    return row['retirement_rate'].iloc[0]
+    return row["retirement_rate"].iloc[0]
 
 
 def generate_separation_table(
     class_name: str,
     withdrawal_df: pd.DataFrame,
-    retirement_tables: Dict[str, pd.DataFrame],
+    retirement_tables: dict[str, pd.DataFrame],
     entry_year_range: range,
     entry_age_range: range,
     age_range: range,
     yos_range: range,
-    new_year: int = 2024
+    new_year: int = 2024,
 ) -> pd.DataFrame:
     """
     Generate combined separation rate table following R model's get_separation_table function.
@@ -259,15 +261,17 @@ def generate_separation_table(
                 else:
                     sep_rate = 0.0  # Non-vested members don't separate
 
-                rows.append({
-                    'entry_year': entry_year,
-                    'entry_age': entry_age,
-                    'term_age': term_age,
-                    'yos': yos,
-                    'term_year': term_year,
-                    'tier': tier,
-                    'separation_rate': sep_rate
-                })
+                rows.append(
+                    {
+                        "entry_year": entry_year,
+                        "entry_age": entry_age,
+                        "term_age": term_age,
+                        "yos": yos,
+                        "term_year": term_year,
+                        "tier": tier,
+                        "separation_rate": sep_rate,
+                    }
+                )
 
     return pd.DataFrame(rows)
 
@@ -278,7 +282,7 @@ def get_entry_ages_from_workforce(class_name: str, baseline_dir: Path) -> List[i
         wf_file = baseline_dir / f"{class_name}_wf_active.csv"
         if wf_file.exists():
             wf_df = pd.read_csv(wf_file)
-            return sorted(wf_df['entry_age'].unique().tolist())
+            return sorted(wf_df["entry_age"].unique().tolist())
     except Exception as e:
         print(f"Warning: Could not load workforce data for {class_name}: {e}")
     return []
@@ -342,7 +346,7 @@ def main():
             print(f"  Using entry ages from workforce data: {workforce_entry_ages}")
             entry_age_range = workforce_entry_ages
         else:
-            print(f"  Using default entry ages")
+            print("  Using default entry ages")
             entry_age_range = default_entry_ages.get(class_name, range(20, 56))
 
         # Generate separation table
@@ -354,7 +358,7 @@ def main():
             entry_age_range=entry_age_range,
             age_range=age_range,
             yos_range=yos_range,
-            new_year=new_year
+            new_year=new_year,
         )
 
         # Save to CSV

--- a/scripts/build/term_vested_deferred_annuity.py
+++ b/scripts/build/term_vested_deferred_annuity.py
@@ -88,7 +88,7 @@ def deferred_annuity_stream(
     if abs(g - 1.0) < 1e-12:
         factor = payout_years * v ** (deferral_years + 1)
     else:
-        factor = v ** (deferral_years + 1) * (1.0 - g ** payout_years) / (1.0 - g)
+        factor = v ** (deferral_years + 1) * (1.0 - g**payout_years) / (1.0 - g)
 
     c = pvfb_term_current / factor
 

--- a/scripts/build/verify_term_vested_cashflow.py
+++ b/scripts/build/verify_term_vested_cashflow.py
@@ -28,7 +28,6 @@ from pension_model.core.pipeline_current import (
     _recur_grow3,
 )
 
-
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 
 
@@ -42,18 +41,14 @@ def runtime_growing_annuity_stream(
     return _recur_grow3(first, growth, amo_period)
 
 
-def runtime_bell_curve_stream(
-    pvfb: float, rate: float, amo_period: int
-) -> np.ndarray:
+def runtime_bell_curve_stream(pvfb: float, rate: float, amo_period: int) -> np.ndarray:
     """Mirror the runtime bell_curve branch."""
     if pvfb == 0:
         return np.zeros(amo_period)
     mid = amo_period / 2
     spread = amo_period / 5
     seq = np.arange(1, amo_period + 1)
-    weights = (1 / (spread * np.sqrt(2 * np.pi))) * np.exp(
-        -0.5 * ((seq - mid) / spread) ** 2
-    )
+    weights = (1 / (spread * np.sqrt(2 * np.pi))) * np.exp(-0.5 * ((seq - mid) / spread) ** 2)
     ratio = weights / weights[0]
     first = pvfb / _npv(rate, ratio)
     return first * ratio
@@ -83,9 +78,7 @@ def verify_legacy(plan: str, runtime_fn, **kwargs) -> bool:
         pvfb = class_cal["pvfb_term_current"]
         runtime_stream = runtime_fn(pvfb, rate, amo_period=amo_period, **kwargs)
         csv_stream = (
-            df[df["class_name"] == class_name]
-            .sort_values("year_offset")["payment"]
-            .to_numpy()
+            df[df["class_name"] == class_name].sort_values("year_offset")["payment"].to_numpy()
         )
         if not np.array_equal(runtime_stream, csv_stream):
             max_abs = float(np.max(np.abs(runtime_stream - csv_stream)))
@@ -107,11 +100,7 @@ def verify_npv_identity(plan: str) -> bool:
     ok = True
     for class_name, class_cal in calibration["classes"].items():
         pvfb = class_cal["pvfb_term_current"]
-        stream = (
-            df[df["class_name"] == class_name]
-            .sort_values("year_offset")["payment"]
-            .to_numpy()
-        )
+        stream = df[df["class_name"] == class_name].sort_values("year_offset")["payment"].to_numpy()
         npv = _npv(rate, stream)
         if pvfb == 0:
             if npv != 0:

--- a/scripts/diagnostic/compare_cells.py
+++ b/scripts/diagnostic/compare_cells.py
@@ -30,9 +30,7 @@ COMPARE_DIR = PROJECT_ROOT / "output"
 
 def _parse_cell(cell: str) -> tuple[str, str]:
     if "/" not in cell:
-        raise ValueError(
-            f"Cell identifier must be 'plan/scenario'; got {cell!r}"
-        )
+        raise ValueError(f"Cell identifier must be 'plan/scenario'; got {cell!r}")
     plan, scenario = cell.split("/", 1)
     if not plan or not scenario:
         raise ValueError(
@@ -44,7 +42,7 @@ def _parse_cell(cell: str) -> tuple[str, str]:
 def _filter_cell(df: pd.DataFrame, plan: str, scenario: str) -> pd.DataFrame:
     cell = df[(df["plan"] == plan) & (df["scenario"] == scenario)]
     if cell.empty:
-        available = sorted({(p, s) for p, s in zip(df["plan"], df["scenario"])})
+        available = sorted({(p, s) for p, s in zip(df["plan"], df["scenario"], strict=False)})
         raise SystemExit(
             f"No rows for plan={plan} scenario={scenario} in {ALL_RUNS_PATH}. "
             f"Run `make run plan={plan} scenario={scenario}` first.\n"
@@ -82,20 +80,26 @@ def print_summary(comparison: pd.DataFrame, a_label: str, b_label: str) -> None:
         max_pct = grp["pct_diff"].abs().max()
         y0 = grp[grp["year"] == grp["year"].min()].iloc[0] if len(grp) else None
         ylast = grp[grp["year"] == grp["year"].max()].iloc[0] if len(grp) else None
-        summary_rows.append({
-            "metric": metric,
-            "y0_a": float(y0["value_a"]) if y0 is not None else np.nan,
-            "y0_b": float(y0["value_b"]) if y0 is not None else np.nan,
-            "y0_pct": float(y0["pct_diff"]) if y0 is not None else np.nan,
-            "ylast_pct": float(ylast["pct_diff"]) if ylast is not None else np.nan,
-            "max_abs_pct": float(max_pct) if pd.notna(max_pct) else np.nan,
-        })
+        summary_rows.append(
+            {
+                "metric": metric,
+                "y0_a": float(y0["value_a"]) if y0 is not None else np.nan,
+                "y0_b": float(y0["value_b"]) if y0 is not None else np.nan,
+                "y0_pct": float(y0["pct_diff"]) if y0 is not None else np.nan,
+                "ylast_pct": float(ylast["pct_diff"]) if ylast is not None else np.nan,
+                "max_abs_pct": float(max_pct) if pd.notna(max_pct) else np.nan,
+            }
+        )
     summary = pd.DataFrame(summary_rows)
     with pd.option_context(
-        "display.max_rows", None,
-        "display.max_columns", None,
-        "display.width", 140,
-        "display.float_format", lambda v: f"{v:,.4g}" if abs(v) >= 1 else f"{v:.4g}",
+        "display.max_rows",
+        None,
+        "display.max_columns",
+        None,
+        "display.width",
+        140,
+        "display.float_format",
+        lambda v: f"{v:,.4g}" if abs(v) >= 1 else f"{v:.4g}",
     ):
         print(summary.to_string(index=False))
     print()

--- a/scripts/diagnostic/compare_txtrs_av_to_av.py
+++ b/scripts/diagnostic/compare_txtrs_av_to_av.py
@@ -21,27 +21,26 @@ from pathlib import Path
 
 import pandas as pd
 
-
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 LIAB_PATH = PROJECT_ROOT / "output" / "txtrs-av" / "liability_stacked.csv"
 
 # AV Table 2 published values for valuation as of 8/31/2024 (Texas TRS).
 # Source: prep/txtrs-av/sources/Texas TRS Valuation 2024.pdf, printed p. 17.
 AV_TABLE_2_2024 = {
-    "active_members":                 970_872,
-    "average_pay_dollars":             59_210,
-    "active_total_payroll":     57_484_875_501,   # AV Table 15a active member annualized salary
-    "projected_payroll":        61_388_248_000,   # AV Table 2 line 10
-    "pvfs":                    517_122_182_135,   # line 3
-    "pvfb_retired_in_pay":     133_927_805_157,   # line 5a
-    "pvfb_retired_survivors":    2_079_196_524,   # line 5b
-    "pvfb_vested_inactive":      7_509_703_539,   # line 5c
-    "pvfb_active":             187_884_499_767,   # line 5d
-    "pvfb_inactive_nonvested":   1_218_489_735,   # line 5e
-    "pvfb_total":              332_619_694_722,   # line 5f
-    "pvfnc":                    59_524_634_671,   # line 6
-    "aal_total":               273_095_060_051,   # line 7
-    "nc_rate_gross":                    0.1210,   # line 4a
+    "active_members": 970_872,
+    "average_pay_dollars": 59_210,
+    "active_total_payroll": 57_484_875_501,  # AV Table 15a active member annualized salary
+    "projected_payroll": 61_388_248_000,  # AV Table 2 line 10
+    "pvfs": 517_122_182_135,  # line 3
+    "pvfb_retired_in_pay": 133_927_805_157,  # line 5a
+    "pvfb_retired_survivors": 2_079_196_524,  # line 5b
+    "pvfb_vested_inactive": 7_509_703_539,  # line 5c
+    "pvfb_active": 187_884_499_767,  # line 5d
+    "pvfb_inactive_nonvested": 1_218_489_735,  # line 5e
+    "pvfb_total": 332_619_694_722,  # line 5f
+    "pvfnc": 59_524_634_671,  # line 6
+    "aal_total": 273_095_060_051,  # line 7
+    "nc_rate_gross": 0.1210,  # line 4a
 }
 
 
@@ -84,23 +83,38 @@ def _bucket_year_zero(liab_path: Path) -> dict:
 
 def build_comparison(model: dict, av: dict) -> pd.DataFrame:
     rows = [
-        ("Active total payroll (cohort-derived)", model["active_total_payroll"], av["active_total_payroll"]),
-        ("PVFB - active members",                  model["pvfb_active"],          av["pvfb_active"]),
-        ("PVFB - retirees in pay or deferred",     model["pvfb_retire_total"],    av["pvfb_retired_in_pay"]),
-        ("PVFB - retiree future survivor",         0,                              av["pvfb_retired_survivors"]),
-        ("PVFB - vested inactive",                 model["pvfb_term_total"],      av["pvfb_vested_inactive"]),
-        ("PVFB - inactive nonvested",              0,                              av["pvfb_inactive_nonvested"]),
-        ("PVFB - total",                            model["pvfb_total"],           av["pvfb_total"]),
-        ("PVFNC (employee + employer)",            model["pvfnc"],                 av["pvfnc"]),
-        ("AAL - active (PVFB - PVFNC)",            model["aal_active"],            av["pvfb_active"] - av["pvfnc"]),
-        ("AAL - current retirees",                 model["aal_retire_current"],    av["pvfb_retired_in_pay"]),
-        ("AAL - other (term + survivor + nonvested)", model["aal_term_total"],
-                                                   av["pvfb_vested_inactive"] + av["pvfb_retired_survivors"] + av["pvfb_inactive_nonvested"]),
-        ("AAL - total",                             model["aal_total"],            av["aal_total"]),
+        (
+            "Active total payroll (cohort-derived)",
+            model["active_total_payroll"],
+            av["active_total_payroll"],
+        ),
+        ("PVFB - active members", model["pvfb_active"], av["pvfb_active"]),
+        (
+            "PVFB - retirees in pay or deferred",
+            model["pvfb_retire_total"],
+            av["pvfb_retired_in_pay"],
+        ),
+        ("PVFB - retiree future survivor", 0, av["pvfb_retired_survivors"]),
+        ("PVFB - vested inactive", model["pvfb_term_total"], av["pvfb_vested_inactive"]),
+        ("PVFB - inactive nonvested", 0, av["pvfb_inactive_nonvested"]),
+        ("PVFB - total", model["pvfb_total"], av["pvfb_total"]),
+        ("PVFNC (employee + employer)", model["pvfnc"], av["pvfnc"]),
+        ("AAL - active (PVFB - PVFNC)", model["aal_active"], av["pvfb_active"] - av["pvfnc"]),
+        ("AAL - current retirees", model["aal_retire_current"], av["pvfb_retired_in_pay"]),
+        (
+            "AAL - other (term + survivor + nonvested)",
+            model["aal_term_total"],
+            av["pvfb_vested_inactive"]
+            + av["pvfb_retired_survivors"]
+            + av["pvfb_inactive_nonvested"],
+        ),
+        ("AAL - total", model["aal_total"], av["aal_total"]),
     ]
     out = pd.DataFrame(rows, columns=["quantity", "model", "av"])
     out["gap_dollars"] = out["model"] - out["av"]
-    out["gap_pct"] = ((out["model"] - out["av"]) / out["av"]).where(out["av"] != 0, float("nan")) * 100
+    out["gap_pct"] = ((out["model"] - out["av"]) / out["av"]).where(
+        out["av"] != 0, float("nan")
+    ) * 100
     return out
 
 
@@ -111,20 +125,18 @@ def format_table(df: pd.DataFrame) -> str:
     def fmt_pct(x):
         return "      " if pd.isna(x) else f"{x:+6.2f}%"
 
-    lines = ["=" * 90,
-             f"{'Quantity':<44s} {'Model':>14s} {'AV':>14s} {'Gap':>14s}",
-             "=" * 90]
+    lines = ["=" * 90, f"{'Quantity':<44s} {'Model':>14s} {'AV':>14s} {'Gap':>14s}", "=" * 90]
     for _, r in df.iterrows():
-        lines.append(f"{r.quantity:<44s} {fmt_b(r.model):>14s} {fmt_b(r.av):>14s} {fmt_pct(r.gap_pct):>14s}")
+        lines.append(
+            f"{r.quantity:<44s} {fmt_b(r.model):>14s} {fmt_b(r.av):>14s} {fmt_pct(r.gap_pct):>14s}"
+        )
     lines.append("=" * 90)
     return "\n".join(lines)
 
 
 def main() -> None:
     if not LIAB_PATH.exists():
-        raise SystemExit(
-            f"Missing {LIAB_PATH}. Run `pension-model run txtrs-av --no-test` first."
-        )
+        raise SystemExit(f"Missing {LIAB_PATH}. Run `pension-model run txtrs-av --no-test` first.")
     model = _bucket_year_zero(LIAB_PATH)
     print(f"txtrs-av year-{model['year']} liability vs AV Table 2 (2024)")
     print()

--- a/scripts/diagnostic/run_cell.py
+++ b/scripts/diagnostic/run_cell.py
@@ -38,8 +38,7 @@ NON_METRIC_COLS = {"plan", "year"}
 def truth_table_to_long(plan: str, scenario: str, df: pd.DataFrame) -> pd.DataFrame:
     """Reshape a truth-table DataFrame into the canonical long format."""
     metric_cols = [
-        c for c in df.columns
-        if c not in NON_METRIC_COLS and pd.api.types.is_numeric_dtype(df[c])
+        c for c in df.columns if c not in NON_METRIC_COLS and pd.api.types.is_numeric_dtype(df[c])
     ]
     long = df.melt(
         id_vars=["year"],
@@ -59,9 +58,7 @@ def upsert_rows(new_rows: pd.DataFrame, path: Path) -> None:
         existing = pd.read_csv(path)
         plan = new_rows["plan"].iloc[0]
         scenario = new_rows["scenario"].iloc[0]
-        keep = existing[
-            ~((existing["plan"] == plan) & (existing["scenario"] == scenario))
-        ]
+        keep = existing[~((existing["plan"] == plan) & (existing["scenario"] == scenario))]
         combined = pd.concat([keep, new_rows], ignore_index=True)
     else:
         combined = new_rows
@@ -89,8 +86,7 @@ def main() -> None:
     long = truth_table_to_long(args.plan, args.scenario, tt)
     upsert_rows(long, args.output)
     print(
-        f"Wrote {len(long)} rows for plan={args.plan} scenario={args.scenario} "
-        f"to {args.output}"
+        f"Wrote {len(long)} rows for plan={args.plan} scenario={args.scenario} " f"to {args.output}"
     )
 
 

--- a/scripts/extract/extract_decrement_tables.py
+++ b/scripts/extract/extract_decrement_tables.py
@@ -5,10 +5,9 @@ This script parses the raw Excel files from the R model's extracted inputs
 and converts them to standardized CSV files for use in the Python model.
 """
 
-import pandas as pd
-import numpy as np
 from pathlib import Path
-from typing import Dict, List, Tuple, Optional
+
+import pandas as pd
 
 
 def parse_withdrawal_table(filepath: Path) -> pd.DataFrame:
@@ -30,9 +29,9 @@ def parse_withdrawal_table(filepath: Path) -> pd.DataFrame:
     # Find the data rows by looking for the YOS header row
     start_row = None
     for idx, row in df_raw.iterrows():
-        if row[0] == 'Combined Years' or (isinstance(row[0], str) and 'of Service' in str(row[0])):
+        if row[0] == "Combined Years" or (isinstance(row[0], str) and "of Service" in str(row[0])):
             start_row = idx + 1
-            if row[0] == 'Combined Years':
+            if row[0] == "Combined Years":
                 # Header row is next, data starts after
                 start_row = idx + 2
             break
@@ -40,7 +39,7 @@ def parse_withdrawal_table(filepath: Path) -> pd.DataFrame:
     if start_row is None:
         # Try to find by looking for numeric YOS values
         for idx, row in df_raw.iterrows():
-            if row[0] == 0 or row[0] == '0':
+            if row[0] == 0 or row[0] == "0":
                 start_row = idx
                 break
 
@@ -54,7 +53,7 @@ def parse_withdrawal_table(filepath: Path) -> pd.DataFrame:
 
     # If no age bands found, use defaults
     if not age_bands:
-        age_bands = ['Under 25', '25 to 29', '30 to 34', '35 to 44', '45 to 54', '55+']
+        age_bands = ["Under 25", "25 to 29", "30 to 34", "35 to 44", "45 to 54", "55+"]
 
     # Extract data rows
     data_rows = []
@@ -67,7 +66,7 @@ def parse_withdrawal_table(filepath: Path) -> pd.DataFrame:
             continue
 
         # Handle YOS values
-        if yos_raw == '30+':
+        if yos_raw == "30+":
             yos = 30
         elif isinstance(yos_raw, (int, float)):
             try:
@@ -82,16 +81,14 @@ def parse_withdrawal_table(filepath: Path) -> pd.DataFrame:
             if col_idx + 1 < len(row):
                 rate = row[col_idx + 1]
                 if pd.notna(rate):
-                    data_rows.append({
-                        'yos': yos,
-                        'age_band': age_band,
-                        'withdrawal_rate': float(rate)
-                    })
+                    data_rows.append(
+                        {"yos": yos, "age_band": age_band, "withdrawal_rate": float(rate)}
+                    )
 
     return pd.DataFrame(data_rows)
 
 
-def parse_retirement_table(filepath: Path, table_type: str = 'normal') -> pd.DataFrame:
+def parse_retirement_table(filepath: Path, table_type: str = "normal") -> pd.DataFrame:
     """
     Parse a retirement rate table from Excel.
 
@@ -113,7 +110,7 @@ def parse_retirement_table(filepath: Path, table_type: str = 'normal') -> pd.Dat
     # Find the Age header row to determine table structure
     age_header_row = None
     for idx, row in df_raw.iterrows():
-        if row[0] == 'Age':
+        if row[0] == "Age":
             age_header_row = idx
             break
 
@@ -131,28 +128,28 @@ def parse_retirement_table(filepath: Path, table_type: str = 'normal') -> pd.Dat
     if num_cols >= 11:
         # Full structure with K-12 split (11 columns)
         column_mappings = {
-            1: ('regular_k12', 'female'),
-            2: ('regular_k12', 'male'),
-            3: ('regular_non_k12', 'female'),
-            4: ('regular_non_k12', 'male'),
-            5: ('special', 'female'),
-            6: ('special', 'male'),
-            7: ('elected_officers', 'female'),
-            8: ('elected_officers', 'male'),
-            9: ('senior_management', 'female'),
-            10: ('senior_management', 'male'),
+            1: ("regular_k12", "female"),
+            2: ("regular_k12", "male"),
+            3: ("regular_non_k12", "female"),
+            4: ("regular_non_k12", "male"),
+            5: ("special", "female"),
+            6: ("special", "male"),
+            7: ("elected_officers", "female"),
+            8: ("elected_officers", "male"),
+            9: ("senior_management", "female"),
+            10: ("senior_management", "male"),
         }
     else:
         # Reduced structure without K-12 split (9 columns)
         column_mappings = {
-            1: ('regular_non_k12', 'female'),
-            2: ('regular_non_k12', 'male'),
-            3: ('special', 'female'),
-            4: ('special', 'male'),
-            5: ('elected_officers', 'female'),
-            6: ('elected_officers', 'male'),
-            7: ('senior_management', 'female'),
-            8: ('senior_management', 'male'),
+            1: ("regular_non_k12", "female"),
+            2: ("regular_non_k12", "male"),
+            3: ("special", "female"),
+            4: ("special", "male"),
+            5: ("elected_officers", "female"),
+            6: ("elected_officers", "male"),
+            7: ("senior_management", "female"),
+            8: ("senior_management", "male"),
         }
 
     # Extract data rows
@@ -166,7 +163,7 @@ def parse_retirement_table(filepath: Path, table_type: str = 'normal') -> pd.Dat
             continue
 
         # Handle age values
-        if age_raw == '70-79':
+        if age_raw == "70-79":
             age = 70
         elif isinstance(age_raw, (int, float)) and not pd.isna(age_raw):
             try:
@@ -181,15 +178,17 @@ def parse_retirement_table(filepath: Path, table_type: str = 'normal') -> pd.Dat
             if col_idx < len(row):
                 rate = row[col_idx]
                 if pd.notna(rate):
-                    data_rows.append({
-                        'age': age,
-                        'class_name': class_name,
-                        'gender': gender,
-                        'retirement_rate': float(rate)
-                    })
+                    data_rows.append(
+                        {
+                            "age": age,
+                            "class_name": class_name,
+                            "gender": gender,
+                            "retirement_rate": float(rate),
+                        }
+                    )
 
     df = pd.DataFrame(data_rows)
-    df['table_type'] = table_type
+    df["table_type"] = table_type
     return df
 
 
@@ -202,7 +201,7 @@ def parse_drop_entry_table(filepath: Path) -> pd.DataFrame:
 
     Returns a DataFrame in long format.
     """
-    return parse_retirement_table(filepath, table_type='drop_entry')
+    return parse_retirement_table(filepath, table_type="drop_entry")
 
 
 def parse_early_retirement_table(filepath: Path) -> pd.DataFrame:
@@ -211,10 +210,10 @@ def parse_early_retirement_table(filepath: Path) -> pd.DataFrame:
 
     Returns a DataFrame in long format.
     """
-    return parse_retirement_table(filepath, table_type='early')
+    return parse_retirement_table(filepath, table_type="early")
 
 
-def expand_age_band(age_band: str) -> Tuple[int, int]:
+def expand_age_band(age_band: str) -> tuple[int, int]:
     """
     Convert age band string to min/max ages.
 
@@ -224,17 +223,17 @@ def expand_age_band(age_band: str) -> Tuple[int, int]:
     Returns:
         Tuple of (min_age, max_age)
     """
-    if age_band == 'Under 25':
+    if age_band == "Under 25":
         return (18, 24)
-    elif age_band == '25 to 29':
+    elif age_band == "25 to 29":
         return (25, 29)
-    elif age_band == '30 to 34':
+    elif age_band == "30 to 34":
         return (30, 34)
-    elif age_band == '35 to 44':
+    elif age_band == "35 to 44":
         return (35, 44)
-    elif age_band == '45 to 54':
+    elif age_band == "45 to 54":
         return (45, 54)
-    elif age_band == '55+':
+    elif age_band == "55+":
         return (55, 120)
     else:
         return (18, 120)
@@ -252,20 +251,13 @@ def expand_withdrawal_to_single_ages(df: pd.DataFrame) -> pd.DataFrame:
     """
     rows = []
     for _, row in df.iterrows():
-        min_age, max_age = expand_age_band(row['age_band'])
+        min_age, max_age = expand_age_band(row["age_band"])
         for age in range(min_age, max_age + 1):
-            rows.append({
-                'yos': row['yos'],
-                'age': age,
-                'withdrawal_rate': row['withdrawal_rate']
-            })
+            rows.append({"yos": row["yos"], "age": age, "withdrawal_rate": row["withdrawal_rate"]})
     return pd.DataFrame(rows)
 
 
-def parse_withdrawal_from_main_excel(
-    filepath: Path,
-    sheet_name: str
-) -> pd.DataFrame:
+def parse_withdrawal_from_main_excel(filepath: Path, sheet_name: str) -> pd.DataFrame:
     """
     Parse withdrawal table from main Excel file (Florida FRS inputs.xlsx).
 
@@ -284,11 +276,11 @@ def parse_withdrawal_from_main_excel(
     start_row = None
     for idx, row in df_raw.iterrows():
         first_val = str(row[0]).strip() if pd.notna(row[0]) else ""
-        if 'Years of Service' in first_val or 'years of service' in first_val.lower():
+        if "Years of Service" in first_val or "years of service" in first_val.lower():
             start_row = idx + 1
             break
         # Also check for numeric YOS values starting at 0
-        if row[0] == 0 or row[0] == '0':
+        if row[0] == 0 or row[0] == "0":
             start_row = idx
             break
 
@@ -304,8 +296,19 @@ def parse_withdrawal_from_main_excel(
             age_bands.append(str(val).strip())
 
     # If no age bands found, use defaults
-    if not age_bands or all(ab == '' for ab in age_bands):
-        age_bands = ['Under 25', '25 to 29', '30 to 34', '35 to 39', '40 to 44', '45 to 49', '50 to 54', '55 to 59', '60 to 64', '65+']
+    if not age_bands or all(ab == "" for ab in age_bands):
+        age_bands = [
+            "Under 25",
+            "25 to 29",
+            "30 to 34",
+            "35 to 39",
+            "40 to 44",
+            "45 to 49",
+            "50 to 54",
+            "55 to 59",
+            "60 to 64",
+            "65+",
+        ]
 
     # Extract data rows
     data_rows = []
@@ -318,8 +321,8 @@ def parse_withdrawal_from_main_excel(
             continue
 
         # Handle YOS values
-        if isinstance(yos_raw, str) and '+' in yos_raw:
-            yos = int(yos_raw.replace('+', ''))
+        if isinstance(yos_raw, str) and "+" in yos_raw:
+            yos = int(yos_raw.replace("+", ""))
         elif isinstance(yos_raw, (int, float)):
             try:
                 yos = int(yos_raw)
@@ -337,11 +340,9 @@ def parse_withdrawal_from_main_excel(
             if col_idx + 1 < len(row):
                 rate = row[col_idx + 1]
                 if pd.notna(rate):
-                    data_rows.append({
-                        'yos': yos,
-                        'age_band': age_band,
-                        'withdrawal_rate': float(rate)
-                    })
+                    data_rows.append(
+                        {"yos": yos, "age_band": age_band, "withdrawal_rate": float(rate)}
+                    )
 
     return pd.DataFrame(data_rows)
 
@@ -364,13 +365,13 @@ def main():
     print("\n1. Extracting Withdrawal Tables from extracted inputs...")
 
     withdrawal_files = {
-        'special_male': 'withdrawal rate spec risk male.xlsx',
-        'special_female': 'withdrawal rate spec risk female.xlsx',
-        'senior_management_male': 'withdrawal rate sen man male.xlsx',
-        'senior_management_female': 'withdrawal rate sen man female.xlsx',
-        'eco': 'withdrawal rate eco.xlsx',
-        'eso': 'withdrawal rate eso.xlsx',
-        'judges': 'withdrawal rate judges.xlsx',
+        "special_male": "withdrawal rate spec risk male.xlsx",
+        "special_female": "withdrawal rate spec risk female.xlsx",
+        "senior_management_male": "withdrawal rate sen man male.xlsx",
+        "senior_management_female": "withdrawal rate sen man female.xlsx",
+        "eco": "withdrawal rate eco.xlsx",
+        "eso": "withdrawal rate eso.xlsx",
+        "judges": "withdrawal rate judges.xlsx",
     }
 
     for name, filename in withdrawal_files.items():
@@ -396,10 +397,10 @@ def main():
     print("\n1b. Extracting Withdrawal Tables from main Excel file...")
 
     main_excel_withdrawal = {
-        'regular_male': 'Withdrawal Rate Regular Male',
-        'regular_female': 'Withdrawal Rate Regular Female',
-        'admin_male': 'Withdrawal Rate Admin Male',
-        'admin_female': 'Withdrawal Rate Admin Female',
+        "regular_male": "Withdrawal Rate Regular Male",
+        "regular_female": "Withdrawal Rate Regular Female",
+        "admin_male": "Withdrawal Rate Admin Male",
+        "admin_female": "Withdrawal Rate Admin Female",
     }
 
     if main_excel_file.exists():
@@ -415,7 +416,7 @@ def main():
                     df_expanded.to_csv(output_dir / f"withdrawal_{name}.csv", index=False)
                     print(f"      Saved {len(df_expanded)} records")
                 else:
-                    print(f"      WARNING: No data extracted")
+                    print("      WARNING: No data extracted")
             except Exception as e:
                 print(f"      ERROR: {e}")
     else:
@@ -428,8 +429,8 @@ def main():
 
     # Normal retirement
     retirement_files = {
-        'tier1': 'normal retirement tier 1.xlsx',
-        'tier2': 'normal retirement tier 2.xlsx',
+        "tier1": "normal retirement tier 1.xlsx",
+        "tier2": "normal retirement tier 2.xlsx",
     }
 
     for tier, filename in retirement_files.items():
@@ -437,7 +438,7 @@ def main():
         if filepath.exists():
             print(f"   Processing {filename}...")
             try:
-                df = parse_retirement_table(filepath, table_type='normal')
+                df = parse_retirement_table(filepath, table_type="normal")
                 df.to_csv(output_dir / f"normal_retirement_{tier}.csv", index=False)
                 print(f"      Saved {len(df)} records")
             except Exception as e:
@@ -447,8 +448,8 @@ def main():
 
     # Early retirement
     early_files = {
-        'tier1': 'early retirement tier 1.xlsx',
-        'tier2': 'early retirement tier 2.xlsx',
+        "tier1": "early retirement tier 1.xlsx",
+        "tier2": "early retirement tier 2.xlsx",
     }
 
     for tier, filename in early_files.items():
@@ -456,7 +457,7 @@ def main():
         if filepath.exists():
             print(f"   Processing {filename}...")
             try:
-                df = parse_retirement_table(filepath, table_type='early')
+                df = parse_retirement_table(filepath, table_type="early")
                 df.to_csv(output_dir / f"early_retirement_{tier}.csv", index=False)
                 print(f"      Saved {len(df)} records")
             except Exception as e:
@@ -466,8 +467,8 @@ def main():
 
     # DROP entry
     drop_files = {
-        'tier1': 'drop entry tier 1.xlsx',
-        'tier2': 'drop entry tier 2.xlsx',
+        "tier1": "drop entry tier 1.xlsx",
+        "tier2": "drop entry tier 2.xlsx",
     }
 
     for tier, filename in drop_files.items():

--- a/src/pension_model/cli.py
+++ b/src/pension_model/cli.py
@@ -13,15 +13,14 @@ Usage:
 Plans are auto-discovered from ``plans/<plan>/config/plan_config.json``.
 """
 
+import argparse
 import sys
 import time
-import argparse
 import warnings
 from pathlib import Path
 
 import numpy as np
 import pandas as pd
-
 
 OUTPUT_BASE = Path("output")
 
@@ -29,6 +28,7 @@ OUTPUT_BASE = Path("output")
 # ---------------------------------------------------------------------------
 # Formatting helpers
 # ---------------------------------------------------------------------------
+
 
 def _fmt_dollars(val):
     """Format a dollar value in billions."""
@@ -59,12 +59,21 @@ def _fmt_smoothing(cfg):
 
 # Columns in summary.csv (plan-wide, by year).
 SUMMARY_COLUMNS = [
-    "plan", "year",
-    "n_active", "payroll", "benefits",
-    "aal", "ual_ava", "ual_mva",
-    "er_cont", "ee_cont",
-    "mva", "ava", "invest_income",
-    "fr_mva", "fr_ava",
+    "plan",
+    "year",
+    "n_active",
+    "payroll",
+    "benefits",
+    "aal",
+    "ual_ava",
+    "ual_mva",
+    "er_cont",
+    "ee_cont",
+    "mva",
+    "ava",
+    "invest_income",
+    "fr_mva",
+    "fr_ava",
 ]
 
 
@@ -134,28 +143,31 @@ def build_plan_summary(plan_name, liability, funding, constants):
     def _safe(arr):
         return arr if arr is not None else np.full(n_rows, np.nan)
 
-    return pd.DataFrame({
-        "plan": plan_name,
-        "year": pd.array(year, dtype="Int64") if year is not None else range(n_rows),
-        "n_active": _safe(n_active),
-        "payroll": _safe(payroll),
-        "benefits": _safe(benefits),
-        "aal": _safe(aal),
-        "ual_ava": _safe(ual_ava),
-        "ual_mva": _safe(ual_mva),
-        "er_cont": _safe(er_cont),
-        "ee_cont": _safe(ee_cont),
-        "mva": _safe(mva),
-        "ava": _safe(ava),
-        "invest_income": _safe(invest_income),
-        "fr_mva": _safe(fr_mva),
-        "fr_ava": _safe(fr_ava),
-    })[SUMMARY_COLUMNS]
+    return pd.DataFrame(
+        {
+            "plan": plan_name,
+            "year": pd.array(year, dtype="Int64") if year is not None else range(n_rows),
+            "n_active": _safe(n_active),
+            "payroll": _safe(payroll),
+            "benefits": _safe(benefits),
+            "aal": _safe(aal),
+            "ual_ava": _safe(ual_ava),
+            "ual_mva": _safe(ual_mva),
+            "er_cont": _safe(er_cont),
+            "ee_cont": _safe(ee_cont),
+            "mva": _safe(mva),
+            "ava": _safe(ava),
+            "invest_income": _safe(invest_income),
+            "fr_mva": _safe(fr_mva),
+            "fr_ava": _safe(fr_ava),
+        }
+    )[SUMMARY_COLUMNS]
 
 
 # ---------------------------------------------------------------------------
 # Console output
 # ---------------------------------------------------------------------------
+
 
 def print_parameters(constants):
     """Print key model parameters."""
@@ -164,7 +176,7 @@ def print_parameters(constants):
     fn = constants.funding
     rn = constants.ranges
 
-    print(f"\n  Parameters (baseline defaults):")
+    print("\n  Parameters (baseline defaults):")
     print(f"    Discount rate:          {ec.dr_current:.1%}")
     print(f"    Investment return:      {ec.model_return:.1%}")
     print(f"    Payroll growth:         {ec.payroll_growth:.2%}")
@@ -172,7 +184,10 @@ def print_parameters(constants):
     print(f"    Funding policy:         {fn.policy}")
     print(f"    Amortization:           {fn.amo_method}, {fn.amo_period_new}-year period")
     print(f"    Asset smoothing:        {_fmt_smoothing(fn)}")
-    print(f"    Projection horizon:     {rn.model_period} years from {rn.start_year} valuation (through {rn.start_year + rn.model_period})")
+    print(
+        f"    Projection horizon:     {rn.model_period} years from {rn.start_year} valuation"
+        f" (through {rn.start_year + rn.model_period})"
+    )
     print(f"    Plan config:            {constants.plan_name}")
 
 
@@ -181,21 +196,49 @@ def print_summary_table(summary):
     y1 = summary.iloc[0]
     y_last = summary.iloc[-1]
 
-    print(f"\n  Summary (all groups combined):")
+    print("\n  Summary (all groups combined):")
     col1 = f"Valuation ({int(y1['year'])})"
     col2 = f"Final ({int(y_last['year'])})"
     print(f"  {'':30s} {col1:>16s}  {col2:>16s}")
-    print(f"  {'Assets (AVA)':30s} {_fmt_dollars(y1['ava']):>16s}  {_fmt_dollars(y_last['ava']):>16s}")
-    print(f"  {'Assets (MVA)':30s} {_fmt_dollars(y1['mva']):>16s}  {_fmt_dollars(y_last['mva']):>16s}")
-    print(f"  {'Liabilities (AAL)':30s} {_fmt_dollars(y1['aal']):>16s}  {_fmt_dollars(y_last['aal']):>16s}")
-    print(f"  {'Unfunded liability (UAL)':30s} {_fmt_dollars(y1['ual_ava']):>16s}  {_fmt_dollars(y_last['ual_ava']):>16s}")
-    print(f"  {'Funded ratio (AVA)':30s} {_fmt_pct(y1['fr_ava']):>16s}  {_fmt_pct(y_last['fr_ava']):>16s}")
-    print(f"  {'Funded ratio (MVA)':30s} {_fmt_pct(y1['fr_mva']):>16s}  {_fmt_pct(y_last['fr_mva']):>16s}")
+    print(
+        f"  {'Assets (AVA)':30s} {_fmt_dollars(y1['ava']):>16s}  {_fmt_dollars(y_last['ava']):>16s}"
+    )
+    print(
+        f"  {'Assets (MVA)':30s} {_fmt_dollars(y1['mva']):>16s}  {_fmt_dollars(y_last['mva']):>16s}"
+    )
+    print(
+        f"  {'Liabilities (AAL)':30s} "
+        f"{_fmt_dollars(y1['aal']):>16s}  {_fmt_dollars(y_last['aal']):>16s}"
+    )
+    print(
+        f"  {'Unfunded liability (UAL)':30s} "
+        f"{_fmt_dollars(y1['ual_ava']):>16s}  {_fmt_dollars(y_last['ual_ava']):>16s}"
+    )
+    print(
+        f"  {'Funded ratio (AVA)':30s} "
+        f"{_fmt_pct(y1['fr_ava']):>16s}  {_fmt_pct(y_last['fr_ava']):>16s}"
+    )
+    print(
+        f"  {'Funded ratio (MVA)':30s} "
+        f"{_fmt_pct(y1['fr_mva']):>16s}  {_fmt_pct(y_last['fr_mva']):>16s}"
+    )
     print(f"  {'Active members':30s} {y1['n_active']:>16,.0f}  {y_last['n_active']:>16,.0f}")
-    print(f"  {'Payroll':30s} {_fmt_dollars(y1['payroll']):>16s}  {_fmt_dollars(y_last['payroll']):>16s}")
-    print(f"  {'Benefit payments':30s} {_fmt_dollars(y1['benefits']):>16s}  {_fmt_dollars(y_last['benefits']):>16s}")
-    print(f"  {'Employer contributions':30s} {_fmt_dollars(y1['er_cont']):>16s}  {_fmt_dollars(y_last['er_cont']):>16s}")
-    print(f"  {'Employee contributions':30s} {_fmt_dollars(y1['ee_cont']):>16s}  {_fmt_dollars(y_last['ee_cont']):>16s}")
+    print(
+        f"  {'Payroll':30s} "
+        f"{_fmt_dollars(y1['payroll']):>16s}  {_fmt_dollars(y_last['payroll']):>16s}"
+    )
+    print(
+        f"  {'Benefit payments':30s} "
+        f"{_fmt_dollars(y1['benefits']):>16s}  {_fmt_dollars(y_last['benefits']):>16s}"
+    )
+    print(
+        f"  {'Employer contributions':30s} "
+        f"{_fmt_dollars(y1['er_cont']):>16s}  {_fmt_dollars(y_last['er_cont']):>16s}"
+    )
+    print(
+        f"  {'Employee contributions':30s} "
+        f"{_fmt_dollars(y1['ee_cont']):>16s}  {_fmt_dollars(y_last['ee_cont']):>16s}"
+    )
 
 
 def _write_outputs(summary, liability_stacked, output_dir):
@@ -204,8 +247,10 @@ def _write_outputs(summary, liability_stacked, output_dir):
     summary.to_csv(output_dir / "summary.csv", index=False)
     liability_stacked.to_csv(output_dir / "liability_stacked.csv", index=False)
 
-    rel = output_dir.relative_to(Path.cwd()) if output_dir.is_relative_to(Path.cwd()) else output_dir
-    print(f"\n  Files:")
+    rel = (
+        output_dir.relative_to(Path.cwd()) if output_dir.is_relative_to(Path.cwd()) else output_dir
+    )
+    print("\n  Files:")
     print(f"    {rel}/summary.csv            - plan-wide summary by year")
     print(f"    {rel}/liability_stacked.csv  - liability detail by class and year")
 
@@ -213,6 +258,7 @@ def _write_outputs(summary, liability_stacked, output_dir):
 # ---------------------------------------------------------------------------
 # Truth table (optional, for R-vs-Python comparison)
 # ---------------------------------------------------------------------------
+
 
 def _emit_truth_table(plan_name, liability, funding, constants, output_dir):
     """Build the Python truth table, write CSV + Excel sheet.
@@ -230,6 +276,7 @@ def _emit_truth_table(plan_name, liability, funding, constants, output_dir):
 
         from pension_model.output_uniformity import assert_output_uniformity
         from pension_model.truth_table import TRUTH_TABLE_COLUMNS
+
         assert_output_uniformity(
             df,
             canonical_columns=TRUTH_TABLE_COLUMNS,
@@ -259,10 +306,7 @@ def _emit_truth_table(plan_name, liability, funding, constants, output_dir):
         r_csv = Path("plans") / plan_name / "baselines" / "r_truth_table.csv"
         if scenario:
             scenario_r_csv = (
-                Path("plans")
-                / plan_name
-                / "baselines"
-                / f"r_truth_table_{scenario}.csv"
+                Path("plans") / plan_name / "baselines" / f"r_truth_table_{scenario}.csv"
             )
             if scenario_r_csv.exists():
                 r_csv = scenario_r_csv
@@ -275,13 +319,15 @@ def _emit_truth_table(plan_name, liability, funding, constants, output_dir):
             for col in numeric_cols:
                 side_by_side[f"{col}_R"] = r_df[col]
                 side_by_side[f"{col}_Py"] = df[col] if col in df.columns else pd.NA
-                side_by_side[f"{col}_diff"] = (
-                    df[col] - r_df[col] if col in df.columns else pd.NA)
-            upsert_sheet_to_excel(
-                pd.DataFrame(side_by_side), xlsx_path, f"{sheet_token}_diff")
+                side_by_side[f"{col}_diff"] = df[col] - r_df[col] if col in df.columns else pd.NA
+            upsert_sheet_to_excel(pd.DataFrame(side_by_side), xlsx_path, f"{sheet_token}_diff")
 
-        rel_csv = csv_path.relative_to(Path.cwd()) if csv_path.is_relative_to(Path.cwd()) else csv_path
-        rel_xlsx = xlsx_path.relative_to(Path.cwd()) if xlsx_path.is_relative_to(Path.cwd()) else xlsx_path
+        rel_csv = (
+            csv_path.relative_to(Path.cwd()) if csv_path.is_relative_to(Path.cwd()) else csv_path
+        )
+        rel_xlsx = (
+            xlsx_path.relative_to(Path.cwd()) if xlsx_path.is_relative_to(Path.cwd()) else xlsx_path
+        )
         print(f"    {rel_csv}")
         print(f"    {rel_xlsx} (sheet '{sheet_token}_Py')")
     except Exception as e:  # noqa: BLE001 — diagnostic aid must not crash the run
@@ -292,16 +338,18 @@ def _emit_truth_table(plan_name, liability, funding, constants, output_dir):
 # Pipeline executor
 # ---------------------------------------------------------------------------
 
+
 def _execute_pipeline(constants, *, check_identities: bool = False):
     """Run liability + funding pipeline for any plan.
 
     Returns (liability_dict, funding_dict, liability_stacked).
     Funding is always a dict (from run_funding_model).
     """
-    from pension_model.core.pipeline import run_plan_pipeline
     from pension_model.core.funding_model import (
-        load_funding_inputs, run_funding_model,
+        load_funding_inputs,
+        run_funding_model,
     )
+    from pension_model.core.pipeline import run_plan_pipeline
 
     # Fail fast if required data files are missing
     missing = constants.validate_data_files()
@@ -315,12 +363,12 @@ def _execute_pipeline(constants, *, check_identities: bool = False):
     # manifest is the per-plan source of truth, and may declare files
     # the hardcoded validator above doesn't know about).
     from pension_model.config_validation import validate_data_manifest
+
     manifest_missing = validate_data_manifest(constants)
     if manifest_missing:
         raise FileNotFoundError(
             f"Missing files declared in data_manifest.json for plan "
-            f"'{constants.plan_name}':\n"
-            + "\n".join(f"  - {p}" for p in manifest_missing)
+            f"'{constants.plan_name}':\n" + "\n".join(f"  - {p}" for p in manifest_missing)
         )
 
     seen_stages = set()
@@ -353,7 +401,9 @@ def _execute_pipeline(constants, *, check_identities: bool = False):
     funding_inputs = load_funding_inputs(funding_dir)
 
     funding = run_funding_model(
-        liability, funding_inputs, constants,
+        liability,
+        funding_inputs,
+        constants,
         check_identities=check_identities,
     )
 
@@ -363,6 +413,7 @@ def _execute_pipeline(constants, *, check_identities: bool = False):
 # ---------------------------------------------------------------------------
 # Unified plan runner
 # ---------------------------------------------------------------------------
+
 
 def _run_plan(constants, args):
     """Run any plan's pipeline and emit standardized output."""
@@ -393,6 +444,7 @@ def _run_plan(constants, args):
     summary = build_plan_summary(plan_name, liability, funding, constants)
 
     from pension_model.output_uniformity import assert_output_uniformity
+
     assert_output_uniformity(
         summary,
         canonical_columns=SUMMARY_COLUMNS,
@@ -413,14 +465,18 @@ def _run_plan(constants, args):
 # Calibration
 # ---------------------------------------------------------------------------
 
+
 def cmd_calibrate(args):
     """Run calibration: compute nc_cal and pvfb_term_current from AV targets."""
-    from pension_model.core.pipeline import run_plan_pipeline
     from pension_model.config_loading import discover_plans, load_plan_config
     from pension_model.core.calibration import (
-        build_targets_from_config, run_calibration, format_diagnostics,
-        format_comparison, write_calibration_json,
+        build_targets_from_config,
+        format_comparison,
+        format_diagnostics,
+        run_calibration,
+        write_calibration_json,
     )
+    from pension_model.core.pipeline import run_plan_pipeline
 
     plan_name = args.plan_name
 
@@ -451,7 +507,7 @@ def cmd_calibrate(args):
     targets = build_targets_from_config(constants)
     if not targets:
         print(f"  No calibration targets found in valuation_inputs for {plan_name!r}.")
-        print(f"  Each class needs val_norm_cost and val_aal in valuation_inputs.")
+        print("  Each class needs val_norm_cost and val_aal in valuation_inputs.")
         sys.exit(1)
 
     # Run pipeline with neutral calibration
@@ -497,6 +553,7 @@ def _load_plan_test_manifest(plan_name: str) -> list[str]:
     will run only ``DEFAULT_CORE_TEST_FILES`` for that plan.
     """
     import json
+
     from pension_model.config_loading import discover_plans
 
     plans = discover_plans()
@@ -542,6 +599,7 @@ def run_tests(plan_name: str | None = None) -> bool:
     to run every test in the suite.
     """
     import subprocess
+
     targets = _get_test_targets(plan_name)
     _print_test_banner(plan_name, targets)
     # When stdout is piped, the prints above can stay buffered until
@@ -556,6 +614,7 @@ def run_tests(plan_name: str | None = None) -> bool:
 # ---------------------------------------------------------------------------
 # Commands
 # ---------------------------------------------------------------------------
+
 
 def cmd_run(args):
     """Dispatch `pension-model run <plan>` to the unified runner."""
@@ -635,9 +694,7 @@ def cmd_validate_scenarios(args):
         sys.exit(2)
 
     plan_filter = {args.plan} if getattr(args, "plan", None) else set(plans)
-    scenario_filter = (
-        {args.scenario} if getattr(args, "scenario", None) else set(scenarios)
-    )
+    scenario_filter = {args.scenario} if getattr(args, "scenario", None) else set(scenarios)
 
     pairs: list[tuple[str, str]] = [
         (p, s)
@@ -774,16 +831,18 @@ def cmd_benchmark(args):
 
             timing_parts = [
                 "build_plan_benefit_tables="
-                + _format_delta(plan_comparison["stage_timings"]["build_plan_benefit_tables"], suffix="s"),
-                "liability="
-                + _format_delta(plan_comparison["liability_timing"], suffix="s"),
+                + _format_delta(
+                    plan_comparison["stage_timings"]["build_plan_benefit_tables"], suffix="s"
+                ),
+                "liability=" + _format_delta(plan_comparison["liability_timing"], suffix="s"),
                 "prepare_peak="
-                + _format_delta(plan_comparison["prepare_peak_bytes"], scale=1024 * 1024, suffix="MiB"),
+                + _format_delta(
+                    plan_comparison["prepare_peak_bytes"], scale=1024 * 1024, suffix="MiB"
+                ),
             ]
             if plan_comparison["funding_timing"]["current"] is not None:
                 timing_parts.append(
-                    "funding="
-                    + _format_delta(plan_comparison["funding_timing"], suffix="s")
+                    "funding=" + _format_delta(plan_comparison["funding_timing"], suffix="s")
                 )
             print(f"  {plan_name}: " + ", ".join(timing_parts))
 
@@ -792,58 +851,95 @@ def main():
     warnings.filterwarnings("ignore")
 
     from pension_model.config_loading import discover_plans
+
     discovered = sorted(discover_plans().keys())
 
     parser = argparse.ArgumentParser(prog="pension-model", description="Pension model CLI")
     subparsers = parser.add_subparsers(dest="command", help="Command to run")
 
     run_p = subparsers.add_parser("run", help="Run a plan's liability + funding pipeline")
-    run_p.add_argument("plan", choices=discovered or None,
-                       help=f"Plan to run. Discovered: {', '.join(discovered) or '(none)'}")
+    run_p.add_argument(
+        "plan",
+        choices=discovered or None,
+        help=f"Plan to run. Discovered: {', '.join(discovered) or '(none)'}",
+    )
     run_p.add_argument("--no-test", action="store_true", help="Skip tests after the run")
     run_p.add_argument("--test-only", action="store_true", help="Run tests only, skip the model")
-    run_p.add_argument("--truth-table", action="store_true",
-                       help="Write R-vs-Python truth table to CSV and Excel")
-    run_p.add_argument("--scenario", type=str, default=None,
-                       help="Path to scenario JSON file (overrides baseline assumptions)")
-    run_p.add_argument("--check-identities", action="store_true",
-                       help="Verify MVA, AAL, and NC-dollar identities on funding output")
-    run_p.add_argument("--full-suite", action="store_true",
-                       help="Run the full pytest suite after the model run "
-                            "(default: plan-scoped tests only)")
+    run_p.add_argument(
+        "--truth-table", action="store_true", help="Write R-vs-Python truth table to CSV and Excel"
+    )
+    run_p.add_argument(
+        "--scenario",
+        type=str,
+        default=None,
+        help="Path to scenario JSON file (overrides baseline assumptions)",
+    )
+    run_p.add_argument(
+        "--check-identities",
+        action="store_true",
+        help="Verify MVA, AAL, and NC-dollar identities on funding output",
+    )
+    run_p.add_argument(
+        "--full-suite",
+        action="store_true",
+        help="Run the full pytest suite after the model run " "(default: plan-scoped tests only)",
+    )
 
     cal = subparsers.add_parser("calibrate", help="Compute calibration factors")
-    cal.add_argument("plan_name", choices=discovered or None,
-                     help=f"Plan to calibrate. Discovered: {', '.join(discovered) or '(none)'}")
+    cal.add_argument(
+        "plan_name",
+        choices=discovered or None,
+        help=f"Plan to calibrate. Discovered: {', '.join(discovered) or '(none)'}",
+    )
     cal.add_argument("--write", action="store_true", help="Write calibration to JSON")
     cal.add_argument("--output", type=str, default=None, help="Output path for calibration JSON")
 
     subparsers.add_parser("list", help="List discovered plans")
 
     bench = subparsers.add_parser("benchmark", help="Profile runtime stages for one or more plans")
-    bench.add_argument("plan", nargs="?", choices=discovered or None,
-                       help=f"Plan to benchmark. Omit to benchmark all discovered plans.")
-    bench.add_argument("--repeats", type=int, default=2,
-                       help="Number of benchmark runs per plan (default: 2)")
-    bench.add_argument("--include-funding", action="store_true",
-                       help="Also profile the funding stage")
-    bench.add_argument("--research-mode", action="store_true",
-                       help="Retain full stacked plan tables for debug and research inspection")
-    bench.add_argument("--baseline-out", type=str, default=None,
-                       help="Write a JSON runtime baseline summarizing the benchmark runs")
-    bench.add_argument("--compare-baseline", type=str, default=None,
-                       help="Compare the current benchmark summary against a saved baseline JSON")
+    bench.add_argument(
+        "plan",
+        nargs="?",
+        choices=discovered or None,
+        help="Plan to benchmark. Omit to benchmark all discovered plans.",
+    )
+    bench.add_argument(
+        "--repeats", type=int, default=2, help="Number of benchmark runs per plan (default: 2)"
+    )
+    bench.add_argument(
+        "--include-funding", action="store_true", help="Also profile the funding stage"
+    )
+    bench.add_argument(
+        "--research-mode",
+        action="store_true",
+        help="Retain full stacked plan tables for debug and research inspection",
+    )
+    bench.add_argument(
+        "--baseline-out",
+        type=str,
+        default=None,
+        help="Write a JSON runtime baseline summarizing the benchmark runs",
+    )
+    bench.add_argument(
+        "--compare-baseline",
+        type=str,
+        default=None,
+        help="Compare the current benchmark summary against a saved baseline JSON",
+    )
 
     val_scen = subparsers.add_parser(
         "validate-scenarios",
         help="Load every (plan, scenario) pair and report failures up front",
     )
     val_scen.add_argument(
-        "--plan", choices=discovered or None, default=None,
+        "--plan",
+        choices=discovered or None,
+        default=None,
         help="Restrict to one plan",
     )
     val_scen.add_argument(
-        "--scenario", default=None,
+        "--scenario",
+        default=None,
         help="Restrict to one scenario name (the JSON stem)",
     )
 

--- a/src/pension_model/config_helpers.py
+++ b/src/pension_model/config_helpers.py
@@ -1,11 +1,9 @@
 """Config-derived helper functions used outside the main loader/schema module."""
 
-from typing import Tuple
-
 from pension_model.config_schema import PlanConfig
 
 
-def get_plan_design_ratios(config: PlanConfig, class_name: str) -> Tuple[float, float, float]:
+def get_plan_design_ratios(config: PlanConfig, class_name: str) -> tuple[float, float, float]:
     """Return ``(before, after, new)`` DB plan-design ratios."""
     group = config.class_group(class_name)
     ratios = config.plan_design_defs.get(group, config.plan_design_defs.get("default", {}))

--- a/src/pension_model/config_loading.py
+++ b/src/pension_model/config_loading.py
@@ -7,7 +7,6 @@ core ``PlanConfig`` schema and rule-resolution logic in ``plan_config.py``.
 import json
 import logging
 from pathlib import Path
-from typing import Dict, Optional
 
 from pension_model.config_schema import PlanConfig
 from pension_model.schemas import (
@@ -26,24 +25,25 @@ from pension_model.schemas import (
     validate_tier_cross_references,
 )
 
-
 log = logging.getLogger(__name__)
 
 
 # Post-load fields populated by the loader, not present in
 # plan_config.json source. Excluded from the unknown-key check.
-_LOADER_POPULATED_FIELDS = frozenset({
-    "calibration",
-    "reduce_tables",
-    "class_to_group",
-    "tier_name_to_id",
-    "tier_id_to_name",
-    "tier_id_to_cola_key",
-    "tier_id_to_fas_years",
-    "tier_id_to_dr_key",
-    "tier_id_to_retire_rate_set",
-    "scenario_name",
-})
+_LOADER_POPULATED_FIELDS = frozenset(
+    {
+        "calibration",
+        "reduce_tables",
+        "class_to_group",
+        "tier_name_to_id",
+        "tier_id_to_name",
+        "tier_id_to_cola_key",
+        "tier_id_to_fas_years",
+        "tier_id_to_dr_key",
+        "tier_id_to_retire_rate_set",
+        "scenario_name",
+    }
+)
 
 
 def _expected_top_level_keys() -> set[str]:
@@ -92,9 +92,9 @@ def _deep_merge(base: dict, overrides: dict) -> dict:
     return result
 
 
-def _build_class_to_group(raw: dict) -> Dict[str, str]:
+def _build_class_to_group(raw: dict) -> dict[str, str]:
     """Build class-to-group lookup from ``class_groups`` config."""
-    class_to_group: Dict[str, str] = {}
+    class_to_group: dict[str, str] = {}
     for group_name, members in raw.get("class_groups", {}).items():
         for class_name in members:
             class_to_group[class_name] = group_name
@@ -102,10 +102,10 @@ def _build_class_to_group(raw: dict) -> Dict[str, str]:
 
 
 def _load_calibration_data(
-    calibration_path: Optional[Path],
+    calibration_path: Path | None,
     *,
     skip_class_calibration: bool,
-) -> tuple[Dict[str, ClassCalibration], Optional[float]]:
+) -> tuple[dict[str, ClassCalibration], float | None]:
     """Load calibration payload from JSON when available.
 
     Returns:
@@ -165,11 +165,13 @@ def _build_economic_model(
     they're snapshots from before any scenario merge, computed by the
     loader and supplied alongside.
     """
-    return Economic.model_validate({
-        **eco_raw,
-        "baseline_dr_current": baseline_dr_current,
-        "baseline_model_return": baseline_model_return,
-    })
+    return Economic.model_validate(
+        {
+            **eco_raw,
+            "baseline_dr_current": baseline_dr_current,
+            "baseline_model_return": baseline_model_return,
+        }
+    )
 
 
 def _build_funding_model(fun_raw: dict, eco_raw: dict) -> Funding:
@@ -206,8 +208,8 @@ def _build_decrements_model(raw: dict, *, plan_name: str) -> Decrements:
 
 def load_plan_config(
     config_path: Path,
-    calibration_path: Optional[Path] = None,
-    scenario_path: Optional[Path] = None,
+    calibration_path: Path | None = None,
+    scenario_path: Path | None = None,
     skip_class_calibration: bool = False,
 ) -> PlanConfig:
     """Load a PlanConfig from a JSON file."""
@@ -217,9 +219,7 @@ def load_plan_config(
     check_unknown_top_level_keys(raw)
 
     baseline_dr_current = raw["economic"]["dr_current"]
-    baseline_model_return = raw["economic"].get(
-        "model_return", baseline_dr_current
-    )
+    baseline_model_return = raw["economic"].get("model_return", baseline_dr_current)
 
     scenario_name = None
     scenario_requires: list[str] = []
@@ -278,12 +278,9 @@ def load_plan_config(
     benefit_model = Benefit.model_validate(ben)
     plan_design_model = PlanDesign.model_validate(raw.get("plan_design", {}))
     valuation_models = {
-        cn: ValuationInputs.model_validate(v)
-        for cn, v in raw.get("valuation_inputs", {}).items()
+        cn: ValuationInputs.model_validate(v) for cn, v in raw.get("valuation_inputs", {}).items()
     }
-    benefit_mult_model = BenefitMultipliers.model_validate(
-        raw.get("benefit_multipliers", {})
-    )
+    benefit_mult_model = BenefitMultipliers.model_validate(raw.get("benefit_multipliers", {}))
 
     from pension_model.schemas import DataSpec, MortalitySpec, TermVested
 
@@ -291,9 +288,7 @@ def load_plan_config(
         raw.get("data", {"data_dir": f"plans/{raw['plan_name']}/data"})
     )
     mortality_model = (
-        MortalitySpec.model_validate(raw["mortality"])
-        if raw.get("mortality") is not None
-        else None
+        MortalitySpec.model_validate(raw["mortality"]) if raw.get("mortality") is not None else None
     )
     term_vested_model = (
         TermVested.model_validate(raw["term_vested"])
@@ -323,12 +318,8 @@ def load_plan_config(
         salary_growth_col_map=raw.get("salary_growth_col_map", {}),
         base_table_map=raw.get("base_table_map", {}),
         design_ratio_group_map=raw.get("design_ratio_group_map", {}),
-        inapplicable_summary_columns=tuple(
-            raw.get("inapplicable_summary_columns", ())
-        ),
-        inapplicable_truth_table_columns=tuple(
-            raw.get("inapplicable_truth_table_columns", ())
-        ),
+        inapplicable_summary_columns=tuple(raw.get("inapplicable_summary_columns", ())),
+        inapplicable_truth_table_columns=tuple(raw.get("inapplicable_truth_table_columns", ())),
         notes=raw.get("notes", {}),
         calibration=calibration,
         class_to_group=class_to_group,
@@ -343,6 +334,7 @@ def load_plan_config(
     # Fatal: legs must be non-overlapping and cover the full
     # entry-year range. Raises ValueError on misconfiguration.
     from pension_model.config_validation import validate_funding_legs
+
     validate_funding_legs(config)
 
     # Fatal: scenario's declared 'requires' list must resolve to
@@ -351,6 +343,7 @@ def load_plan_config(
     # plan with no DROP).
     if scenario_requires:
         from pension_model.schemas.scenario import check_scenario_requires
+
         check_scenario_requires(config, scenario_requires)
 
     for warning in config.validate():
@@ -359,7 +352,7 @@ def load_plan_config(
     return config
 
 
-def discover_plans(plans_dir: Optional[Path] = None) -> dict[str, Path]:
+def discover_plans(plans_dir: Path | None = None) -> dict[str, Path]:
     """Return {plan_name: plan_config.json path} for discovered plans."""
     if plans_dir is None:
         plans_dir = Path(__file__).parents[2] / "plans"
@@ -377,7 +370,7 @@ def discover_plans(plans_dir: Optional[Path] = None) -> dict[str, Path]:
 
 def load_plan_config_by_name(
     plan_name: str,
-    calibration_path: Optional[Path] = None,
+    calibration_path: Path | None = None,
 ) -> PlanConfig:
     """Load a plan config by plan directory name."""
     plans = discover_plans()

--- a/src/pension_model/config_resolver_common.py
+++ b/src/pension_model/config_resolver_common.py
@@ -17,7 +17,7 @@ def _lookup_reduce_table(table, table_key: str, dist_age: int, yos: int) -> floa
         age_cols = [c for c in table.columns if c != "yos"]
         age_col = int(dist_age) if int(dist_age) in age_cols else None
         if age_col is None:
-            int_cols = [c for c in age_cols if isinstance(c, (int, float))]
+            int_cols = [c for c in age_cols if isinstance(c, int | float)]
             if int_cols:
                 age_col = min(int_cols, key=lambda x: abs(x - dist_age))
         if age_col is not None:

--- a/src/pension_model/config_resolvers.py
+++ b/src/pension_model/config_resolvers.py
@@ -1,6 +1,5 @@
 """Stable public resolver API."""
 
-from pension_model.config_schema import EARLY, NON_VESTED, NORM, VESTED
 from pension_model.config_resolvers_scalar import (
     get_ben_mult,
     get_reduce_factor,
@@ -12,7 +11,7 @@ from pension_model.config_resolvers_vectorized import (
     resolve_reduce_factor_vec,
     resolve_tiers_vec,
 )
-
+from pension_model.config_schema import EARLY, NON_VESTED, NORM, VESTED
 
 __all__ = [
     "EARLY",

--- a/src/pension_model/config_resolvers_scalar.py
+++ b/src/pension_model/config_resolvers_scalar.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Scalar config-derived resolvers."""
+
+from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
@@ -35,19 +35,13 @@ def get_tier(
         elif tier.entry_year_in_window(entry_year, config.new_year):
             if tier.not_grandfathered:
                 gf_tier = next(
-                    (
-                        t
-                        for t in config.tier_defs
-                        if t.assignment == "grandfathered_rule"
-                    ),
+                    (t for t in config.tier_defs if t.assignment == "grandfathered_rule"),
                     None,
                 )
                 if gf_tier is not None:
                     effective_entry_age = entry_age if entry_age > 0 else (age - yos)
                     assert gf_tier.grandfathered_params is not None
-                    if gf_tier.grandfathered_params.matches(
-                        entry_year, effective_entry_age
-                    ):
+                    if gf_tier.grandfathered_params.matches(entry_year, effective_entry_age):
                         continue
             matched_tier = tier
             break

--- a/src/pension_model/config_resolvers_vectorized.py
+++ b/src/pension_model/config_resolvers_vectorized.py
@@ -1,8 +1,8 @@
-from __future__ import annotations
-
 """Vectorized config-derived resolvers."""
 
-from typing import Optional, TYPE_CHECKING, Tuple
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import numpy as np
 
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     from pension_model.config_schema import PlanConfig
 
 
-def _encode_class_name_values(class_name) -> Tuple[np.ndarray, np.ndarray]:
+def _encode_class_name_values(class_name) -> tuple[np.ndarray, np.ndarray]:
     """Return integer class codes plus object labels for grouping work.
 
     `class_name` often arrives as a pandas Categorical when called from the
@@ -37,9 +37,9 @@ def _encode_class_name_values(class_name) -> Tuple[np.ndarray, np.ndarray]:
 
 
 def _encode_class_group_values(
-    config: "PlanConfig",
+    config: PlanConfig,
     class_name,
-) -> Tuple[np.ndarray, Tuple[str, ...]]:
+) -> tuple[np.ndarray, tuple[str, ...]]:
     """Return per-row group codes plus the corresponding group labels.
 
     The benefit-table pipeline frequently passes millions of rows with only a
@@ -48,11 +48,16 @@ def _encode_class_group_values(
     """
     class_codes, class_labels = _encode_class_name_values(class_name)
     group_labels = tuple(
-        dict.fromkeys(config.class_to_group.get(class_value, "default") for class_value in class_labels)
+        dict.fromkeys(
+            config.class_to_group.get(class_value, "default") for class_value in class_labels
+        )
     )
     group_to_code = {group_label: i for i, group_label in enumerate(group_labels)}
     class_group_codes = np.array(
-        [group_to_code[config.class_to_group.get(class_value, "default")] for class_value in class_labels],
+        [
+            group_to_code[config.class_to_group.get(class_value, "default")]
+            for class_value in class_labels
+        ],
         dtype=np.int16,
     )
     return class_group_codes[class_codes], group_labels
@@ -62,7 +67,7 @@ def _iter_class_tier_groups(
     class_name,
     tier_id: np.ndarray,
     n_tiers: int,
-    mask: Optional[np.ndarray] = None,
+    mask: np.ndarray | None = None,
 ):
     """Yield `(class_name, tier_id, row_indices)` groups without pandas."""
     class_codes, class_labels = _encode_class_name_values(class_name)
@@ -83,12 +88,10 @@ def _iter_class_tier_groups(
     pair_codes = class_codes.astype(np.int64) * n_tiers + tier_subset.astype(np.int64)
     order = np.argsort(pair_codes, kind="mergesort")
     sorted_pair_codes = pair_codes[order]
-    group_starts = np.flatnonzero(
-        np.r_[True, sorted_pair_codes[1:] != sorted_pair_codes[:-1]]
-    )
+    group_starts = np.flatnonzero(np.r_[True, sorted_pair_codes[1:] != sorted_pair_codes[:-1]])
     group_stops = np.append(group_starts[1:], len(order))
 
-    for start, stop in zip(group_starts, group_stops):
+    for start, stop in zip(group_starts, group_stops, strict=True):
         idx_arr = row_index[order[start:stop]]
         pair_code = int(sorted_pair_codes[start])
         class_code = pair_code // n_tiers
@@ -101,8 +104,8 @@ def resolve_tiers_vec(
     entry_year: np.ndarray,
     age: np.ndarray,
     yos: np.ndarray,
-    entry_age: Optional[np.ndarray] = None,
-) -> Tuple[np.ndarray, np.ndarray]:
+    entry_age: np.ndarray | None = None,
+) -> tuple[np.ndarray, np.ndarray]:
     entry_year = np.asarray(entry_year, dtype=np.int64)
     age = np.asarray(age, dtype=np.int64)
     yos = np.asarray(yos, dtype=np.int64)
@@ -115,7 +118,9 @@ def resolve_tiers_vec(
 
     group_codes, group_labels = _encode_class_group_values(config, class_name)
     eligibility_by_tier_group = tuple(
-        tuple(tier.resolve_eligibility(group_label, config.tier_defs) for group_label in group_labels)
+        tuple(
+            tier.resolve_eligibility(group_label, config.tier_defs) for group_label in group_labels
+        )
         for tier in config.tier_defs
     )
 
@@ -145,7 +150,7 @@ def resolve_tiers_vec(
     tier_id[tier_id == -1] = len(config.tier_defs) - 1
 
     ret_status = np.full(len(entry_year), NON_VESTED, dtype=np.int8)
-    for tier_index, tier in enumerate(config.tier_defs):
+    for tier_index, _tier in enumerate(config.tier_defs):
         tier_mask = tier_id == tier_index
         if not tier_mask.any():
             continue
@@ -228,9 +233,7 @@ def resolve_ben_mult_vec(
     for class_name_value, tier_index, idx_arr in _iter_class_tier_groups(
         class_name, tier_id, n_tiers
     ):
-        rules = config.resolve_ben_mult(
-            class_name_value, config.tier_id_to_name[tier_index]
-        )
+        rules = config.resolve_ben_mult(class_name_value, config.tier_id_to_name[tier_index])
         if rules is None:
             continue
 

--- a/src/pension_model/config_schema.py
+++ b/src/pension_model/config_schema.py
@@ -14,7 +14,7 @@ content inside ``notes`` instead.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
@@ -38,7 +38,6 @@ from pension_model.schemas import (
     ValuationInputs,
     validate_tier_cross_references,
 )
-
 
 NON_VESTED = 0
 VESTED = 1
@@ -74,8 +73,8 @@ class PlanConfig(BaseModel):
     plan_name: str
     plan_description: str = ""
 
-    classes: Tuple[str, ...]
-    class_groups: Dict[str, List[str]] = Field(default_factory=dict)
+    classes: tuple[str, ...]
+    class_groups: dict[str, list[str]] = Field(default_factory=dict)
 
     economic: Economic
     ranges: Ranges
@@ -84,20 +83,20 @@ class PlanConfig(BaseModel):
     funding: Funding
     benefit: Benefit
 
-    valuation_inputs: Dict[str, ValuationInputs] = Field(default_factory=dict)
+    valuation_inputs: dict[str, ValuationInputs] = Field(default_factory=dict)
     plan_design: PlanDesign = Field(default_factory=PlanDesign)
     benefit_mult_defs: BenefitMultipliers = Field(
         default_factory=BenefitMultipliers, alias="benefit_multipliers"
     )
-    tier_defs: Tuple[Tier, ...] = Field(default=(), alias="tiers")
+    tier_defs: tuple[Tier, ...] = Field(default=(), alias="tiers")
 
     data: DataSpec
-    mortality: Optional[MortalitySpec] = None
-    term_vested: Optional[TermVested] = None
+    mortality: MortalitySpec | None = None
+    term_vested: TermVested | None = None
 
-    salary_growth_col_map: Dict[str, str] = Field(default_factory=dict)
-    base_table_map: Dict[str, str] = Field(default_factory=dict)
-    design_ratio_group_map: Dict[str, str] = Field(default_factory=dict)
+    salary_growth_col_map: dict[str, str] = Field(default_factory=dict)
+    base_table_map: dict[str, str] = Field(default_factory=dict)
+    design_ratio_group_map: dict[str, str] = Field(default_factory=dict)
 
     # Output-uniformity declaration: columns in the canonical summary
     # and truth-table outputs that are structurally inapplicable to
@@ -105,24 +104,24 @@ class PlanConfig(BaseModel):
     # plans populate every column, so this is empty; it exists so a
     # future plan can be honest about what it does and does not
     # produce, and the runtime can assert the rest are populated.
-    inapplicable_summary_columns: Tuple[str, ...] = ()
-    inapplicable_truth_table_columns: Tuple[str, ...] = ()
+    inapplicable_summary_columns: tuple[str, ...] = ()
+    inapplicable_truth_table_columns: tuple[str, ...] = ()
 
-    notes: Dict[str, Any] = Field(default_factory=dict)
+    notes: dict[str, Any] = Field(default_factory=dict)
 
-    scenario_name: Optional[str] = Field(default=None, alias="_scenario_name")
+    scenario_name: str | None = Field(default=None, alias="_scenario_name")
 
     # Populated post-load (calibration is read from a sibling file;
     # reduce_tables and the lookup caches are built during loading).
-    calibration: Dict[str, ClassCalibration] = Field(default_factory=dict)
-    reduce_tables: Optional[Dict[str, Any]] = None
-    class_to_group: Dict[str, str] = Field(default_factory=dict)
-    tier_name_to_id: Dict[str, int] = Field(default_factory=dict)
-    tier_id_to_name: Tuple[str, ...] = ()
-    tier_id_to_cola_key: Tuple[str, ...] = ()
-    tier_id_to_fas_years: Tuple[int, ...] = ()
-    tier_id_to_dr_key: Tuple[str, ...] = ()
-    tier_id_to_retire_rate_set: Tuple[str, ...] = ()
+    calibration: dict[str, ClassCalibration] = Field(default_factory=dict)
+    reduce_tables: dict[str, Any] | None = None
+    class_to_group: dict[str, str] = Field(default_factory=dict)
+    tier_name_to_id: dict[str, int] = Field(default_factory=dict)
+    tier_id_to_name: tuple[str, ...] = ()
+    tier_id_to_cola_key: tuple[str, ...] = ()
+    tier_id_to_fas_years: tuple[int, ...] = ()
+    tier_id_to_dr_key: tuple[str, ...] = ()
+    tier_id_to_retire_rate_set: tuple[str, ...] = ()
 
     # ------------------------------------------------------------------
     # Cross-reference validation. tier_defs ``*_same_as`` references
@@ -174,7 +173,7 @@ class PlanConfig(BaseModel):
         return self.economic.model_return  # type: ignore[return-value]
 
     @property
-    def asset_return_path(self) -> Optional[dict]:
+    def asset_return_path(self) -> dict | None:
         return self.economic.asset_return_path
 
     @property
@@ -226,7 +225,7 @@ class PlanConfig(BaseModel):
         return self.benefit.fas_years_default
 
     @property
-    def benefit_types(self) -> Tuple[str, ...]:
+    def benefit_types(self) -> tuple[str, ...]:
         return tuple(self.benefit.benefit_types)
 
     @property
@@ -262,11 +261,11 @@ class PlanConfig(BaseModel):
         return self.modeling.male_mp_forward_shift
 
     @property
-    def cola_proration_cutoff_year(self) -> Optional[int]:
+    def cola_proration_cutoff_year(self) -> int | None:
         return self.cola.proration_cutoff_year
 
     @property
-    def plan_design_cutoff_year(self) -> Optional[int]:
+    def plan_design_cutoff_year(self) -> int | None:
         return self.plan_design.cutoff_year
 
     @property
@@ -288,7 +287,7 @@ class PlanConfig(BaseModel):
         return self.funding.has_drop
 
     @property
-    def drop_reference_class(self) -> Optional[str]:
+    def drop_reference_class(self) -> str | None:
         return self.funding.drop_reference_class
 
     @property
@@ -297,7 +296,7 @@ class PlanConfig(BaseModel):
         return self.funding.statutory_rates
 
     @property
-    def amo_period_current(self) -> Optional[int]:
+    def amo_period_current(self) -> int | None:
         return self.funding.amo_period_current
 
     @property
@@ -340,7 +339,7 @@ class PlanConfig(BaseModel):
         return self.funding.ava_smoothing
 
     @property
-    def funding_legs(self) -> Tuple[Tuple[str, Optional[int], Optional[int]], ...]:
+    def funding_legs(self) -> tuple[tuple[str, int | None, int | None], ...]:
         """Resolved funding legs as ``((name, lo, hi), ...)``.
 
         ``lo`` is inclusive, ``hi`` is exclusive — same convention as
@@ -384,7 +383,7 @@ class PlanConfig(BaseModel):
         return self.ranges.max_year
 
     @property
-    def class_data(self) -> Dict[str, ClassData]:
+    def class_data(self) -> dict[str, ClassData]:
         """Per-class merged view of valuation_inputs + calibration.
 
         Returns typed ``ClassData`` objects, one per class. Same
@@ -418,7 +417,7 @@ class PlanConfig(BaseModel):
             for name, ratios in self.plan_design.groups.items()
         }
 
-    def get_design_ratios(self, class_name: str) -> Dict[str, Tuple[float, float, float]]:
+    def get_design_ratios(self, class_name: str) -> dict[str, tuple[float, float, float]]:
         group_name = self.design_ratio_group_map.get(class_name, self.class_group(class_name))
         ratios = (
             self.plan_design.group(group_name)
@@ -444,9 +443,7 @@ class PlanConfig(BaseModel):
     def class_group(self, class_name: str) -> str:
         return self.class_to_group.get(class_name, "default")
 
-    def resolve_ben_mult(
-        self, class_name: str, tier_name: str
-    ) -> Optional[MultiplierRules]:
+    def resolve_ben_mult(self, class_name: str, tier_name: str) -> MultiplierRules | None:
         """Look up the typed :class:`MultiplierRules` for a (class, tier).
 
         Encapsulates the ``all_tiers`` / ``<tier>_same_as`` / direct
@@ -467,8 +464,10 @@ class PlanConfig(BaseModel):
 
     def validate(self) -> list:
         from pension_model.config_validation import validate_config
+
         return validate_config(self)
 
     def validate_data_files(self) -> list:
         from pension_model.config_validation import validate_data_files
+
         return validate_data_files(self)

--- a/src/pension_model/config_validation.py
+++ b/src/pension_model/config_validation.py
@@ -34,20 +34,19 @@ def validate_funding_legs(config) -> None:
 
     for ey in range(lo_bound, hi_bound):
         matches = [
-            name for name, lo, hi in legs
-            if (lo is None or ey >= lo) and (hi is None or ey < hi)
+            name for name, lo, hi in legs if (lo is None or ey >= lo) and (hi is None or ey < hi)
         ]
         if len(matches) == 0:
             raise ValueError(
                 f"Plan {config.plan_name!r}: entry_year {ey} is not "
                 f"covered by any funding leg. Legs: "
-                f"{[(n, lo, hi) for n, lo, hi in legs]}."
+                f"{list(legs)}."
             )
         if len(matches) > 1:
             raise ValueError(
                 f"Plan {config.plan_name!r}: entry_year {ey} is covered "
                 f"by multiple funding legs {matches}. Legs must not "
-                f"overlap. Legs: {[(n, lo, hi) for n, lo, hi in legs]}."
+                f"overlap. Legs: {list(legs)}."
             )
 
 
@@ -101,7 +100,8 @@ def validate_config(config) -> list[str]:
                 peer_target = peer_val.total_active_member if peer_val is not None else None
                 if peer_target != target:
                     warnings.append(
-                        f"headcount_group mismatch: '{class_name}' has total_active_member={target} "
+                        f"headcount_group mismatch: '{class_name}' "
+                        f"has total_active_member={target} "
                         f"but peer '{peer}' has {peer_target}."
                     )
                     break

--- a/src/pension_model/core/__init__.py
+++ b/src/pension_model/core/__init__.py
@@ -7,6 +7,8 @@ Production pipeline for pension modeling:
 - funding_model: Funding projection (assets, contributions, amortization)
 """
 
+from .data_loader import load_plan_inputs
+from .funding_model import load_funding_inputs, run_funding_model
 from .pipeline import (
     PreparedPlanRun,
     build_plan_benefit_tables,
@@ -15,9 +17,6 @@ from .pipeline import (
     run_prepared_plan_pipeline,
     summarize_prepared_plan_run,
 )
-from .runtime_contracts import ClassRuntimeTables
-from .data_loader import load_plan_inputs
-from .funding_model import load_funding_inputs, run_funding_model
 from .profiling import (
     build_runtime_baseline,
     compare_runtime_baselines,
@@ -26,6 +25,7 @@ from .profiling import (
     summarize_runtime_samples,
     write_runtime_baseline,
 )
+from .runtime_contracts import ClassRuntimeTables
 
 __all__ = [
     "ClassRuntimeTables",

--- a/src/pension_model/core/_funding_core.py
+++ b/src/pension_model/core/_funding_core.py
@@ -17,7 +17,6 @@ implementation):
     write order; do not convert to bulk ``f.loc[i, cols] = values``.
 """
 
-import numpy as np
 import pandas as pd
 
 from pension_model.core._funding_helpers import _maybe_accumulate
@@ -49,7 +48,9 @@ from pension_model.core._funding_setup import (
 )
 
 
-def _accumulate_class_payroll(ctx: FundingContext, agg: pd.DataFrame, f: pd.DataFrame, i: int) -> None:
+def _accumulate_class_payroll(
+    ctx: FundingContext, agg: pd.DataFrame, f: pd.DataFrame, i: int
+) -> None:
     """Accumulate class payroll columns into the aggregate row."""
     _maybe_accumulate(ctx, agg, f, i, ["total_payroll", "payroll_db_legacy", "payroll_db_new"])
     if ctx.has_dc:
@@ -64,9 +65,13 @@ def _write_benefit_refund_totals(f: pd.DataFrame, i: int) -> None:
         f.loc[i, "total_refund"] = f.loc[i, "refund_legacy"] + f.loc[i, "refund_new"]
 
 
-def _accumulate_benefits_refunds(ctx: FundingContext, agg: pd.DataFrame, f: pd.DataFrame, i: int) -> None:
+def _accumulate_benefits_refunds(
+    ctx: FundingContext, agg: pd.DataFrame, f: pd.DataFrame, i: int
+) -> None:
     """Accumulate per-class benefit/refund columns into the aggregate row."""
-    _maybe_accumulate(ctx, agg, f, i, ["ben_payment_legacy", "refund_legacy", "ben_payment_new", "refund_new"])
+    _maybe_accumulate(
+        ctx, agg, f, i, ["ben_payment_legacy", "refund_legacy", "ben_payment_new", "refund_new"]
+    )
     if "total_ben_payment" in f.columns:
         _maybe_accumulate(ctx, agg, f, i, ["total_ben_payment", "total_refund"])
 
@@ -92,9 +97,17 @@ def _set_dc_rates(f: pd.DataFrame, i: int, cn: str, ctx: FundingContext, constan
     f.loc[i, "er_dc_rate_new"] = dc_rate
 
 
-def _accumulate_db_contributions(ctx: FundingContext, agg: pd.DataFrame, f: pd.DataFrame, i: int) -> None:
+def _accumulate_db_contributions(
+    ctx: FundingContext, agg: pd.DataFrame, f: pd.DataFrame, i: int
+) -> None:
     """Accumulate DB employer contribution columns into the aggregate row."""
-    _maybe_accumulate(ctx, agg, f, i, ["er_nc_cont_legacy", "er_nc_cont_new", "er_amo_cont_legacy", "er_amo_cont_new"])
+    _maybe_accumulate(
+        ctx,
+        agg,
+        f,
+        i,
+        ["er_nc_cont_legacy", "er_nc_cont_new", "er_amo_cont_legacy", "er_amo_cont_new"],
+    )
     if "total_er_db_cont" in f.columns:
         _maybe_accumulate(ctx, agg, f, i, ["total_er_db_cont"])
 
@@ -117,11 +130,20 @@ def _set_total_contribution_rate(f: pd.DataFrame, i: int) -> None:
     total_payroll = f.loc[i, "total_payroll"]
     f.loc[i, "tot_cont_rate"] = (
         (
-            f.loc[i, "ee_nc_cont_legacy"] + f.loc[i, "er_nc_cont_legacy"] + f.loc[i, "er_amo_cont_legacy"]
-            + f.loc[i, "ee_nc_cont_new"] + f.loc[i, "er_nc_cont_new"] + f.loc[i, "er_amo_cont_new"]
-            + f.loc[i, "solv_cont"]
-        ) / total_payroll
-    ) if total_payroll > 0 else 0
+            (
+                f.loc[i, "ee_nc_cont_legacy"]
+                + f.loc[i, "er_nc_cont_legacy"]
+                + f.loc[i, "er_amo_cont_legacy"]
+                + f.loc[i, "ee_nc_cont_new"]
+                + f.loc[i, "er_nc_cont_new"]
+                + f.loc[i, "er_amo_cont_new"]
+                + f.loc[i, "solv_cont"]
+            )
+            / total_payroll
+        )
+        if total_payroll > 0
+        else 0
+    )
 
 
 def _finalize_aggregate_row(agg: pd.DataFrame, i: int) -> None:
@@ -130,7 +152,9 @@ def _finalize_aggregate_row(agg: pd.DataFrame, i: int) -> None:
     total_payroll = agg.loc[i, "total_payroll"]
     agg.loc[i, "fr_mva"] = agg.loc[i, "total_mva"] / total_aal if total_aal != 0 else 0
     agg.loc[i, "fr_ava"] = agg.loc[i, "total_ava"] / total_aal if total_aal != 0 else 0
-    agg.loc[i, "total_er_cont_rate"] = agg.loc[i, "total_er_cont"] / total_payroll if total_payroll > 0 else 0
+    agg.loc[i, "total_er_cont_rate"] = (
+        agg.loc[i, "total_er_cont"] / total_payroll if total_payroll > 0 else 0
+    )
 
 
 def _run_phase1_for_class(
@@ -192,14 +216,18 @@ def _run_phase2_for_class(
     if ctx.builds_aggregate_in_loop:
         if "total_er_db_cont" in ctx.init_funding.columns:
             f.loc[i, "total_er_db_cont"] = (
-                f.loc[i, "er_nc_cont_legacy"] + f.loc[i, "er_nc_cont_new"]
-                + f.loc[i, "er_amo_cont_legacy"] + f.loc[i, "er_amo_cont_new"]
+                f.loc[i, "er_nc_cont_legacy"]
+                + f.loc[i, "er_nc_cont_new"]
+                + f.loc[i, "er_amo_cont_legacy"]
+                + f.loc[i, "er_amo_cont_new"]
             )
         _accumulate_db_contributions(ctx, agg, f, i)
 
     if ctx.has_dc:
         _phase_dc_contributions(f, i)
-        _maybe_accumulate(ctx, agg, f, i, ["er_dc_cont_legacy", "er_dc_cont_new", "total_er_dc_cont"])
+        _maybe_accumulate(
+            ctx, agg, f, i, ["er_dc_cont_legacy", "er_dc_cont_new", "total_er_dc_cont"]
+        )
 
     roa = _resolve_roa(ret_scen, year, dr_current)
     f.loc[i, "roa"] = roa
@@ -240,6 +268,8 @@ def _run_phase3_for_class(
     _set_total_contribution_rate(f, i)
 
     funding[cn] = f
+
+
 def _compute_funding(
     liability_results: dict,
     funding_inputs: dict,
@@ -292,8 +322,18 @@ def _compute_funding(
         # --- Phase 2: contributions, ROA, cash flow, MVA, AVA prep ---
         for cn in ctx.all_classes:
             _run_phase2_for_class(
-                cn, i, year, funding, agg, amort_state, ctx, constants,
-                ctx.cont_strategy, ret_scen, dr_current, dr_new,
+                cn,
+                i,
+                year,
+                funding,
+                agg,
+                amort_state,
+                ctx,
+                constants,
+                ctx.cont_strategy,
+                ret_scen,
+                dr_current,
+                dr_new,
             )
 
         if ctx.ava_strategy.aggregation_level == "plan":

--- a/src/pension_model/core/_funding_helpers.py
+++ b/src/pension_model/core/_funding_helpers.py
@@ -19,7 +19,7 @@ import math
 import numpy as np
 import pandas as pd
 
-from pension_model.core.pipeline import _get_pmt
+from pension_model.core.pipeline_current import _get_pmt
 
 
 def _get_init_row(init_funding: pd.DataFrame, class_name: str) -> pd.Series:
@@ -32,8 +32,14 @@ def _get_init_row(init_funding: pd.DataFrame, class_name: str) -> pd.Series:
 
 
 def _ava_gain_loss_smoothing(
-    ava_prev, net_cf, mva, dr,
-    defer_y1_prev, defer_y2_prev, defer_y3_prev, defer_y4_prev,
+    ava_prev,
+    net_cf,
+    mva,
+    dr,
+    defer_y1_prev,
+    defer_y2_prev,
+    defer_y3_prev,
+    defer_y4_prev,
 ):
     """AVA gain/loss deferral smoothing (4-year phased recognition).
 
@@ -51,51 +57,65 @@ def _ava_gain_loss_smoothing(
     if math.copysign(1, remain_defer_boy) == math.copysign(1, defer_y4_prev) or defer_y4_prev == 0:
         aft_offset_y4 = remain_defer_boy
     else:
-        aft_offset_y4 = math.copysign(
-            max(0, abs(remain_defer_boy) - abs(defer_y4_prev)),
-            remain_defer_boy) if remain_defer_boy != 0 else 0.0
+        aft_offset_y4 = (
+            math.copysign(max(0, abs(remain_defer_boy) - abs(defer_y4_prev)), remain_defer_boy)
+            if remain_defer_boy != 0
+            else 0.0
+        )
     if math.copysign(1, aft_offset_y4) == math.copysign(1, defer_y3_prev) or defer_y3_prev == 0:
         new_y4 = defer_y3_prev * 0.5
     else:
-        new_y4 = math.copysign(
-            max(0, abs(defer_y3_prev) - abs(aft_offset_y4)),
-            defer_y3_prev) * 0.5 if defer_y3_prev != 0 else 0.0
+        new_y4 = (
+            math.copysign(max(0, abs(defer_y3_prev) - abs(aft_offset_y4)), defer_y3_prev) * 0.5
+            if defer_y3_prev != 0
+            else 0.0
+        )
 
     # Step 2: offset defer_y3
     if math.copysign(1, aft_offset_y4) == math.copysign(1, defer_y3_prev) or defer_y3_prev == 0:
         aft_offset_y3 = aft_offset_y4
     else:
-        aft_offset_y3 = math.copysign(
-            max(0, abs(aft_offset_y4) - abs(defer_y3_prev)),
-            aft_offset_y4) if aft_offset_y4 != 0 else 0.0
+        aft_offset_y3 = (
+            math.copysign(max(0, abs(aft_offset_y4) - abs(defer_y3_prev)), aft_offset_y4)
+            if aft_offset_y4 != 0
+            else 0.0
+        )
     if math.copysign(1, aft_offset_y3) == math.copysign(1, defer_y2_prev) or defer_y2_prev == 0:
         new_y3 = defer_y2_prev * (2 / 3)
     else:
-        new_y3 = math.copysign(
-            max(0, abs(defer_y2_prev) - abs(aft_offset_y3)),
-            defer_y2_prev) * (2 / 3) if defer_y2_prev != 0 else 0.0
+        new_y3 = (
+            math.copysign(max(0, abs(defer_y2_prev) - abs(aft_offset_y3)), defer_y2_prev) * (2 / 3)
+            if defer_y2_prev != 0
+            else 0.0
+        )
 
     # Step 3: offset defer_y2
     if math.copysign(1, aft_offset_y3) == math.copysign(1, defer_y2_prev) or defer_y2_prev == 0:
         aft_offset_y2 = aft_offset_y3
     else:
-        aft_offset_y2 = math.copysign(
-            max(0, abs(aft_offset_y3) - abs(defer_y2_prev)),
-            aft_offset_y3) if aft_offset_y3 != 0 else 0.0
+        aft_offset_y2 = (
+            math.copysign(max(0, abs(aft_offset_y3) - abs(defer_y2_prev)), aft_offset_y3)
+            if aft_offset_y3 != 0
+            else 0.0
+        )
     if math.copysign(1, aft_offset_y2) == math.copysign(1, defer_y1_prev) or defer_y1_prev == 0:
         new_y2 = defer_y1_prev * (3 / 4)
     else:
-        new_y2 = math.copysign(
-            max(0, abs(defer_y1_prev) - abs(aft_offset_y2)),
-            defer_y1_prev) * (3 / 4) if defer_y1_prev != 0 else 0.0
+        new_y2 = (
+            math.copysign(max(0, abs(defer_y1_prev) - abs(aft_offset_y2)), defer_y1_prev) * (3 / 4)
+            if defer_y1_prev != 0
+            else 0.0
+        )
 
     # Step 4: offset defer_y1
     if math.copysign(1, aft_offset_y2) == math.copysign(1, defer_y1_prev) or defer_y1_prev == 0:
         aft_offset_y1 = aft_offset_y2
     else:
-        aft_offset_y1 = math.copysign(
-            max(0, abs(aft_offset_y2) - abs(defer_y1_prev)),
-            aft_offset_y2) if aft_offset_y2 != 0 else 0.0
+        aft_offset_y1 = (
+            math.copysign(max(0, abs(aft_offset_y2) - abs(defer_y1_prev)), aft_offset_y2)
+            if aft_offset_y2 != 0
+            else 0.0
+        )
     new_y1 = aft_offset_y1 * (4 / 5)
 
     remain_defer_eoy = new_y1 + new_y2 + new_y3 + new_y4
@@ -134,11 +154,7 @@ def _aal_rollforward(aal_prev, nc, ben, refund, liab_gl, dr):
     precomputed ``sqrt_factor`` — so the floating-point operations match
     the original inline expression bit-for-bit (see bit-identity risk #1).
     """
-    return (
-        aal_prev * (1 + dr)
-        + (nc - ben - refund) * (1 + dr) ** 0.5
-        + liab_gl
-    )
+    return aal_prev * (1 + dr) + (nc - ben - refund) * (1 + dr) ** 0.5 + liab_gl
 
 
 def _mva_rollforward(mva_prev, net_cf, roa):
@@ -204,15 +220,18 @@ def _roll_amort_layer(debt, pay, per, i, max_col, ual, dr, amo_pay_growth):
     intentionally NOT unified — see the build_amort_period_tables
     helper and the TRS-side diagonal-shift code.
     """
-    debt[i, 1:max_col + 1] = (
-        debt[i - 1, :max_col] * (1 + dr)
-        - pay[i - 1, :max_col] * (1 + dr) ** 0.5
+    debt[i, 1 : max_col + 1] = (
+        debt[i - 1, :max_col] * (1 + dr) - pay[i - 1, :max_col] * (1 + dr) ** 0.5
     )
-    debt[i, 0] = ual - debt[i, 1:max_col + 1].sum()
+    debt[i, 0] = ual - debt[i, 1 : max_col + 1].sum()
     for j in range(max_col):
         if per[i, j] > 0 and abs(debt[i, j]) > 1e-6:
             pay[i, j] = _get_pmt(
-                dr, amo_pay_growth, int(per[i, j]), debt[i, j], t=0.5,
+                dr,
+                amo_pay_growth,
+                int(per[i, j]),
+                debt[i, j],
+                t=0.5,
             )
         else:
             pay[i, j] = 0
@@ -240,16 +259,12 @@ def _populate_calibrated_nc_rates(f, liab, nc_cal, n_years):
     TRS's fallback chain (bit-identity risk #2 in the plan).
     """
     nc_legacy = liab["nc_rate_db_legacy_est"].values * nc_cal
-    nc_new_db = liab.get(
-        "nc_rate_db_new_est", pd.Series(np.zeros(n_years))
-    ).values * nc_cal
+    nc_new_db = liab.get("nc_rate_db_new_est", pd.Series(np.zeros(n_years))).values * nc_cal
     f.loc[1:, "nc_rate_db_legacy"] = nc_legacy[:-1]
     f.loc[1:, "nc_rate_db_new"] = nc_new_db[:-1]
 
     if "payroll_cb_new_est" in liab.columns:
-        nc_new_cb = liab.get(
-            "nc_rate_cb_new_est", pd.Series(np.zeros(n_years))
-        ).values
+        nc_new_cb = liab.get("nc_rate_cb_new_est", pd.Series(np.zeros(n_years))).values
         f.loc[1:, "nc_rate_cb_new"] = nc_new_cb[:-1]
 
 

--- a/src/pension_model/core/_funding_phases.py
+++ b/src/pension_model/core/_funding_phases.py
@@ -19,7 +19,9 @@ def _phase_payroll(f: pd.DataFrame, i: int, ctx: FundingContext) -> None:
     if ctx.has_cb:
         f.loc[i, "payroll_cb_new"] = f.loc[i, "total_payroll"] * f.loc[i, "payroll_cb_new_ratio"]
     if ctx.has_dc:
-        f.loc[i, "payroll_dc_legacy"] = f.loc[i, "total_payroll"] * f.loc[i, "payroll_dc_legacy_ratio"]
+        f.loc[i, "payroll_dc_legacy"] = (
+            f.loc[i, "total_payroll"] * f.loc[i, "payroll_dc_legacy_ratio"]
+        )
         f.loc[i, "payroll_dc_new"] = f.loc[i, "total_payroll"] * f.loc[i, "payroll_dc_new_ratio"]
 
 
@@ -29,7 +31,9 @@ def _phase_dc_contributions(f: pd.DataFrame, i: int) -> None:
     f.loc[i, "total_er_dc_cont"] = f.loc[i, "er_dc_cont_legacy"] + f.loc[i, "er_dc_cont_new"]
 
 
-def _phase_benefits_refunds(f: pd.DataFrame, liab: pd.DataFrame, i: int, ctx: FundingContext) -> None:
+def _phase_benefits_refunds(
+    f: pd.DataFrame, liab: pd.DataFrame, i: int, ctx: FundingContext
+) -> None:
     f.loc[i, "ben_payment_legacy"] = (
         liab["retire_ben_db_legacy_est"].iloc[i]
         + liab["retire_ben_current_est"].iloc[i]
@@ -50,7 +54,9 @@ def _nc_rate_agg(agg: pd.DataFrame, i: int, ctx: FundingContext) -> None:
     denom = agg.loc[i, "payroll_db_legacy"] + agg.loc[i, "payroll_db_new"]
     if ctx.has_cb:
         denom = denom + agg.loc[i, "payroll_cb_new"]
-    agg.loc[i, "nc_rate"] = (agg.loc[i, "nc_legacy"] + agg.loc[i, "nc_new"]) / denom if denom > 0 else 0
+    agg.loc[i, "nc_rate"] = (
+        (agg.loc[i, "nc_legacy"] + agg.loc[i, "nc_new"]) / denom if denom > 0 else 0
+    )
 
 
 def _phase_normal_cost(f: pd.DataFrame, i: int, ctx: FundingContext) -> None:
@@ -79,29 +85,55 @@ def _phase_drop_projection(funding: dict, agg: pd.DataFrame, i: int, ctx: Fundin
     if reg.loc[i - 1, "total_ben_payment"] > 0:
         drop.loc[i, "total_ben_payment"] = (
             drop.loc[i - 1, "total_ben_payment"]
-            * reg.loc[i, "total_ben_payment"] / reg.loc[i - 1, "total_ben_payment"]
+            * reg.loc[i, "total_ben_payment"]
+            / reg.loc[i - 1, "total_ben_payment"]
         )
     if reg.loc[i - 1, "total_refund"] > 0:
         drop.loc[i, "total_refund"] = (
             drop.loc[i - 1, "total_refund"]
-            * reg.loc[i, "total_refund"] / reg.loc[i - 1, "total_refund"]
+            * reg.loc[i, "total_refund"]
+            / reg.loc[i - 1, "total_refund"]
         )
 
     if reg.loc[i, "total_ben_payment"] > 0:
-        drop.loc[i, "ben_payment_legacy"] = drop.loc[i, "total_ben_payment"] * reg.loc[i, "ben_payment_legacy"] / reg.loc[i, "total_ben_payment"]
-        drop.loc[i, "ben_payment_new"] = drop.loc[i, "total_ben_payment"] * reg.loc[i, "ben_payment_new"] / reg.loc[i, "total_ben_payment"]
+        drop.loc[i, "ben_payment_legacy"] = (
+            drop.loc[i, "total_ben_payment"]
+            * reg.loc[i, "ben_payment_legacy"]
+            / reg.loc[i, "total_ben_payment"]
+        )
+        drop.loc[i, "ben_payment_new"] = (
+            drop.loc[i, "total_ben_payment"]
+            * reg.loc[i, "ben_payment_new"]
+            / reg.loc[i, "total_ben_payment"]
+        )
     if reg.loc[i, "total_refund"] > 0:
-        drop.loc[i, "refund_legacy"] = drop.loc[i, "total_refund"] * reg.loc[i, "refund_legacy"] / reg.loc[i, "total_refund"]
-        drop.loc[i, "refund_new"] = drop.loc[i, "total_refund"] * reg.loc[i, "refund_new"] / reg.loc[i, "total_refund"]
+        drop.loc[i, "refund_legacy"] = (
+            drop.loc[i, "total_refund"] * reg.loc[i, "refund_legacy"] / reg.loc[i, "total_refund"]
+        )
+        drop.loc[i, "refund_new"] = (
+            drop.loc[i, "total_refund"] * reg.loc[i, "refund_new"] / reg.loc[i, "total_refund"]
+        )
 
-    drop.loc[i, "nc_rate_db_legacy"] = agg.loc[i, "nc_legacy"] / agg.loc[i, "payroll_db_legacy"] if agg.loc[i, "payroll_db_legacy"] > 0 else 0
-    drop.loc[i, "nc_rate_db_new"] = agg.loc[i, "nc_new"] / agg.loc[i, "payroll_db_new"] if agg.loc[i, "payroll_db_new"] > 0 else 0
+    drop.loc[i, "nc_rate_db_legacy"] = (
+        agg.loc[i, "nc_legacy"] / agg.loc[i, "payroll_db_legacy"]
+        if agg.loc[i, "payroll_db_legacy"] > 0
+        else 0
+    )
+    drop.loc[i, "nc_rate_db_new"] = (
+        agg.loc[i, "nc_new"] / agg.loc[i, "payroll_db_new"]
+        if agg.loc[i, "payroll_db_new"] > 0
+        else 0
+    )
     drop.loc[i, "nc_legacy"] = drop.loc[i, "nc_rate_db_legacy"] * drop.loc[i, "payroll_db_legacy"]
     drop.loc[i, "nc_new"] = drop.loc[i, "nc_rate_db_new"] * drop.loc[i, "payroll_db_new"]
 
     drop.loc[i, "aal_legacy"] = (
         drop.loc[i - 1, "aal_legacy"] * (1 + ctx.dr_current)
-        + (drop.loc[i, "nc_legacy"] - drop.loc[i, "ben_payment_legacy"] - drop.loc[i, "refund_legacy"])
+        + (
+            drop.loc[i, "nc_legacy"]
+            - drop.loc[i, "ben_payment_legacy"]
+            - drop.loc[i, "refund_legacy"]
+        )
         * (1 + ctx.dr_current) ** 0.5
     )
     drop.loc[i, "aal_new"] = (
@@ -113,14 +145,33 @@ def _phase_drop_projection(funding: dict, agg: pd.DataFrame, i: int, ctx: Fundin
     funding["drop"] = drop
 
     _maybe_accumulate(ctx, agg, drop, i, ["total_payroll", "payroll_db_legacy", "payroll_db_new"])
-    _maybe_accumulate(ctx, agg, drop, i, [
-        "ben_payment_legacy", "refund_legacy", "ben_payment_new", "refund_new", "total_ben_payment", "total_refund",
-    ])
+    _maybe_accumulate(
+        ctx,
+        agg,
+        drop,
+        i,
+        [
+            "ben_payment_legacy",
+            "refund_legacy",
+            "ben_payment_new",
+            "refund_new",
+            "total_ben_payment",
+            "total_refund",
+        ],
+    )
     _maybe_accumulate(ctx, agg, drop, i, ["nc_legacy", "nc_new"])
 
     _nc_rate_agg(agg, i, ctx)
-    agg.loc[i, "nc_rate_db_legacy"] = agg.loc[i, "nc_legacy"] / agg.loc[i, "payroll_db_legacy"] if agg.loc[i, "payroll_db_legacy"] > 0 else 0
-    agg.loc[i, "nc_rate_db_new"] = agg.loc[i, "nc_new"] / agg.loc[i, "payroll_db_new"] if agg.loc[i, "payroll_db_new"] > 0 else 0
+    agg.loc[i, "nc_rate_db_legacy"] = (
+        agg.loc[i, "nc_legacy"] / agg.loc[i, "payroll_db_legacy"]
+        if agg.loc[i, "payroll_db_legacy"] > 0
+        else 0
+    )
+    agg.loc[i, "nc_rate_db_new"] = (
+        agg.loc[i, "nc_new"] / agg.loc[i, "payroll_db_new"]
+        if agg.loc[i, "payroll_db_new"] > 0
+        else 0
+    )
     _maybe_accumulate(ctx, agg, drop, i, ["aal_legacy", "aal_new", "total_aal"])
 
 
@@ -128,10 +179,18 @@ def _finalize_ava_with_drop(funding: dict, agg: pd.DataFrame, i: int, ctx: Fundi
     if ctx.has_drop:
         drop = funding["drop"]
         if agg.loc[i, "aal_legacy"] != 0:
-            drop.loc[i, "net_reallocation_legacy"] = drop.loc[i, "unadj_ava_legacy"] - drop.loc[i, "aal_legacy"] * agg.loc[i, "ava_legacy"] / agg.loc[i, "aal_legacy"]
-        drop.loc[i, "ava_legacy"] = drop.loc[i, "unadj_ava_legacy"] - drop.loc[i, "net_reallocation_legacy"]
+            drop.loc[i, "net_reallocation_legacy"] = (
+                drop.loc[i, "unadj_ava_legacy"]
+                - drop.loc[i, "aal_legacy"] * agg.loc[i, "ava_legacy"] / agg.loc[i, "aal_legacy"]
+            )
+        drop.loc[i, "ava_legacy"] = (
+            drop.loc[i, "unadj_ava_legacy"] - drop.loc[i, "net_reallocation_legacy"]
+        )
         if agg.loc[i, "aal_new"] != 0:
-            drop.loc[i, "net_reallocation_new"] = drop.loc[i, "unadj_ava_new"] - drop.loc[i, "aal_new"] * agg.loc[i, "ava_new"] / agg.loc[i, "aal_new"]
+            drop.loc[i, "net_reallocation_new"] = (
+                drop.loc[i, "unadj_ava_new"]
+                - drop.loc[i, "aal_new"] * agg.loc[i, "ava_new"] / agg.loc[i, "aal_new"]
+            )
         drop.loc[i, "ava_new"] = drop.loc[i, "unadj_ava_new"] - drop.loc[i, "net_reallocation_new"]
         funding["drop"] = drop
 
@@ -140,7 +199,9 @@ def _finalize_ava_with_drop(funding: dict, agg: pd.DataFrame, i: int, ctx: Fundi
             agg_ex_drop_leg = agg.loc[i, "aal_legacy"] - drop.loc[i, "aal_legacy"]
             prop_leg = f.loc[i, "aal_legacy"] / agg_ex_drop_leg if agg_ex_drop_leg != 0 else 0
             f.loc[i, "net_reallocation_legacy"] = prop_leg * drop.loc[i, "net_reallocation_legacy"]
-            f.loc[i, "ava_legacy"] = f.loc[i, "unadj_ava_legacy"] + f.loc[i, "net_reallocation_legacy"]
+            f.loc[i, "ava_legacy"] = (
+                f.loc[i, "unadj_ava_legacy"] + f.loc[i, "net_reallocation_legacy"]
+            )
 
             agg_ex_drop_new = agg.loc[i, "aal_new"] - drop.loc[i, "aal_new"]
             prop_new = f.loc[i, "aal_new"] / agg_ex_drop_new if agg_ex_drop_new != 0 else 0
@@ -155,7 +216,9 @@ def _finalize_ava_with_drop(funding: dict, agg: pd.DataFrame, i: int, ctx: Fundi
             funding[cn] = f
 
 
-def _phase_ava_corridor_smoothing(agg: pd.DataFrame, i: int, ava_strategy, dr_current: float, dr_new: float) -> None:
+def _phase_ava_corridor_smoothing(
+    agg: pd.DataFrame, i: int, ava_strategy, dr_current: float, dr_new: float
+) -> None:
     for leg, dr in (("legacy", dr_current), ("new", dr_new)):
         result = ava_strategy.smooth(
             ava_prev=agg.loc[i - 1, f"ava_{leg}"],
@@ -171,7 +234,9 @@ def _phase_ava_corridor_smoothing(agg: pd.DataFrame, i: int, ava_strategy, dr_cu
         agg.loc[i, f"ava_base_{leg}"] = result["ava_base"]
 
 
-def _phase_ava_gainloss_smoothing(f: pd.DataFrame, i: int, ava_strategy, dr_current: float, dr_new: float) -> None:
+def _phase_ava_gainloss_smoothing(
+    f: pd.DataFrame, i: int, ava_strategy, dr_current: float, dr_new: float
+) -> None:
     for leg, dr in (("legacy", dr_current), ("new", dr_new)):
         result = ava_strategy.smooth(
             ava_prev=f.loc[i - 1, f"ava_{leg}"],
@@ -203,31 +268,57 @@ def _phase_amort_rolling(funding: dict, amort_state: dict, i: int, ctx: FundingC
             amo = amort_state["amo_tables"][cn]
             mc = amo["max_col"]
             _roll_amort_layer(
-                debt=amo["cur_debt"], pay=amo["cur_pay"], per=amo["cur_per"],
-                i=i, max_col=mc, ual=f.loc[i, "ual_ava_legacy"], dr=ctx.dr_current, amo_pay_growth=ctx.amo_pay_growth,
+                debt=amo["cur_debt"],
+                pay=amo["cur_pay"],
+                per=amo["cur_per"],
+                i=i,
+                max_col=mc,
+                ual=f.loc[i, "ual_ava_legacy"],
+                dr=ctx.dr_current,
+                amo_pay_growth=ctx.amo_pay_growth,
             )
             _roll_amort_layer(
-                debt=amo["fut_debt"], pay=amo["fut_pay"], per=amo["fut_per"],
-                i=i, max_col=mc, ual=f.loc[i, "ual_ava_new"], dr=ctx.dr_new, amo_pay_growth=ctx.amo_pay_growth,
+                debt=amo["fut_debt"],
+                pay=amo["fut_pay"],
+                per=amo["fut_per"],
+                i=i,
+                max_col=mc,
+                ual=f.loc[i, "ual_ava_new"],
+                dr=ctx.dr_new,
+                amo_pay_growth=ctx.amo_pay_growth,
             )
         return
 
     f = funding[ctx.class_names[0]]
     n_amo = amort_state["n_amo"]
     _roll_amort_layer(
-        debt=amort_state["debt_current"], pay=amort_state["pay_current"], per=amort_state["amo_per_current_diag"],
-        i=i, max_col=n_amo, ual=f.loc[i, "ual_ava_legacy"], dr=ctx.dr_current, amo_pay_growth=ctx.amo_pay_growth,
+        debt=amort_state["debt_current"],
+        pay=amort_state["pay_current"],
+        per=amort_state["amo_per_current_diag"],
+        i=i,
+        max_col=n_amo,
+        ual=f.loc[i, "ual_ava_legacy"],
+        dr=ctx.dr_current,
+        amo_pay_growth=ctx.amo_pay_growth,
     )
     _roll_amort_layer(
-        debt=amort_state["debt_new"], pay=amort_state["pay_new"], per=amort_state["amo_per_new"],
-        i=i, max_col=n_amo, ual=f.loc[i, "ual_ava_new"], dr=ctx.dr_new, amo_pay_growth=ctx.amo_pay_growth,
+        debt=amort_state["debt_new"],
+        pay=amort_state["pay_new"],
+        per=amort_state["amo_per_new"],
+        i=i,
+        max_col=n_amo,
+        ual=f.loc[i, "ual_ava_new"],
+        dr=ctx.dr_new,
+        amo_pay_growth=ctx.amo_pay_growth,
     )
 
 
 def _phase_er_cont_totals(f: pd.DataFrame, i: int, ctx: FundingContext) -> None:
     total = (
-        f.loc[i, "er_nc_cont_legacy"] + f.loc[i, "er_nc_cont_new"]
-        + f.loc[i, "er_amo_cont_legacy"] + f.loc[i, "er_amo_cont_new"]
+        f.loc[i, "er_nc_cont_legacy"]
+        + f.loc[i, "er_nc_cont_new"]
+        + f.loc[i, "er_amo_cont_legacy"]
+        + f.loc[i, "er_amo_cont_new"]
         + f.loc[i, "solv_cont"]
     )
     if ctx.has_dc:
@@ -273,32 +364,48 @@ def _phase_contributions(f: pd.DataFrame, i: int, ctx: FundingContext) -> None:
 
 def _phase_cash_flow_and_solvency(f: pd.DataFrame, i: int, roa: float) -> None:
     cf_legacy = (
-        f.loc[i, "ee_nc_cont_legacy"] + f.loc[i, "er_nc_cont_legacy"]
-        + f.loc[i, "er_amo_cont_legacy"] - f.loc[i, "ben_payment_legacy"]
-        - f.loc[i, "refund_legacy"] - f.loc[i, "admin_exp_legacy"]
+        f.loc[i, "ee_nc_cont_legacy"]
+        + f.loc[i, "er_nc_cont_legacy"]
+        + f.loc[i, "er_amo_cont_legacy"]
+        - f.loc[i, "ben_payment_legacy"]
+        - f.loc[i, "refund_legacy"]
+        - f.loc[i, "admin_exp_legacy"]
     )
     cf_new = (
-        f.loc[i, "ee_nc_cont_new"] + f.loc[i, "er_nc_cont_new"]
-        + f.loc[i, "er_amo_cont_new"] - f.loc[i, "ben_payment_new"]
-        - f.loc[i, "refund_new"] - f.loc[i, "admin_exp_new"]
+        f.loc[i, "ee_nc_cont_new"]
+        + f.loc[i, "er_nc_cont_new"]
+        + f.loc[i, "er_amo_cont_new"]
+        - f.loc[i, "ben_payment_new"]
+        - f.loc[i, "refund_new"]
+        - f.loc[i, "admin_exp_new"]
     )
 
-    f.loc[i, "solv_cont"] = _solvency_cont(mva_prev=f.loc[i - 1, "total_mva"], cf_total=cf_legacy + cf_new, roa=roa)
+    f.loc[i, "solv_cont"] = _solvency_cont(
+        mva_prev=f.loc[i - 1, "total_mva"], cf_total=cf_legacy + cf_new, roa=roa
+    )
     if f.loc[i, "total_aal"] > 0:
-        f.loc[i, "solv_cont_legacy"] = f.loc[i, "solv_cont"] * f.loc[i, "aal_legacy"] / f.loc[i, "total_aal"]
-        f.loc[i, "solv_cont_new"] = f.loc[i, "solv_cont"] * f.loc[i, "aal_new"] / f.loc[i, "total_aal"]
+        f.loc[i, "solv_cont_legacy"] = (
+            f.loc[i, "solv_cont"] * f.loc[i, "aal_legacy"] / f.loc[i, "total_aal"]
+        )
+        f.loc[i, "solv_cont_new"] = (
+            f.loc[i, "solv_cont"] * f.loc[i, "aal_new"] / f.loc[i, "total_aal"]
+        )
 
     f.loc[i, "net_cf_legacy"] = cf_legacy + f.loc[i, "solv_cont_legacy"]
     f.loc[i, "net_cf_new"] = cf_new + f.loc[i, "solv_cont_new"]
 
 
 def _phase_mva(f: pd.DataFrame, i: int, roa: float) -> None:
-    f.loc[i, "mva_legacy"] = _mva_rollforward(f.loc[i - 1, "mva_legacy"], f.loc[i, "net_cf_legacy"], roa)
+    f.loc[i, "mva_legacy"] = _mva_rollforward(
+        f.loc[i - 1, "mva_legacy"], f.loc[i, "net_cf_legacy"], roa
+    )
     f.loc[i, "mva_new"] = _mva_rollforward(f.loc[i - 1, "mva_new"], f.loc[i, "net_cf_new"], roa)
     f.loc[i, "total_mva"] = f.loc[i, "mva_legacy"] + f.loc[i, "mva_new"]
 
 
-def _phase_liability_gl_and_aal(f: pd.DataFrame, liab: pd.DataFrame, i: int, dr_current: float, dr_new: float) -> None:
+def _phase_liability_gl_and_aal(
+    f: pd.DataFrame, liab: pd.DataFrame, i: int, dr_current: float, dr_new: float
+) -> None:
     f.loc[i, "liability_gain_loss_legacy"] = liab["liability_gain_loss_legacy_est"].iloc[i]
     f.loc[i, "liability_gain_loss_new"] = liab["liability_gain_loss_new_est"].iloc[i]
     f.loc[i, "aal_legacy"] = _aal_rollforward(

--- a/src/pension_model/core/_funding_setup.py
+++ b/src/pension_model/core/_funding_setup.py
@@ -1,13 +1,12 @@
 """Funding-model context and setup helpers."""
 
 from dataclasses import dataclass, field
-from typing import Any, Optional
+from typing import Any
 
 import numpy as np
 import pandas as pd
 
 from pension_model.config_schema import PlanConfig
-from pension_model.core.pipeline_current import _get_pmt
 from pension_model.core._funding_helpers import (
     _get_init_row,
     _populate_calibrated_nc_rates,
@@ -19,6 +18,7 @@ from pension_model.core._funding_strategies import (
     RateComponent,
     StatutoryContributions,
 )
+from pension_model.core.pipeline_current import _get_pmt
 from pension_model.core.returns import build_return_stream
 
 
@@ -28,7 +28,7 @@ class FundingContext:
 
     dr_current: float
     dr_new: float
-    dr_old: Optional[float]
+    dr_old: float | None
     payroll_growth: float
     amo_pay_growth: float
     amo_period_new: int
@@ -42,14 +42,14 @@ class FundingContext:
     class_names: list
     agg_name: str
     has_drop: bool
-    drop_ref_class: Optional[str]
+    drop_ref_class: str | None
     all_classes: list
     builds_aggregate_in_loop: bool
     has_cb: bool
     has_dc: bool
     funding_policy: str
     init_funding: pd.DataFrame
-    amort_layers: Optional[pd.DataFrame]
+    amort_layers: pd.DataFrame | None
     ret_scen: pd.Series = field(default_factory=lambda: pd.Series(dtype=float))
 
 
@@ -96,10 +96,7 @@ def resolve_funding_context(
     # earnings to classes). Class count alone is insufficient: a
     # single-class plan with corridor smoothing still needs the
     # aggregate built up so the allocate-back step has values to read.
-    builds_aggregate_in_loop = (
-        len(class_names) > 1
-        or ava_strategy.aggregation_level == "plan"
-    )
+    builds_aggregate_in_loop = len(class_names) > 1 or ava_strategy.aggregation_level == "plan"
 
     # ``fund.contribution_strategy`` validity is enforced by the
     # Funding schema (Literal["statutory", "actuarial"]); the
@@ -108,8 +105,7 @@ def resolve_funding_context(
     if fund.contribution_strategy == "statutory":
         stat_rates = fund.statutory_rates
         ee_schedule = [
-            {"from_year": e.from_year, "rate": e.rate}
-            for e in stat_rates.ee_rate_schedule
+            {"from_year": e.from_year, "rate": e.rate} for e in stat_rates.ee_rate_schedule
         ]
         cont_strategy = StatutoryContributions(
             funding_policy=fund.policy,
@@ -150,9 +146,7 @@ def resolve_funding_context(
     )
 
 
-def _build_return_stream_for_funding(
-    constants: PlanConfig, ava_strategy
-) -> pd.Series:
+def _build_return_stream_for_funding(constants: PlanConfig, ava_strategy) -> pd.Series:
     """Return stream for the funding model.
 
     Same as :func:`build_return_stream`, except: when the smoothing
@@ -181,10 +175,7 @@ def resolve_er_rate_components(stat_rates) -> list:
     strategy-side ``RateComponent`` via ``model_dump()`` — the field
     shapes match by design.
     """
-    return [
-        RateComponent.from_config(c.model_dump())
-        for c in stat_rates.er_rate_components
-    ]
+    return [RateComponent.from_config(c.model_dump()) for c in stat_rates.er_rate_components]
 
 
 def setup_funding_frames(ctx: FundingContext) -> dict:
@@ -224,7 +215,7 @@ def setup_amort_state(ctx: FundingContext, funding: dict, constants: PlanConfig)
 
             cur_debt = np.zeros((ctx.n_years, max_col + 1))
             if len(init_bal) > 0:
-                cur_debt[0, :len(init_bal)] = init_bal
+                cur_debt[0, : len(init_bal)] = init_bal
             fut_debt = np.zeros((ctx.n_years, max_col + 1))
 
             cur_pay = np.zeros((ctx.n_years, max_col))
@@ -235,7 +226,7 @@ def setup_amort_state(ctx: FundingContext, funding: dict, constants: PlanConfig)
                         dr_old, ctx.amo_pay_growth, int(cur_per[0, j]), cur_debt[0, j], t=0.5
                     )
             if ctx.funding_lag > 0:
-                cur_pay[0, :ctx.funding_lag] = 0
+                cur_pay[0, : ctx.funding_lag] = 0
 
             fut_pay = np.zeros((ctx.n_years, max_col))
             amo_tables[cn] = {
@@ -258,7 +249,7 @@ def setup_amort_state(ctx: FundingContext, funding: dict, constants: PlanConfig)
     n_amo = max(len(amo_seq_current), len(amo_seq_new), amo_period_new + ctx.funding_lag)
 
     amo_per_current_diag = np.zeros((n_years, n_amo))
-    amo_per_current_diag[0, :len(amo_seq_current)] = amo_seq_current
+    amo_per_current_diag[0, : len(amo_seq_current)] = amo_seq_current
     for row in range(1, n_years):
         amo_per_current_diag[row, 0] = amo_seq_new[0] if len(amo_seq_new) > 0 else 0
     for j in range(1, n_amo):
@@ -281,7 +272,11 @@ def setup_amort_state(ctx: FundingContext, funding: dict, constants: PlanConfig)
     debt_current[0, 0] = f.loc[0, "total_ual_ava"]
     if amo_per_current_diag[0, 0] > 0:
         pay_current[0, 0] = _get_pmt(
-            ctx.dr_current, ctx.amo_pay_growth, int(amo_per_current_diag[0, 0]), debt_current[0, 0], t=0.5
+            ctx.dr_current,
+            ctx.amo_pay_growth,
+            int(amo_per_current_diag[0, 0]),
+            debt_current[0, 0],
+            t=0.5,
         )
 
     return {

--- a/src/pension_model/core/_funding_strategies.py
+++ b/src/pension_model/core/_funding_strategies.py
@@ -57,8 +57,8 @@ config author and used only for the output DataFrame's column names.
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
-from typing import ClassVar, Literal, Optional, Protocol, runtime_checkable
+from dataclasses import dataclass
+from typing import ClassVar, Literal, Protocol, runtime_checkable
 
 import pandas as pd
 
@@ -67,7 +67,6 @@ from pension_model.core._funding_helpers import (
     _ava_gain_loss_smoothing,
     _lookup_rate_schedule,
 )
-
 
 # ---------------------------------------------------------------------------
 # AVA smoothing strategies
@@ -388,12 +387,10 @@ class ActuarialContributions:
 
         # Total NC rates
         f.loc[i, "nc_rate_legacy"] = (
-            f.loc[i, "nc_legacy"] / payroll_db_legacy
-            if payroll_db_legacy > 0 else 0
+            f.loc[i, "nc_legacy"] / payroll_db_legacy if payroll_db_legacy > 0 else 0
         )
         f.loc[i, "nc_rate_new"] = (
-            f.loc[i, "nc_new"] / payroll_new_denom
-            if payroll_new_denom > 0 else 0
+            f.loc[i, "nc_new"] / payroll_new_denom if payroll_new_denom > 0 else 0
         )
 
         # Flat EE rate
@@ -408,12 +405,10 @@ class ActuarialContributions:
         cur_pay = amo_state["cur_pay"]
         fut_pay = amo_state["fut_pay"]
         f.loc[i, "amo_rate_legacy"] = (
-            cur_pay[i - 1].sum() / payroll_db_legacy
-            if payroll_db_legacy > 0 else 0
+            cur_pay[i - 1].sum() / payroll_db_legacy if payroll_db_legacy > 0 else 0
         )
         f.loc[i, "amo_rate_new"] = (
-            fut_pay[i - 1].sum() / payroll_new_denom
-            if payroll_new_denom > 0 else 0
+            fut_pay[i - 1].sum() / payroll_new_denom if payroll_new_denom > 0 else 0
         )
 
 
@@ -447,13 +442,13 @@ class RateComponent:
 
     name: str
     payroll_share: float = 1.0
-    schedule: Optional[list] = None
-    initial_rate: Optional[float] = None
-    ramp: Optional[dict] = None
-    start_year: Optional[int] = None
+    schedule: list | None = None
+    initial_rate: float | None = None
+    ramp: dict | None = None
+    start_year: int | None = None
 
     @classmethod
-    def from_config(cls, cfg: dict) -> "RateComponent":
+    def from_config(cls, cfg: dict) -> RateComponent:
         return cls(
             name=cfg["name"],
             payroll_share=float(cfg.get("payroll_share", 1.0)),
@@ -534,8 +529,7 @@ class StatutoryContributions:
         self.ee_schedule = ee_schedule
         # Accept either a list of RateComponent or a list of raw dicts.
         self.components: list[RateComponent] = [
-            c if isinstance(c, RateComponent) else RateComponent.from_config(c)
-            for c in components
+            c if isinstance(c, RateComponent) else RateComponent.from_config(c) for c in components
         ]
 
     def compute_rates(
@@ -550,12 +544,10 @@ class StatutoryContributions:
 
         # Total NC rates
         f.loc[i, "nc_rate_legacy"] = (
-            f.loc[i, "nc_legacy"] / payroll_db_legacy
-            if payroll_db_legacy > 0 else 0
+            f.loc[i, "nc_legacy"] / payroll_db_legacy if payroll_db_legacy > 0 else 0
         )
         f.loc[i, "nc_rate_new"] = (
-            f.loc[i, "nc_new"] / payroll_new_denom
-            if payroll_new_denom > 0 else 0
+            f.loc[i, "nc_new"] / payroll_new_denom if payroll_new_denom > 0 else 0
         )
 
         # EE rate from schedule
@@ -583,18 +575,14 @@ class StatutoryContributions:
             f.loc[i, "amo_rate_legacy"] = (
                 f.loc[i, "er_stat_eff_rate"] - f.loc[i, "er_nc_rate_legacy"]
             )
-            f.loc[i, "amo_rate_new"] = (
-                f.loc[i, "er_stat_eff_rate"] - f.loc[i, "er_nc_rate_new"]
-            )
+            f.loc[i, "amo_rate_new"] = f.loc[i, "er_stat_eff_rate"] - f.loc[i, "er_nc_rate_new"]
         else:
             cur_pay = amo_state["cur_pay"]
             fut_pay = amo_state["fut_pay"]
             total_payroll = f.loc[i, "total_payroll"]
             f.loc[i, "amo_rate_legacy"] = (
-                cur_pay[i - 1].sum() / total_payroll
-                if total_payroll > 0 else 0
+                cur_pay[i - 1].sum() / total_payroll if total_payroll > 0 else 0
             )
             f.loc[i, "amo_rate_new"] = (
-                fut_pay[i - 1].sum() / payroll_new_denom
-                if payroll_new_denom > 0 else 0
+                fut_pay[i - 1].sum() / payroll_new_denom if payroll_new_denom > 0 else 0
             )

--- a/src/pension_model/core/benefit_tables.py
+++ b/src/pension_model/core/benefit_tables.py
@@ -15,16 +15,19 @@ Design for generalization:
 
 import numpy as np
 import pandas as pd
+
 from pension_model.config_schema import EARLY, NORM, VESTED, PlanConfig
 
 try:
     from numba import njit as _njit
 except ImportError:
+
     def _njit(func=None, **kwargs):
         """No-op fallback when numba is not installed."""
         if func is not None:
             return func
         return lambda f: f
+
 
 def _get_salary_growth_col(class_name: str, constants=None) -> str:
     """Resolve salary growth column name for a class.
@@ -42,6 +45,7 @@ def _get_salary_growth_col(class_name: str, constants=None) -> str:
 # ---------------------------------------------------------------------------
 # 1. Salary / headcount table construction
 # ---------------------------------------------------------------------------
+
 
 def _is_long_format(df: pd.DataFrame, value_col: str) -> bool:
     """Check if a DataFrame is already in long format (age, yos, value)."""
@@ -87,10 +91,7 @@ def build_salary_headcount_table(
     sg = sg.rename(columns={growth_col: "salary_increase"})
 
     # Extend to cover all possible yos values (up to max yos in headcount)
-    max_possible_yos = (
-        constants.max_age - constants.min_age
-        if constants is not None else 102
-    )
+    max_possible_yos = constants.max_age - constants.min_age if constants is not None else 102
     if sg["yos"].max() < max_possible_yos:
         extra = pd.DataFrame({"yos": range(sg["yos"].max() + 1, max_possible_yos + 1)})
         sg = pd.concat([sg, extra], ignore_index=True)
@@ -130,7 +131,9 @@ def build_salary_headcount_table(
     merged = merged.merge(sg[["yos", "cumprod_salary_increase"]], on="yos", how="left")
     merged["entry_salary"] = merged["salary"] / merged["cumprod_salary_increase"]
 
-    result = merged[["entry_year", "entry_age", "age", "yos", "count", "entry_salary"]].reset_index(drop=True)
+    result = merged[["entry_year", "entry_age", "age", "yos", "count", "entry_salary"]].reset_index(
+        drop=True
+    )
     result["class_name"] = class_name
     return result
 
@@ -149,14 +152,18 @@ def build_entrant_profile(salary_headcount: pd.DataFrame) -> pd.DataFrame:
     recent = salary_headcount[salary_headcount["entry_year"] == max_year].copy()
     total = recent["count"].sum()
     recent["entrant_dist"] = recent["count"] / total
-    return recent[["entry_age", "entry_salary"]].rename(
-        columns={"entry_salary": "start_sal"}
-    ).assign(entrant_dist=recent["entrant_dist"].values).reset_index(drop=True)
+    return (
+        recent[["entry_age", "entry_salary"]]
+        .rename(columns={"entry_salary": "start_sal"})
+        .assign(entrant_dist=recent["entrant_dist"].values)
+        .reset_index(drop=True)
+    )
 
 
 # ---------------------------------------------------------------------------
 # 2. Salary / benefit table (per cohort: salary, FAS, db_ee_balance)
 # ---------------------------------------------------------------------------
+
 
 def _rolling_mean_lagged(arr: np.ndarray, window: int) -> np.ndarray:
     """
@@ -193,8 +200,9 @@ def _cum_fv(interest_rate: float, contributions: np.ndarray) -> np.ndarray:
     return balance
 
 
-def _cum_fv_vec(interest_vec: np.ndarray, contributions: np.ndarray,
-                first_value: float = 0.0) -> np.ndarray:
+def _cum_fv_vec(
+    interest_vec: np.ndarray, contributions: np.ndarray, first_value: float = 0.0
+) -> np.ndarray:
     """
     Cumulative future value with time-varying interest rates.
 
@@ -219,8 +227,8 @@ def build_salary_benefit_table(
     salary_growth: pd.DataFrame,
     class_name: str,
     constants,
-    actual_icr_series: "Optional[pd.Series]" = None,
-    forward_salary_growth: "Optional[pd.DataFrame]" = None,
+    actual_icr_series: "pd.Series | None" = None,
+    forward_salary_growth: "pd.DataFrame | None" = None,
 ) -> pd.DataFrame:
     """
     Build the salary/benefit table for all cohorts.
@@ -276,8 +284,7 @@ def build_salary_benefit_table(
     entry_ages = np.asarray(entrant_profile["entry_age"].values, dtype=np.int64)
 
     # Vectorized cross product (entry_year, entry_age, yos) → filter term_age <= max_age
-    ey_axis = np.arange(r.entry_year_range.start, r.entry_year_range.stop,
-                        dtype=np.int64)
+    ey_axis = np.arange(r.entry_year_range.start, r.entry_year_range.stop, dtype=np.int64)
     yos_axis = np.arange(0, max_yos + 1, dtype=np.int64)
     mg_ey, mg_ea, mg_yos = np.meshgrid(ey_axis, entry_ages, yos_axis, indexing="ij")
     ey_flat = mg_ey.ravel()
@@ -290,21 +297,28 @@ def build_salary_benefit_table(
     yos_flat = yos_flat[keep]
     term_age_flat = term_age_flat[keep]
 
-    df = pd.DataFrame({
-        "entry_year": ey_flat,
-        "entry_age": ea_flat,
-        "yos": yos_flat,
-        "term_age": term_age_flat,
-    })
+    df = pd.DataFrame(
+        {
+            "entry_year": ey_flat,
+            "entry_age": ea_flat,
+            "yos": yos_flat,
+            "term_age": term_age_flat,
+        }
+    )
 
     # Vectorized tier at term_age (resolve_tiers_vec takes (class, ey, age, yos))
     from pension_model.config_resolvers import resolve_tiers_vec as _resolve_tiers_int
+
     cn_arr = pd.Categorical.from_codes(
         np.zeros(len(df), dtype=np.int8),
         categories=[class_name],
     )
     tier_id_arr, ret_status_arr = _resolve_tiers_int(
-        constants, cn_arr, ey_flat, term_age_flat, yos_flat,
+        constants,
+        cn_arr,
+        ey_flat,
+        term_age_flat,
+        yos_flat,
     )
     df["tier_id"] = tier_id_arr
     df["ret_status"] = ret_status_arr
@@ -332,7 +346,8 @@ def build_salary_benefit_table(
     df["salary"] = np.where(
         df["entry_year"] <= max_hist_year,
         df["entry_salary"] * df["cumprod_salary_increase"],
-        df["start_sal"] * df["cumprod_salary_increase"]
+        df["start_sal"]
+        * df["cumprod_salary_increase"]
         * (1 + econ.payroll_growth) ** (df["entry_year"] - max_hist_year),
     )
 
@@ -345,7 +360,8 @@ def build_salary_benefit_table(
 
     # Compute FAS and db_ee_balance within each (entry_year, entry_age) group.
     # FAS = lagged rolling mean of salary (window = fas_period, NOT including current)
-    # db_ee_balance = cumulative contributions with lag (balance[0]=0, balance[i]=sum of contribs[0..i-1])
+    # db_ee_balance = cumulative contributions, lagged
+    # (balance[0]=0, balance[i]=sum of contribs[0..i-1])
     df = df.sort_values(["entry_year", "entry_age", "yos"]).reset_index(drop=True)
     grp_keys = ["entry_year", "entry_age"]
     g = df.groupby(grp_keys)
@@ -360,7 +376,12 @@ def build_salary_benefit_table(
     for fp in df["fas_period"].unique():
         mask = first_fas == fp
         if mask.any():
-            rolled = sal_shifted.where(mask).groupby([df.loc[mask, c] for c in grp_keys]).rolling(fp, min_periods=1).mean()
+            rolled = (
+                sal_shifted.where(mask)
+                .groupby([df.loc[mask, c] for c in grp_keys])
+                .rolling(fp, min_periods=1)
+                .mean()
+            )
             df.loc[rolled.index.get_level_values(-1), "fas"] = rolled.values
 
     # db_ee_balance: cumsum of lagged contributions with interest
@@ -397,12 +418,12 @@ def build_salary_benefit_table(
             group = group.sort_values("yos")
             cal_years = group["_cal_year"].values
             # Look up actual ICR for each calendar year
-            icr_vals = np.array([actual_icr_series.get(int(y), 0.04)
-                                 for y in cal_years])
+            icr_vals = np.array([actual_icr_series.get(int(y), 0.04) for y in cal_years])
             group["cb_ee_balance"] = _cum_fv_vec(icr_vals, group["cb_ee_cont"].values)
             group["cb_er_balance"] = _cum_fv_vec(icr_vals, group["cb_er_cont"].values)
             group["cb_balance"] = group["cb_ee_balance"] + np.where(
-                group["yos"].values >= cb_vesting, group["cb_er_balance"], 0.0)
+                group["yos"].values >= cb_vesting, group["cb_er_balance"], 0.0
+            )
             return group
 
         cb_parts = []
@@ -414,8 +435,18 @@ def build_salary_benefit_table(
 
     df = df[df["salary"].notna()].copy()
 
-    out_cols = ["entry_year", "entry_age", "yos", "term_age", "tier_id", "ret_status",
-                "salary", "fas", "db_ee_balance", "cumprod_salary_increase"]
+    out_cols = [
+        "entry_year",
+        "entry_age",
+        "yos",
+        "term_age",
+        "tier_id",
+        "ret_status",
+        "salary",
+        "fas",
+        "db_ee_balance",
+        "cumprod_salary_increase",
+    ]
     # Include CB columns if they were computed
     for col in ["cb_ee_cont", "cb_er_cont", "cb_ee_balance", "cb_er_balance", "cb_balance"]:
         if col in df.columns:
@@ -429,6 +460,7 @@ def build_salary_benefit_table(
 # ---------------------------------------------------------------------------
 # 2b. Separation rate table (withdrawal + retirement by tier)
 # ---------------------------------------------------------------------------
+
 
 def build_separation_rate_table(
     term_rate_avg: pd.DataFrame,
@@ -468,11 +500,10 @@ def build_separation_rate_table(
     # Pivot term rates to long format
     term_long = term_rate_avg.melt(id_vars="yos", var_name="age_group", value_name="term_rate")
 
-    entry_ages = set(int(ea) for ea in entrant_profile["entry_age"].values)
+    entry_ages = {int(ea) for ea in entrant_profile["entry_age"].values}
 
     # Vectorized expand_grid: (entry_year, term_age, yos) × filter entry_age in set
-    ey_axis = np.arange(r.entry_year_range.start, r.entry_year_range.stop,
-                        dtype=np.int64)
+    ey_axis = np.arange(r.entry_year_range.start, r.entry_year_range.stop, dtype=np.int64)
     ta_axis = np.arange(r.age_range.start, r.age_range.stop, dtype=np.int64)
     yos_axis = np.arange(r.yos_range.start, r.yos_range.stop, dtype=np.int64)
     mg_ey, mg_ta, mg_yos = np.meshgrid(ey_axis, ta_axis, yos_axis, indexing="ij")
@@ -489,13 +520,15 @@ def build_separation_rate_table(
     ea_flat = ea_flat[keep]
     term_year_flat = ey_flat + yos_flat
 
-    df = pd.DataFrame({
-        "entry_year": ey_flat,
-        "term_age": ta_flat,
-        "yos": yos_flat,
-        "entry_age": ea_flat,
-        "term_year": term_year_flat,
-    })
+    df = pd.DataFrame(
+        {
+            "entry_year": ey_flat,
+            "term_age": ta_flat,
+            "yos": yos_flat,
+            "entry_age": ea_flat,
+            "term_year": term_year_flat,
+        }
+    )
 
     # Assign age groups using pd.cut (matching R's cut())
     df["age_group"] = pd.cut(df["term_age"], bins=breaks, labels=labels, right=True)
@@ -518,9 +551,7 @@ def build_separation_rate_table(
         merge_specs.append((tbl, f"early_retire_rate_{set_name}"))
     for tbl, col_name in merge_specs:
         rate_col = [c for c in tbl.columns if c != "age"][0]
-        sub = tbl[["age", rate_col]].rename(
-            columns={"age": "_ret_age", rate_col: col_name}
-        )
+        sub = tbl[["age", rate_col]].rename(columns={"age": "_ret_age", rate_col: col_name})
         df = df.merge(sub, left_on="term_age", right_on="_ret_age", how="left")
         df = df.drop(columns=["_ret_age"])
 
@@ -533,6 +564,7 @@ def build_separation_rate_table(
 
     # Vectorized tier at term_age
     from pension_model.config_resolvers import resolve_tiers_vec as _resolve_tiers_int
+
     n = len(df)
     cn_arr = pd.Categorical.from_codes(
         np.zeros(n, dtype=np.int8),
@@ -554,9 +586,7 @@ def build_separation_rate_table(
     # fall through to the withdrawal rate.
     is_norm = rs_arr == NORM
     is_early = rs_arr == EARLY
-    rate_set_by_tid = np.array(
-        constants.tier_id_to_retire_rate_set, dtype=object
-    )
+    rate_set_by_tid = np.array(constants.tier_id_to_retire_rate_set, dtype=object)
     rate_set_per_row = rate_set_by_tid[tid_arr]
     sep_rate = df["term_rate"].values.copy()
     for set_name in normal_retire_rate_by_set:
@@ -576,9 +606,19 @@ def build_separation_rate_table(
     df["separation_prob"] = rp_lagged - df["remaining_prob"]
 
     df["class_name"] = class_name
-    return df[["entry_year", "entry_age", "term_age", "yos", "term_year",
-               "separation_rate", "remaining_prob", "separation_prob",
-               "class_name"]].reset_index(drop=True)
+    return df[
+        [
+            "entry_year",
+            "entry_age",
+            "term_age",
+            "yos",
+            "term_year",
+            "separation_rate",
+            "remaining_prob",
+            "separation_prob",
+            "class_name",
+        ]
+    ].reset_index(drop=True)
 
 
 # ---------------------------------------------------------------------------
@@ -667,11 +707,12 @@ def _compute_cb_annuity_metrics(
 
     return surv_icr, ann_factor_acr
 
+
 def build_ann_factor_table(
     salary_benefit_table: pd.DataFrame,
     compact_mortality_by_class: dict,
     constants,
-    expected_icr_by_class: "Optional[dict]" = None,
+    expected_icr_by_class: "dict | None" = None,
 ) -> pd.DataFrame:
     """Build annuity factor table for one or more classes in a single pass.
 
@@ -700,7 +741,11 @@ def build_ann_factor_table(
         when CB is active for any class.
     """
     from pension_model.config_resolvers import (
-        resolve_tiers_vec as _resolve_tiers_int, resolve_cola_vec, EARLY,
+        EARLY,
+        resolve_cola_vec,
+    )
+    from pension_model.config_resolvers import (
+        resolve_tiers_vec as _resolve_tiers_int,
     )
 
     econ = constants.economic
@@ -712,9 +757,9 @@ def build_ann_factor_table(
     # ``salary_benefit_table`` has one row per
     # (class_name, entry_year, entry_age, yos) cohort cell, so an extra
     # ``drop_duplicates`` scan just adds hot-path overhead.
-    cohorts = salary_benefit_table[
-        ["class_name", "entry_year", "entry_age", "yos"]
-    ].reset_index(drop=True)
+    cohorts = salary_benefit_table[["class_name", "entry_year", "entry_age", "yos"]].reset_index(
+        drop=True
+    )
     term_age_c = cohorts["entry_age"].values + cohorts["yos"].values
     cohorts = cohorts[term_age_c <= max_age].reset_index(drop=True)
 
@@ -730,17 +775,16 @@ def build_ann_factor_table(
     ey_arr = np.repeat(cohorts["entry_year"].values, n_per_cohort).astype(np.int64)
     ea_arr = np.repeat(cohorts["entry_age"].values, n_per_cohort).astype(np.int64)
     yos_arr = np.repeat(cohorts["yos"].values, n_per_cohort).astype(np.int64)
-    dist_age_arr = np.concatenate([
-        np.arange(ta, max_age + 1, dtype=np.int64) for ta in term_ages
-    ])
+    dist_age_arr = np.concatenate([np.arange(ta, max_age + 1, dtype=np.int64) for ta in term_ages])
 
     dist_year_arr = ey_arr + dist_age_arr - ea_arr
     term_year_arr = ey_arr + yos_arr
 
     # --- 3. Vectorized tier-at-dist-age resolution (integer) ---
     cn_arr = pd.Categorical.from_codes(class_code_arr, categories=class_labels)
-    tid_da, rs_da = _resolve_tiers_int(constants, cn_arr, ey_arr, dist_age_arr, yos_arr,
-                                        entry_age=ea_arr)
+    tid_da, rs_da = _resolve_tiers_int(
+        constants, cn_arr, ey_arr, dist_age_arr, yos_arr, entry_age=ea_arr
+    )
 
     # --- 4. Discount rate (single value across all current plans) ---
     dr_arr = np.full(len(dist_age_arr), econ.dr_current, dtype=np.float64)
@@ -774,26 +818,28 @@ def build_ann_factor_table(
     ) = _compute_annuity_metrics(mort_arr, dr_arr, cola_arr, n_per_cohort.astype(np.int64))
 
     # --- 8. Assemble DataFrame once, after the heavy array work ---
-    df = pd.DataFrame({
-        "class_name": pd.Categorical.from_codes(class_code_arr, categories=class_labels),
-        "entry_year": ey_arr,
-        "entry_age": ea_arr,
-        "dist_year": dist_year_arr,
-        "dist_age": dist_age_arr,
-        "yos": yos_arr,
-        "term_year": term_year_arr,
-        "mort_final": mort_arr,
-        "tier_id_at_da": tid_da,
-        "ret_status_at_da": rs_da,
-        "dr": dr_arr,
-        "cola": cola_arr,
-        "cum_dr": cum_dr_arr,
-        "cum_mort": cum_mort_arr,
-        "cum_cola": cum_cola_arr,
-        "cum_mort_dr": cum_mort_dr_arr,
-        "cum_mort_dr_cola": cum_mort_dr_cola_arr,
-        "ann_factor": ann_factor_arr,
-    })
+    df = pd.DataFrame(
+        {
+            "class_name": pd.Categorical.from_codes(class_code_arr, categories=class_labels),
+            "entry_year": ey_arr,
+            "entry_age": ea_arr,
+            "dist_year": dist_year_arr,
+            "dist_age": dist_age_arr,
+            "yos": yos_arr,
+            "term_year": term_year_arr,
+            "mort_final": mort_arr,
+            "tier_id_at_da": tid_da,
+            "ret_status_at_da": rs_da,
+            "dr": dr_arr,
+            "cola": cola_arr,
+            "cum_dr": cum_dr_arr,
+            "cum_mort": cum_mort_arr,
+            "cum_cola": cum_cola_arr,
+            "cum_mort_dr": cum_mort_dr_arr,
+            "cum_mort_dr_cola": cum_mort_dr_cola_arr,
+            "ann_factor": ann_factor_arr,
+        }
+    )
 
     # --- 9. CB annuity factors (per class that has CB) ---
     if expected_icr_by_class:
@@ -823,6 +869,7 @@ def build_ann_factor_table(
 # 4. Benefit table (db_benefit, pvfb_db_at_term_age)
 # ---------------------------------------------------------------------------
 
+
 def build_benefit_table(
     ann_factor_table: pd.DataFrame,
     salary_benefit_table: pd.DataFrame,
@@ -849,7 +896,8 @@ def build_benefit_table(
         optionally cb_benefit, pv_cb_benefit added. class_name is preserved.
     """
     from pension_model.config_resolvers import (
-        resolve_ben_mult_vec, resolve_reduce_factor_vec,
+        resolve_ben_mult_vec,
+        resolve_reduce_factor_vec,
     )
 
     cal = constants.benefit.cal_factor
@@ -878,12 +926,12 @@ def build_benefit_table(
 
     # Join salary/benefit data for FAS and db_ee_balance (+ CB columns if present).
     # Join key includes class_name so the merge is stacked-correct.
-    sbt_cols = ["class_name", "entry_year", "entry_age", "yos", "term_age",
-                "fas", "db_ee_balance"]
+    sbt_cols = ["class_name", "entry_year", "entry_age", "yos", "term_age", "fas", "db_ee_balance"]
     has_cb = "cb_balance" in salary_benefit_table.columns
     if has_cb:
-        sbt_cols.extend(["cb_balance", "cb_ee_balance", "cb_er_balance",
-                         "cb_ee_cont", "cb_er_cont"])
+        sbt_cols.extend(
+            ["cb_balance", "cb_ee_balance", "cb_er_balance", "cb_ee_cont", "cb_er_cont"]
+        )
     sbt_values = sbt_cols[5:]
     sbt_filtered = salary_benefit_table.loc[
         salary_benefit_table["term_age"] <= constants.ranges.max_age,
@@ -895,9 +943,8 @@ def build_benefit_table(
     # that contract holds, we can attach salary/FAS data by repeated row take
     # instead of a 7M-row merge. Fall back to the merge if the contract is not
     # met so the function remains correct for plausible future callers.
-    term_row_mask = (
-        df["dist_age"].to_numpy(dtype=np.int64, copy=False)
-        == df["term_age"].to_numpy(dtype=np.int64, copy=False)
+    term_row_mask = df["dist_age"].to_numpy(dtype=np.int64, copy=False) == df["term_age"].to_numpy(
+        dtype=np.int64, copy=False
     )
     ann_term = df.loc[term_row_mask, ["class_name", "entry_year", "entry_age", "yos", "term_age"]]
 
@@ -929,7 +976,11 @@ def build_benefit_table(
         )
 
     if aligned:
-        repeat_counts = constants.ranges.max_age - sbt_filtered["term_age"].to_numpy(dtype=np.int64, copy=False) + 1
+        repeat_counts = (
+            constants.ranges.max_age
+            - sbt_filtered["term_age"].to_numpy(dtype=np.int64, copy=False)
+            + 1
+        )
         lookup_index = np.repeat(np.arange(len(sbt_filtered), dtype=np.int64), repeat_counts)
         for col in sbt_values:
             df[col] = sbt_filtered[col].to_numpy(copy=False)[lookup_index]
@@ -1013,8 +1064,9 @@ def build_benefit_table(
     return df[out_cols]
 
 
-def build_final_benefit_table(benefit_table: pd.DataFrame,
-                              use_earliest_retire: bool = False) -> pd.DataFrame:
+def build_final_benefit_table(
+    benefit_table: pd.DataFrame, use_earliest_retire: bool = False
+) -> pd.DataFrame:
     """
     Determine distribution age and extract final benefit for each cohort.
 
@@ -1039,8 +1091,16 @@ def build_final_benefit_table(benefit_table: pd.DataFrame,
         bt["term_age"] = bt["entry_age"] + bt["yos"]
 
     if len(bt) == 0:
-        out_cols = ["class_name", "entry_year", "entry_age", "term_age", "dist_age",
-                    "db_benefit", "pvfb_db_at_term_age", "ann_factor_term"]
+        out_cols = [
+            "class_name",
+            "entry_year",
+            "entry_age",
+            "term_age",
+            "dist_age",
+            "db_benefit",
+            "pvfb_db_at_term_age",
+            "ann_factor_term",
+        ]
         for col in ["cb_benefit", "pv_cb_benefit", "cb_balance"]:
             if col in bt.columns:
                 out_cols.append(col)
@@ -1102,8 +1162,16 @@ def build_final_benefit_table(benefit_table: pd.DataFrame,
     fbt["db_benefit"] = fbt["db_benefit"].fillna(0)
     fbt["pvfb_db_at_term_age"] = fbt["pvfb_db_at_term_age"].fillna(0)
 
-    out_cols = ["class_name", "entry_year", "entry_age", "term_age", "dist_age",
-                "db_benefit", "pvfb_db_at_term_age", "ann_factor_term"]
+    out_cols = [
+        "class_name",
+        "entry_year",
+        "entry_age",
+        "term_age",
+        "dist_age",
+        "db_benefit",
+        "pvfb_db_at_term_age",
+        "ann_factor_term",
+    ]
     # Pass through CB columns if present
     for col in ["cb_benefit", "pv_cb_benefit", "cb_balance"]:
         if col in fbt.columns:
@@ -1116,6 +1184,7 @@ def build_final_benefit_table(benefit_table: pd.DataFrame,
 # ---------------------------------------------------------------------------
 # 5. Benefit valuation table (PVFB, PVFS, NC)
 # ---------------------------------------------------------------------------
+
 
 @_njit(cache=True)
 def _npv(rate, cashflows):
@@ -1156,7 +1225,7 @@ def _get_pvfb(sep_rate, dr, values):
             lag1_j = sep_rate[i + j - 1]
             # lag2[j]: shift right by 2 → lag2[j] = sr[j-2] if j>=2, else 0
             if j >= 2:
-                cum_surv *= (1.0 - sep_rate[i + j - 2])
+                cum_surv *= 1.0 - sep_rate[i + j - 2]
             sep_prob_j = cum_surv * lag1_j
             val_adj = values[i + j] * sep_prob_j
             total += val_adj / factor
@@ -1197,9 +1266,12 @@ _SEP_TYPE_LABELS = np.array(["non_vested", "vested", "retire"], dtype=object)
 
 
 def _get_pvfb_cb(
-    cb_ee_balance: np.ndarray, cb_ee_cont: np.ndarray,
-    cb_er_balance: np.ndarray, cb_er_cont: np.ndarray,
-    vesting_yos: int, retire_refund_ratio: float,
+    cb_ee_balance: np.ndarray,
+    cb_ee_cont: np.ndarray,
+    cb_er_balance: np.ndarray,
+    cb_er_cont: np.ndarray,
+    vesting_yos: int,
+    retire_refund_ratio: float,
     yos: np.ndarray,
     sep_kind: np.ndarray,
     sep_rate: np.ndarray,
@@ -1252,7 +1324,8 @@ def _get_pvfb_cb(
         # CB wealth by separation type
         sep_slice = sep_kind[i:]
         cb_wealth = np.where(
-            sep_slice == SEP_RETIRE, pv_cb_benefit,
+            sep_slice == SEP_RETIRE,
+            pv_cb_benefit,
             np.where(
                 sep_slice == SEP_VESTED,
                 retire_refund_ratio * pv_cb_benefit + (1 - retire_refund_ratio) * cb_bal_proj,
@@ -1315,8 +1388,8 @@ def build_benefit_val_table(
     benefit_table: pd.DataFrame,
     sep_rate_table: pd.DataFrame,
     constants,
-    expected_icr: "Optional[float]" = None,
-    ann_factor_table: "Optional[pd.DataFrame]" = None,
+    expected_icr: "float | None" = None,
+    ann_factor_table: "pd.DataFrame | None" = None,
 ) -> pd.DataFrame:
     """
     Build benefit valuation table with PVFB, PVFS, and normal cost.
@@ -1345,10 +1418,12 @@ def build_benefit_val_table(
     r = constants.benefit.retire_refund_ratio
     econ = constants.economic
 
-    has_cb = (expected_icr is not None
-              and "cb_balance" in salary_benefit_table.columns
-              and ann_factor_table is not None
-              and "surv_icr" in ann_factor_table.columns)
+    has_cb = (
+        expected_icr is not None
+        and "cb_balance" in salary_benefit_table.columns
+        and ann_factor_table is not None
+        and "surv_icr" in ann_factor_table.columns
+    )
 
     cb_vesting = 5
     if has_cb:
@@ -1361,8 +1436,14 @@ def build_benefit_val_table(
     sbt["term_year"] = sbt["entry_year"] + sbt["yos"]
 
     # Join final_benefit_table on (class_name, entry_year, entry_age, term_age)
-    fbt_cols = ["class_name", "entry_year", "entry_age", "term_age",
-                "db_benefit", "pvfb_db_at_term_age"]
+    fbt_cols = [
+        "class_name",
+        "entry_year",
+        "entry_age",
+        "term_age",
+        "db_benefit",
+        "pvfb_db_at_term_age",
+    ]
     # ``benefit_table`` is already unique on (class_name, entry_year,
     # entry_age, term_age) for current plans, so avoid a redundant scan.
     sbt = sbt.merge(
@@ -1375,16 +1456,14 @@ def build_benefit_val_table(
     # so the sep_rate_table carries class_name matching sbt's class_name.
     sbt = sbt.merge(
         sep_rate_table,
-        on=["class_name", "entry_year", "entry_age", "term_age", "yos",
-            "term_year"],
+        on=["class_name", "entry_year", "entry_age", "term_age", "yos", "term_year"],
         how="left",
     )
 
     ret_status_arr = sbt["ret_status"].to_numpy(dtype=np.int8, copy=False)
     sep_kind_arr = _resolve_sep_kind_vec(ret_status_arr)
     dr_by_tier_id = np.array(
-        [_resolve_econ_rate(econ, k, constants.plan_name)
-         for k in constants.tier_id_to_dr_key],
+        [_resolve_econ_rate(econ, k, constants.plan_name) for k in constants.tier_id_to_dr_key],
         dtype=np.float64,
     )
     dr_arr = dr_by_tier_id[sbt["tier_id"].to_numpy()]
@@ -1393,7 +1472,8 @@ def build_benefit_val_table(
     # Retirees get full annuity PV; vested get retire_refund_ratio-weighted
     # mix of annuity PV and refund (DBEEBalance); non-vested get refund only.
     pvfb_db_wealth_term_arr = np.where(
-        sep_kind_arr == SEP_RETIRE, sbt["pvfb_db_at_term_age"],
+        sep_kind_arr == SEP_RETIRE,
+        sbt["pvfb_db_at_term_age"],
         np.where(
             sep_kind_arr == SEP_VESTED,
             r * sbt["pvfb_db_at_term_age"] + (1 - r) * sbt["db_ee_balance"],
@@ -1478,7 +1558,7 @@ def build_benefit_val_table(
         ann_acr_all = np.nan_to_num(sbt["ann_factor_acr"].to_numpy(dtype=np.float64), nan=0.0)
         ann_adj_all = np.nan_to_num(sbt["ann_factor_adj_dr"].to_numpy(dtype=np.float64), nan=0.0)
 
-    for start, stop in zip(starts, stops):
+    for start, stop in zip(starts, stops, strict=True):
         sep = sep_arr_all[start:stop]
         rp = rp_arr_all[start:stop]
         dr_arr = dr_arr_all[start:stop]
@@ -1535,12 +1615,14 @@ def build_benefit_val_table(
     for col in ["surv_icr", "ann_factor_acr", "ann_factor_adj_dr"]:
         if col in sbt.columns:
             output_cols.append(col)
-    output_cols.extend([
-        "pvfb_db_wealth_at_current_age",
-        "pvfs_at_current_age",
-        "indv_norm_cost",
-        "pvfnc_db",
-    ])
+    output_cols.extend(
+        [
+            "pvfb_db_wealth_at_current_age",
+            "pvfs_at_current_age",
+            "indv_norm_cost",
+            "pvfnc_db",
+        ]
+    )
     for col in ["pvfb_cb_at_current_age", "indv_norm_cost_cb", "pvfnc_cb"]:
         if col in sbt.columns:
             output_cols.append(col)

--- a/src/pension_model/core/calibration.py
+++ b/src/pension_model/core/calibration.py
@@ -13,9 +13,8 @@ The calibration process:
 """
 
 import json
-from dataclasses import dataclass, asdict
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, Optional
 
 import pandas as pd
 
@@ -23,16 +22,18 @@ import pandas as pd
 @dataclass
 class CalibrationTargets:
     """Per-class targets from actuarial valuation report."""
-    val_norm_cost: float       # NC rate from AV
-    val_aal: float             # Total AAL from AV
+
+    val_norm_cost: float  # NC rate from AV
+    val_aal: float  # Total AAL from AV
     # Diagnostic-only targets (not calibrated against, but reported)
-    val_payroll: Optional[float] = None
-    val_benefit_payments: Optional[float] = None
+    val_payroll: float | None = None
+    val_benefit_payments: float | None = None
 
 
 @dataclass
 class CalibrationResult:
     """Computed calibration for a single class."""
+
     nc_cal: float
     pvfb_term_current: float
     # Diagnostics: what the model produced before calibration
@@ -76,10 +77,10 @@ def calibrate_class(
 
 
 def run_calibration(
-    liability_results: Dict[str, pd.DataFrame],
-    targets: Dict[str, CalibrationTargets],
+    liability_results: dict[str, pd.DataFrame],
+    targets: dict[str, CalibrationTargets],
     start_year: int,
-) -> Dict[str, CalibrationResult]:
+) -> dict[str, CalibrationResult]:
     """Compute calibration factors for all classes.
 
     liability_results: output from pipeline runs with neutral calibration.
@@ -94,8 +95,8 @@ def run_calibration(
 
 def load_targets_from_init_funding(
     init_funding: pd.DataFrame,
-    val_norm_costs: Dict[str, float],
-) -> Dict[str, CalibrationTargets]:
+    val_norm_costs: dict[str, float],
+) -> dict[str, CalibrationTargets]:
     """Build calibration targets from init_funding_data.csv and known NC rates.
 
     init_funding: DataFrame with columns 'class', 'total_aal', 'total_payroll', etc.
@@ -112,12 +113,14 @@ def load_targets_from_init_funding(
             val_norm_cost=val_norm_costs[cn],
             val_aal=row["total_aal"],
             val_payroll=row.get("total_payroll"),
-            val_benefit_payments=row.get("total_ben_payment") if "total_ben_payment" in row.index else None,
+            val_benefit_payments=(
+                row.get("total_ben_payment") if "total_ben_payment" in row.index else None
+            ),
         )
     return targets
 
 
-def build_targets_from_config(constants) -> Dict[str, CalibrationTargets]:
+def build_targets_from_config(constants) -> dict[str, CalibrationTargets]:
     """Build calibration targets from plan config's valuation_inputs.
 
     Requires each class entry in valuation_inputs to have at least ``val_norm_cost``
@@ -143,8 +146,8 @@ def build_targets_from_config(constants) -> Dict[str, CalibrationTargets]:
 
 
 def format_diagnostics(
-    results: Dict[str, CalibrationResult],
-    targets: Dict[str, CalibrationTargets],
+    results: dict[str, CalibrationResult],
+    targets: dict[str, CalibrationTargets],
     cal_factor: float,
 ) -> str:
     """Format calibration diagnostics as a human-readable string."""
@@ -171,7 +174,10 @@ def format_diagnostics(
 
     # AAL calibration
     lines.append("  AAL calibration (pvfb_term_current = AV AAL - model AAL):")
-    lines.append(f"  {'Class':20s} {'Model AAL($B)':>14s} {'AV AAL($B)':>14s} {'pvfb_term($B)':>14s} {'Gap%':>8s}")
+    lines.append(
+        f"  {'Class':20s} {'Model AAL($B)':>14s} {'AV AAL($B)':>14s}"
+        f" {'pvfb_term($B)':>14s} {'Gap%':>8s}"
+    )
     lines.append(f"  {'-'*20} {'-'*14} {'-'*14} {'-'*14} {'-'*8}")
     for cn in sorted(results.keys()):
         r = results[cn]
@@ -204,9 +210,9 @@ def format_diagnostics(
 
 
 def format_comparison(
-    results: Dict[str, CalibrationResult],
+    results: dict[str, CalibrationResult],
     existing_path: Path,
-) -> Optional[str]:
+) -> str | None:
     """Compare computed calibration to an existing calibration.json.
 
     Returns formatted comparison string, or None if no existing file.
@@ -215,6 +221,7 @@ def format_comparison(
         return None
 
     import json
+
     with open(existing_path) as f:
         existing = json.load(f)
 
@@ -224,8 +231,10 @@ def format_comparison(
 
     lines = []
     lines.append("  Comparison with existing calibration.json:")
-    lines.append(f"  {'Class':20s} {'nc_cal(new)':>12s} {'nc_cal(old)':>12s} {'diff':>10s}  "
-                 f"{'pvfb(new,$B)':>12s} {'pvfb(old,$B)':>12s} {'diff($M)':>10s}")
+    lines.append(
+        f"  {'Class':20s} {'nc_cal(new)':>12s} {'nc_cal(old)':>12s} {'diff':>10s}  "
+        f"{'pvfb(new,$B)':>12s} {'pvfb(old,$B)':>12s} {'diff($M)':>10s}"
+    )
     lines.append(f"  {'-'*20} {'-'*12} {'-'*12} {'-'*10}  {'-'*12} {'-'*12} {'-'*10}")
 
     for cn in sorted(results.keys()):
@@ -245,7 +254,7 @@ def format_comparison(
 
 def write_calibration_json(
     cal_factor: float,
-    results: Dict[str, CalibrationResult],
+    results: dict[str, CalibrationResult],
     output_path: Path,
 ) -> None:
     """Write computed calibration factors to JSON file."""

--- a/src/pension_model/core/compact_mortality.py
+++ b/src/pension_model/core/compact_mortality.py
@@ -11,9 +11,10 @@ pre-computed 3M-row table. Later, we'll build directly from the raw
 Excel mortality tables.
 """
 
+from pathlib import Path
+
 import numpy as np
 import pandas as pd
-from pathlib import Path
 
 
 class CompactMortality:
@@ -66,8 +67,9 @@ class CompactMortality:
             return grid[ai, yi]
         return 0.0
 
-    def get_rates_vec(self, ages: np.ndarray, years: np.ndarray,
-                      is_retiree: bool = False) -> np.ndarray:
+    def get_rates_vec(
+        self, ages: np.ndarray, years: np.ndarray, is_retiree: bool = False
+    ) -> np.ndarray:
         """Get mortality rates for vectors of (age, year)."""
         grid = self._ret_grid if is_retiree else self._emp_grid
         ai = ages - self._age_offset
@@ -77,9 +79,9 @@ class CompactMortality:
         yi = np.clip(yi, 0, grid.shape[1] - 1)
         return grid[ai, yi]
 
-    def get_survival_discount(self, start_age: int, start_year: int,
-                              end_age: int, dr: float,
-                              is_retiree: bool = False) -> np.ndarray:
+    def get_survival_discount(
+        self, start_age: int, start_year: int, end_age: int, dr: float, is_retiree: bool = False
+    ) -> np.ndarray:
         """
         Compute cumulative survival × discount from start_age to end_age.
 
@@ -117,12 +119,18 @@ def extract_compact_mortality(mort_table_path: Path, class_name: str) -> Compact
     # Split by retirement status
     mort["is_retired"] = mort["tier_at_dist_age"].str.contains("norm|early")
 
-    employee = (mort[~mort["is_retired"]]
-                .groupby(["dist_age", "dist_year"])["mort_final"]
-                .first().reset_index())
+    employee = (
+        mort[~mort["is_retired"]]
+        .groupby(["dist_age", "dist_year"])["mort_final"]
+        .first()
+        .reset_index()
+    )
 
-    retiree = (mort[mort["is_retired"]]
-               .groupby(["dist_age", "dist_year"])["mort_final"]
-               .first().reset_index())
+    retiree = (
+        mort[mort["is_retired"]]
+        .groupby(["dist_age", "dist_year"])["mort_final"]
+        .first()
+        .reset_index()
+    )
 
     return CompactMortality(employee, retiree)

--- a/src/pension_model/core/data_loader.py
+++ b/src/pension_model/core/data_loader.py
@@ -13,12 +13,18 @@ Entry points:
   - load_plan_data(class_name, constants): per-class loader (called
     internally by load_plan_inputs; still available for debugging).
 """
+
 from pathlib import Path
-import pandas as pd
+from typing import TYPE_CHECKING
+
 import numpy as np
+import pandas as pd
 
 from pension_model.config_schema import PlanConfig
 from pension_model.core.returns import build_return_stream
+
+if TYPE_CHECKING:
+    from pension_model.core.compact_mortality import CompactMortality
 
 
 def load_reduction_tables(constants: PlanConfig) -> dict | None:
@@ -127,6 +133,7 @@ def load_plan_data(
         cache=mortality_cache,
     )
     from pension_model.core.mortality_builder import build_ann_factor_retire_table
+
     ann_factor_key = None
     if ann_factor_retire_cache is not None:
         ann_factor_key = (
@@ -141,8 +148,12 @@ def load_plan_data(
         afr = None
     if afr is None:
         afr = build_ann_factor_retire_table(
-            cm, class_name, constants.ranges.start_year, constants.ranges.model_period,
-            constants.economic.dr_current, constants.benefit.cola.current_retire,
+            cm,
+            class_name,
+            constants.ranges.start_year,
+            constants.ranges.model_period,
+            constants.economic.dr_current,
+            constants.benefit.cola.current_retire,
         )
         if ann_factor_retire_cache is not None:
             ann_factor_retire_cache[ann_factor_key] = afr
@@ -180,8 +191,10 @@ def _get_mortality_cache_key(
         table_name,
         constants.ranges.min_age,
         constants.max_age,
-        constants.ranges.start_year + constants.ranges.model_period
-        + constants.max_age - constants.ranges.min_age,
+        constants.ranges.start_year
+        + constants.ranges.model_period
+        + constants.max_age
+        - constants.ranges.min_age,
         constants.male_mp_forward_shift,
     )
 
@@ -205,8 +218,10 @@ def _build_mortality_from_csv(
     max_age = constants.max_age
 
     cm = build_compact_mortality_from_csv(
-        base_path, imp_path,
-        class_name, table_name=table_name,
+        base_path,
+        imp_path,
+        class_name,
+        table_name=table_name,
         min_age=constants.ranges.min_age,
         max_age=max_age,
         max_year=max_year,
@@ -395,12 +410,15 @@ def _build_years_from_nr_decrements(
     # Retirement rates: extract normal and reduced (early) rates
     normal_mask = ret_df["retire_type"] == "normal"
     early_mask = ret_df["retire_type"] == "early"
-    retire_rates = pd.DataFrame({
-        "age": ret_df[normal_mask]["age"].values,
-        "normal_rate": ret_df[normal_mask]["retire_rate"].values,
-    })
+    retire_rates = pd.DataFrame(
+        {
+            "age": ret_df[normal_mask]["age"].values,
+            "normal_rate": ret_df[normal_mask]["retire_rate"].values,
+        }
+    )
     early_rates = ret_df[early_mask][["age", "retire_rate"]].rename(
-        columns={"retire_rate": "reduced_rate"})
+        columns={"retire_rate": "reduced_rate"}
+    )
     retire_rates = retire_rates.merge(early_rates, on="age", how="outer").fillna(0)
 
     # Get entrant profile for entry_ages
@@ -430,8 +448,10 @@ def _build_years_from_nr_decrements(
     statuses = np.empty(len(df), dtype=object)
     for i in range(len(df)):
         tier_names[i], statuses[i] = get_tier(
-            constants, class_name,
-            int(df.iloc[i]["entry_year"]), int(df.iloc[i]["term_age"]),
+            constants,
+            class_name,
+            int(df.iloc[i]["entry_year"]),
+            int(df.iloc[i]["term_age"]),
             int(df.iloc[i]["yos"]),
             entry_age=int(df.iloc[i]["entry_age"]),
         )
@@ -442,18 +462,28 @@ def _build_years_from_nr_decrements(
     df["is_early_retire"] = df["status"] == "early"
 
     # Find years from normal retirement
-    first_normal = df[df["is_normal_retire"]].groupby(
-        ["entry_year", "entry_age"])["term_age"].min().reset_index()
+    first_normal = (
+        df[df["is_normal_retire"]]
+        .groupby(["entry_year", "entry_age"])["term_age"]
+        .min()
+        .reset_index()
+    )
     first_normal = first_normal.rename(columns={"term_age": "first_normal_age"})
     df = df.merge(first_normal, on=["entry_year", "entry_age"], how="left")
     df["first_normal_age"] = df["first_normal_age"].fillna(r.max_age)
     df["years_from_nr"] = (df["first_normal_age"] - df["term_age"]).clip(lower=0).astype(int)
 
     # Join rates
-    df = df.merge(before10[["yos", "term_rate"]].rename(columns={"term_rate": "before10_rate"}),
-                  on="yos", how="left")
-    df = df.merge(after10[["years_from_nr", "term_rate"]].rename(columns={"term_rate": "after10_rate"}),
-                  on="years_from_nr", how="left")
+    df = df.merge(
+        before10[["yos", "term_rate"]].rename(columns={"term_rate": "before10_rate"}),
+        on="yos",
+        how="left",
+    )
+    df = df.merge(
+        after10[["years_from_nr", "term_rate"]].rename(columns={"term_rate": "after10_rate"}),
+        on="years_from_nr",
+        how="left",
+    )
     df = df.merge(retire_rates, left_on="term_age", right_on="age", how="left")
     df = df.drop(columns=["age"], errors="ignore")
 
@@ -461,11 +491,14 @@ def _build_years_from_nr_decrements(
         df[c] = df[c].fillna(0)
 
     df["separation_rate"] = np.where(
-        df["is_normal_retire"], df["normal_rate"],
+        df["is_normal_retire"],
+        df["normal_rate"],
         np.where(
-            df["is_early_retire"], df["reduced_rate"],
+            df["is_early_retire"],
+            df["reduced_rate"],
             np.where(
-                df["yos"] < 10, df["before10_rate"],
+                df["yos"] < 10,
+                df["before10_rate"],
                 df["after10_rate"],
             ),
         ),
@@ -475,16 +508,23 @@ def _build_years_from_nr_decrements(
     df = df.sort_values(["entry_year", "entry_age", "yos"]).reset_index(drop=True)
     grp = df.groupby(["entry_year", "entry_age"])
     sep_lagged = grp["separation_rate"].shift(1, fill_value=0.0)
-    df["remaining_prob"] = (1 - sep_lagged).groupby(
-        [df["entry_year"], df["entry_age"]]).cumprod()
+    df["remaining_prob"] = (1 - sep_lagged).groupby([df["entry_year"], df["entry_age"]]).cumprod()
     rp_lagged = grp["remaining_prob"].shift(1, fill_value=1.0)
     df["separation_prob"] = rp_lagged - df["remaining_prob"]
 
     df["class_name"] = class_name
     inputs["_separation_rate"] = df[
-        ["entry_year", "entry_age", "term_age", "yos", "term_year",
-         "separation_rate", "remaining_prob", "separation_prob",
-         "class_name"]
+        [
+            "entry_year",
+            "entry_age",
+            "term_age",
+            "yos",
+            "term_year",
+            "separation_rate",
+            "remaining_prob",
+            "separation_prob",
+            "class_name",
+        ]
     ].reset_index(drop=True)
 
     # Load reduction tables if they exist
@@ -509,6 +549,7 @@ _DECREMENT_BUILDERS = {
 # ---------------------------------------------------------------------------
 # Plan-wide stacked loader
 # ---------------------------------------------------------------------------
+
 
 def load_plan_inputs(constants: PlanConfig) -> tuple[PlanConfig, dict]:
     """Load stage 3 data for an entire plan.
@@ -579,9 +620,7 @@ def load_plan_inputs(constants: PlanConfig) -> tuple[PlanConfig, dict]:
     data_dir = constants.resolve_data_dir()
     cashflow_path = data_dir / "funding" / "current_term_vested_cashflow.csv"
     cashflow_df = (
-        pd.read_csv(cashflow_path, float_precision="round_trip")
-        if cashflow_path.exists()
-        else None
+        pd.read_csv(cashflow_path, float_precision="round_trip") if cashflow_path.exists() else None
     )
     for cn in classes:
         pvfb = constants.class_data[cn].pvfb_term_current

--- a/src/pension_model/core/funding_model.py
+++ b/src/pension_model/core/funding_model.py
@@ -57,8 +57,11 @@ def load_funding_inputs(funding_dir: Path) -> dict:
 
 
 def build_amort_period_tables(
-    amort_layers: pd.DataFrame, class_name: str,
-    amo_period_new: int, funding_lag: int, model_period: int,
+    amort_layers: pd.DataFrame,
+    class_name: str,
+    amo_period_new: int,
+    funding_lag: int,
+    model_period: int,
 ) -> tuple:
     """
     Build amortization period matrices for current and future hires.
@@ -72,11 +75,15 @@ def build_amort_period_tables(
     # R converts "n/a" to amo_period_new, then groups by period
     class_layers["amo_period"] = pd.to_numeric(
         class_layers["amo_period"].replace("n/a", str(amo_period_new))
-    ).fillna(amo_period_new)  # Also handle numeric NaN from CSV loading
+    ).fillna(
+        amo_period_new
+    )  # Also handle numeric NaN from CSV loading
     # R groups by (class, amo_period) and sums balances
-    class_layers = (class_layers.groupby("amo_period", as_index=False)
-                    .agg({"amo_balance": "sum"})
-                    .sort_values("amo_period", ascending=False))
+    class_layers = (
+        class_layers.groupby("amo_period", as_index=False)
+        .agg({"amo_balance": "sum"})
+        .sort_values("amo_period", ascending=False)
+    )
 
     current_periods_init = class_layers["amo_period"].dropna().values
     # max_col must accommodate all existing layers AND future layers
@@ -90,7 +97,7 @@ def build_amort_period_tables(
 
     # Current hire periods
     current = np.zeros((n_rows, max_col))
-    current[0, :len(current_periods_init)] = current_periods_init
+    current[0, : len(current_periods_init)] = current_periods_init
     future_period = amo_period_new + funding_lag
     for row in range(1, n_rows):
         current[row, 0] = future_period

--- a/src/pension_model/core/icr.py
+++ b/src/pension_model/core/icr.py
@@ -18,8 +18,7 @@ def _geo_return(returns: np.ndarray) -> float:
     return np.prod(1.0 + returns) ** (1.0 / len(returns)) - 1.0
 
 
-def smooth_return(returns: np.ndarray, floor: float, cap: float,
-                  upside_share: float) -> float:
+def smooth_return(returns: np.ndarray, floor: float, cap: float, upside_share: float) -> float:
     """Smoothed ICR: floor + upside_share * max(0, geo_return - floor), capped.
 
     Formula: min(cap, max(floor, floor + upside_share * (geo_return - floor)))
@@ -35,7 +34,7 @@ def _est_arith_return(geo_return: float, sd: float) -> float:
     R's est_arith_return: arith = (1 + geo) * exp(sd^2 / 2) - 1
     Approximation: arith ≈ geo + sd^2 / 2
     """
-    return (1 + geo_return) * np.exp(sd ** 2 / 2) - 1
+    return (1 + geo_return) * np.exp(sd**2 / 2) - 1
 
 
 def compute_expected_icr(
@@ -83,7 +82,7 @@ def compute_expected_icr(
     smooth_rows = total_rows - smooth_period + 1
     smoothed = np.zeros((smooth_rows, n_simulations))
     for i in range(smooth_rows):
-        window = returns_matrix[i:i + smooth_period, :]
+        window = returns_matrix[i : i + smooth_period, :]
         for j in range(n_simulations):
             smoothed[i, j] = smooth_return(window[:, j], floor, cap, upside_share)
 
@@ -141,7 +140,7 @@ def compute_actual_icr_series(
         if i < smooth_period - 1:
             actual_icr[i] = floor
         else:
-            window = inv_returns[i - smooth_period + 1:i + 1]
+            window = inv_returns[i - smooth_period + 1 : i + 1]
             actual_icr[i] = smooth_return(window, floor, cap, upside_share)
 
     return pd.Series(actual_icr, index=year_list)

--- a/src/pension_model/core/identity_checks.py
+++ b/src/pension_model/core/identity_checks.py
@@ -27,10 +27,9 @@ tolerance. Off by default (zero cost on normal runs); enabled via the
 
 from __future__ import annotations
 
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
-from typing import Iterable, Mapping, Optional
 
-import numpy as np
 import pandas as pd
 
 from pension_model.core._funding_helpers import (
@@ -42,10 +41,11 @@ from pension_model.core._funding_helpers import (
 @dataclass
 class IdentityViolation:
     """One residual that exceeded tolerance."""
+
     year_index: int
     class_name: str
-    leg: str            # "legacy" or "new"
-    identity: str       # "mva_rollforward", "aal_rollforward", "nc_dollar"
+    leg: str  # "legacy" or "new"
+    identity: str  # "mva_rollforward", "aal_rollforward", "nc_dollar"
     expected: float
     actual: float
     residual: float
@@ -67,22 +67,21 @@ class IdentityCheckError(AssertionError):
             f"  residual={first.residual!r}",
         ]
         if n > 1:
-            msg_lines.append(
-                f"  (and {n - 1} more — see ``IdentityCheckError.violations``)"
-            )
+            msg_lines.append(f"  (and {n - 1} more — see ``IdentityCheckError.violations``)")
         super().__init__("\n".join(msg_lines))
 
 
 def _within_tol(residual: float, reference: float, tol_rel: float, tol_abs: float) -> bool:
-    return (
-        abs(residual) <= tol_abs
-        or abs(residual) / max(1.0, abs(reference)) <= tol_rel
-    )
+    return abs(residual) <= tol_abs or abs(residual) / max(1.0, abs(reference)) <= tol_rel
 
 
 def _check_mva_leg(
-    f: pd.DataFrame, leg: str, ret_scen: pd.Series, class_name: str,
-    tol_rel: float, tol_abs: float,
+    f: pd.DataFrame,
+    leg: str,
+    ret_scen: pd.Series,
+    class_name: str,
+    tol_rel: float,
+    tol_abs: float,
 ) -> Iterable[IdentityViolation]:
     mva_col = f"mva_{leg}"
     cf_col = f"net_cf_{leg}"
@@ -98,15 +97,23 @@ def _check_mva_leg(
         residual = actual - expected
         if not _within_tol(residual, expected, tol_rel, tol_abs):
             yield IdentityViolation(
-                year_index=i, class_name=class_name, leg=leg,
+                year_index=i,
+                class_name=class_name,
+                leg=leg,
                 identity="mva_rollforward",
-                expected=expected, actual=actual, residual=residual,
+                expected=expected,
+                actual=actual,
+                residual=residual,
             )
 
 
 def _check_aal_leg(
-    f: pd.DataFrame, leg: str, dr: float, class_name: str,
-    tol_rel: float, tol_abs: float,
+    f: pd.DataFrame,
+    leg: str,
+    dr: float,
+    class_name: str,
+    tol_rel: float,
+    tol_abs: float,
 ) -> Iterable[IdentityViolation]:
     aal_col = f"aal_{leg}"
     nc_col = f"nc_{leg}"
@@ -123,22 +130,33 @@ def _check_aal_leg(
     gl = f[gl_col].to_numpy()
     for i in range(1, len(f)):
         expected = _aal_rollforward(
-            aal_prev=aal[i - 1], nc=nc[i], ben=ben[i],
-            refund=refund[i], liab_gl=gl[i], dr=dr,
+            aal_prev=aal[i - 1],
+            nc=nc[i],
+            ben=ben[i],
+            refund=refund[i],
+            liab_gl=gl[i],
+            dr=dr,
         )
         actual = aal[i]
         residual = actual - expected
         if not _within_tol(residual, expected, tol_rel, tol_abs):
             yield IdentityViolation(
-                year_index=i, class_name=class_name, leg=leg,
+                year_index=i,
+                class_name=class_name,
+                leg=leg,
                 identity="aal_rollforward",
-                expected=expected, actual=actual, residual=residual,
+                expected=expected,
+                actual=actual,
+                residual=residual,
             )
 
 
 def _check_nc_dollar(
-    f: pd.DataFrame, class_name: str, has_cb: bool,
-    tol_rel: float, tol_abs: float,
+    f: pd.DataFrame,
+    class_name: str,
+    has_cb: bool,
+    tol_rel: float,
+    tol_abs: float,
 ) -> Iterable[IdentityViolation]:
     """``nc = nc_rate × payroll`` per leg.
 
@@ -147,15 +165,15 @@ def _check_nc_dollar(
     ``nc_new = nc_rate_db_new * payroll_db_new + nc_rate_cb_new * payroll_cb_new``.
     """
     if {"nc_legacy", "nc_rate_db_legacy", "payroll_db_legacy"} <= set(f.columns):
-        legacy_expected = (
-            f["nc_rate_db_legacy"].to_numpy() * f["payroll_db_legacy"].to_numpy()
-        )
+        legacy_expected = f["nc_rate_db_legacy"].to_numpy() * f["payroll_db_legacy"].to_numpy()
         legacy_actual = f["nc_legacy"].to_numpy()
         for i in range(1, len(f)):
             residual = legacy_actual[i] - legacy_expected[i]
             if not _within_tol(residual, legacy_expected[i], tol_rel, tol_abs):
                 yield IdentityViolation(
-                    year_index=i, class_name=class_name, leg="legacy",
+                    year_index=i,
+                    class_name=class_name,
+                    leg="legacy",
                     identity="nc_dollar",
                     expected=float(legacy_expected[i]),
                     actual=float(legacy_actual[i]),
@@ -163,9 +181,7 @@ def _check_nc_dollar(
                 )
 
     if {"nc_new", "nc_rate_db_new", "payroll_db_new"} <= set(f.columns):
-        new_expected = (
-            f["nc_rate_db_new"].to_numpy() * f["payroll_db_new"].to_numpy()
-        )
+        new_expected = f["nc_rate_db_new"].to_numpy() * f["payroll_db_new"].to_numpy()
         if has_cb and {"nc_rate_cb_new", "payroll_cb_new"} <= set(f.columns):
             new_expected = new_expected + (
                 f["nc_rate_cb_new"].to_numpy() * f["payroll_cb_new"].to_numpy()
@@ -175,7 +191,9 @@ def _check_nc_dollar(
             residual = new_actual[i] - new_expected[i]
             if not _within_tol(residual, new_expected[i], tol_rel, tol_abs):
                 yield IdentityViolation(
-                    year_index=i, class_name=class_name, leg="new",
+                    year_index=i,
+                    class_name=class_name,
+                    leg="new",
                     identity="nc_dollar",
                     expected=float(new_expected[i]),
                     actual=float(new_actual[i]),
@@ -190,7 +208,7 @@ def check_funding_identities(
     dr_new: float,
     ret_scen: pd.Series,
     has_cb: bool,
-    skip_classes: Optional[set[str]] = None,
+    skip_classes: set[str] | None = None,
     tol_rel: float = 1e-9,
     tol_abs: float = 1e-3,
 ) -> None:
@@ -236,15 +254,9 @@ def check_funding_identities(
         if "year" not in frame.columns:
             continue
         for leg, dr in (("legacy", dr_current), ("new", dr_new)):
-            violations.extend(
-                _check_mva_leg(frame, leg, ret_scen, class_name, tol_rel, tol_abs)
-            )
-            violations.extend(
-                _check_aal_leg(frame, leg, dr, class_name, tol_rel, tol_abs)
-            )
-        violations.extend(
-            _check_nc_dollar(frame, class_name, has_cb, tol_rel, tol_abs)
-        )
+            violations.extend(_check_mva_leg(frame, leg, ret_scen, class_name, tol_rel, tol_abs))
+            violations.extend(_check_aal_leg(frame, leg, dr, class_name, tol_rel, tol_abs))
+        violations.extend(_check_nc_dollar(frame, class_name, has_cb, tol_rel, tol_abs))
 
     if violations:
         raise IdentityCheckError(violations)

--- a/src/pension_model/core/mortality_builder.py
+++ b/src/pension_model/core/mortality_builder.py
@@ -7,7 +7,8 @@ Produces a CompactMortality object from:
 
 Supports two input formats:
   - Excel: legacy path via _read_base_mort_table / _read_mp_table
-  - CSV: stage 3 format via build_compact_mortality_from_csv (base_rates.csv + improvement_scale.csv)
+  - CSV: stage 3 format via build_compact_mortality_from_csv
+    (base_rates.csv + improvement_scale.csv)
 
 The result is a compact (age, year) → rate lookup for employee and retiree
 mortality, with class-specific base table selection.
@@ -16,16 +17,16 @@ Class → base table mapping is config-driven via ``base_table_map``
 (per-class mapping) or ``mortality.base_table`` (plan-wide default).
 """
 
+from pathlib import Path
+
 import numpy as np
 import pandas as pd
-from pathlib import Path
 
 from pension_model.core.compact_mortality import CompactMortality
 
-
 # Class to base table mapping (R benefit model lines 258-264)
 BASE_TABLE_MAP = {
-    "regular": "regular",        # average of general + teacher
+    "regular": "regular",  # average of general + teacher
     "special": "safety",
     "admin": "safety",
     "eco": "general",
@@ -60,7 +61,7 @@ def _read_base_mort_table(excel_path: Path, sheet_name: str) -> pd.DataFrame:
         raise ValueError(f"Could not find header row with 'Age' in {sheet_name}")
 
     # Extract data below header
-    data = raw.iloc[header_row + 1:].reset_index(drop=True)
+    data = raw.iloc[header_row + 1 :].reset_index(drop=True)
     headers = raw.iloc[header_row].values
 
     # Find the Age columns (there are typically 2: one for female block, one for male)
@@ -72,13 +73,15 @@ def _read_base_mort_table(excel_path: Path, sheet_name: str) -> pd.DataFrame:
         raise ValueError(f"Expected 2 blocks (female/male) in {sheet_name}")
 
     # Female is the first block, Male is the second
-    result = pd.DataFrame({
-        "age": pd.to_numeric(data.iloc[:, age_cols[0]], errors="coerce"),
-        "employee_female": pd.to_numeric(data.iloc[:, emp_cols[0]], errors="coerce"),
-        "healthy_retiree_female": pd.to_numeric(data.iloc[:, ret_cols[0]], errors="coerce"),
-        "employee_male": pd.to_numeric(data.iloc[:, emp_cols[1]], errors="coerce"),
-        "healthy_retiree_male": pd.to_numeric(data.iloc[:, ret_cols[1]], errors="coerce"),
-    })
+    result = pd.DataFrame(
+        {
+            "age": pd.to_numeric(data.iloc[:, age_cols[0]], errors="coerce"),
+            "employee_female": pd.to_numeric(data.iloc[:, emp_cols[0]], errors="coerce"),
+            "healthy_retiree_female": pd.to_numeric(data.iloc[:, ret_cols[0]], errors="coerce"),
+            "employee_male": pd.to_numeric(data.iloc[:, emp_cols[1]], errors="coerce"),
+            "healthy_retiree_male": pd.to_numeric(data.iloc[:, ret_cols[1]], errors="coerce"),
+        }
+    )
 
     result = result.dropna(subset=["age"])
     result["age"] = result["age"].astype(int)
@@ -123,7 +126,9 @@ def _read_mp_table(excel_path: Path, sheet_name: str, min_age: int = 18) -> pd.D
     data.columns = new_cols
 
     # Handle "≤ 20" or "≤20" in age column
-    data["age"] = data["age"].apply(lambda x: 20 if "20" in str(x) and ("≤" in str(x) or "<" in str(x)) else x)
+    data["age"] = data["age"].apply(
+        lambda x: 20 if "20" in str(x) and ("≤" in str(x) or "<" in str(x)) else x
+    )
 
     # Convert all to numeric
     for c in data.columns:
@@ -145,8 +150,9 @@ def _read_mp_table(excel_path: Path, sheet_name: str, min_age: int = 18) -> pd.D
     return data
 
 
-def _build_mp_final(mp_table: pd.DataFrame, gender: str, base_year: int,
-                    min_age: int, max_age: int, max_year: int) -> pd.DataFrame:
+def _build_mp_final(
+    mp_table: pd.DataFrame, gender: str, base_year: int, min_age: int, max_age: int, max_year: int
+) -> pd.DataFrame:
     """
     Build mortality improvement cumulative adjustment factors.
 
@@ -160,7 +166,8 @@ def _build_mp_final(mp_table: pd.DataFrame, gender: str, base_year: int,
     # Ultimate rates = last year's rates
     max_mp_year = mp_long["year"].max()
     mp_ultimate = mp_long[mp_long["year"] == max_mp_year][["age", "mp"]].rename(
-        columns={"mp": "mp_ultimate"})
+        columns={"mp": "mp_ultimate"}
+    )
 
     # Expand to full age × year grid
     ages = range(min_age, max_age + 1)
@@ -172,13 +179,12 @@ def _build_mp_final(mp_table: pd.DataFrame, gender: str, base_year: int,
 
     # Cumulative product within each age group
     grid = grid.sort_values(["age", "year"]).reset_index(drop=True)
-    grid["mp_cumprod_raw"] = grid.groupby("age")["mp_final"].transform(
-        lambda x: (1 - x).cumprod()
-    )
+    grid["mp_cumprod_raw"] = grid.groupby("age")["mp_final"].transform(lambda x: (1 - x).cumprod())
 
     # Adjust: ratio to the base year value
     base_vals = grid[grid["year"] == base_year][["age", "mp_cumprod_raw"]].rename(
-        columns={"mp_cumprod_raw": "base_val"})
+        columns={"mp_cumprod_raw": "base_val"}
+    )
     grid = grid.merge(base_vals, on="age", how="left")
     adj_col = f"{gender}_mp_cumprod_adj"
     grid[adj_col] = grid["mp_cumprod_raw"] / grid["base_val"]
@@ -214,6 +220,7 @@ def build_compact_mortality_from_excel(
     """
     # Read base mortality tables — use config map if available, else fallback map
     from pension_model.config_schema import PlanConfig
+
     if isinstance(constants, PlanConfig) and constants.base_table_map:
         base_type = constants.get_base_table_type(class_name)
     else:
@@ -223,7 +230,12 @@ def build_compact_mortality_from_excel(
         teacher = _read_base_mort_table(pub2010_path, "PubT.H-2010")
         # Regular = average of general and teacher
         base = general.copy()
-        for col in ["employee_female", "employee_male", "healthy_retiree_female", "healthy_retiree_male"]:
+        for col in [
+            "employee_female",
+            "employee_male",
+            "healthy_retiree_female",
+            "healthy_retiree_male",
+        ]:
             base[col] = (general[col] + teacher[col]) / 2
     elif base_type == "safety":
         base = _read_base_mort_table(pub2010_path, "PubS.H-2010")
@@ -247,14 +259,25 @@ def build_compact_mortality_from_excel(
     # Join base rates
     grid = grid.merge(base.rename(columns={"age": "dist_age"}), on="dist_age", how="left")
     # Fill NaN for ages outside base table range
-    for col in ["employee_female", "employee_male", "healthy_retiree_female", "healthy_retiree_male"]:
+    for col in [
+        "employee_female",
+        "employee_male",
+        "healthy_retiree_female",
+        "healthy_retiree_male",
+    ]:
         grid[col] = grid[col].fillna(0)
 
     # Join improvement factors
-    grid = grid.merge(male_mp_final.rename(columns={"age": "dist_age", "year": "dist_year"}),
-                      on=["dist_age", "dist_year"], how="left")
-    grid = grid.merge(female_mp_final.rename(columns={"age": "dist_age", "year": "dist_year"}),
-                      on=["dist_age", "dist_year"], how="left")
+    grid = grid.merge(
+        male_mp_final.rename(columns={"age": "dist_age", "year": "dist_year"}),
+        on=["dist_age", "dist_year"],
+        how="left",
+    )
+    grid = grid.merge(
+        female_mp_final.rename(columns={"age": "dist_age", "year": "dist_year"}),
+        on=["dist_age", "dist_year"],
+        how="left",
+    )
     grid["male_mp_cumprod_adj"] = grid["male_mp_cumprod_adj"].fillna(1.0)
     grid["female_mp_cumprod_adj"] = grid["female_mp_cumprod_adj"].fillna(1.0)
 
@@ -270,9 +293,11 @@ def build_compact_mortality_from_excel(
     ) / 2
 
     employee_rates = grid[["dist_age", "dist_year", "employee_mort"]].rename(
-        columns={"employee_mort": "mort_final"})
+        columns={"employee_mort": "mort_final"}
+    )
     retiree_rates = grid[["dist_age", "dist_year", "retiree_mort"]].rename(
-        columns={"retiree_mort": "mort_final"})
+        columns={"retiree_mort": "mort_final"}
+    )
 
     return CompactMortality(employee_rates, retiree_rates)
 
@@ -293,10 +318,7 @@ def _read_base_mort_csv(csv_path: Path, table_name: str) -> pd.DataFrame:
     ).reset_index()
 
     # Flatten MultiIndex columns: ('employee', 'female') → 'employee_female'
-    result.columns = [
-        f"{mt}_{g}" if g else str(mt)
-        for mt, g in result.columns
-    ]
+    result.columns = [f"{mt}_{g}" if g else str(mt) for mt, g in result.columns]
     # Rename to match expected column names
     rename_map = {
         "retiree_female": "healthy_retiree_female",
@@ -375,6 +397,7 @@ def build_compact_mortality_from_csv(
     """
     # For "regular" base_type: average of general and teacher tables
     from pension_model.config_schema import PlanConfig
+
     if isinstance(constants, PlanConfig) and constants.base_table_map:
         base_type = constants.get_base_table_type(class_name)
     else:
@@ -384,8 +407,12 @@ def build_compact_mortality_from_csv(
         general = _read_base_mort_csv(base_rates_path, "general")
         teacher = _read_base_mort_csv(base_rates_path, "teacher")
         base = general.copy()
-        for col in ["employee_female", "employee_male",
-                     "healthy_retiree_female", "healthy_retiree_male"]:
+        for col in [
+            "employee_female",
+            "employee_male",
+            "healthy_retiree_female",
+            "healthy_retiree_male",
+        ]:
             base[col] = (general[col] + teacher[col]) / 2
     else:
         base = _read_base_mort_csv(base_rates_path, table_name)
@@ -410,20 +437,27 @@ def build_compact_mortality_from_csv(
     # Build final rates (same logic as build_compact_mortality_from_excel)
     ages = range(min_age, max_age + 1)
     years = range(min_year, max_year + 1)
-    grid = pd.DataFrame([(a, y) for a in ages for y in years],
-                        columns=["dist_age", "dist_year"])
+    grid = pd.DataFrame([(a, y) for a in ages for y in years], columns=["dist_age", "dist_year"])
 
     grid = grid.merge(base.rename(columns={"age": "dist_age"}), on="dist_age", how="left")
-    for col in ["employee_female", "employee_male",
-                "healthy_retiree_female", "healthy_retiree_male"]:
+    for col in [
+        "employee_female",
+        "employee_male",
+        "healthy_retiree_female",
+        "healthy_retiree_male",
+    ]:
         grid[col] = grid[col].fillna(0)
 
     grid = grid.merge(
         male_mp_final.rename(columns={"age": "dist_age", "year": "dist_year"}),
-        on=["dist_age", "dist_year"], how="left")
+        on=["dist_age", "dist_year"],
+        how="left",
+    )
     grid = grid.merge(
         female_mp_final.rename(columns={"age": "dist_age", "year": "dist_year"}),
-        on=["dist_age", "dist_year"], how="left")
+        on=["dist_age", "dist_year"],
+        how="left",
+    )
     grid["male_mp_cumprod_adj"] = grid["male_mp_cumprod_adj"].fillna(1.0)
     grid["female_mp_cumprod_adj"] = grid["female_mp_cumprod_adj"].fillna(1.0)
 
@@ -438,12 +472,13 @@ def build_compact_mortality_from_csv(
     ) / 2
 
     employee_rates = grid[["dist_age", "dist_year", "employee_mort"]].rename(
-        columns={"employee_mort": "mort_final"})
+        columns={"employee_mort": "mort_final"}
+    )
     retiree_rates = grid[["dist_age", "dist_year", "retiree_mort"]].rename(
-        columns={"retiree_mort": "mort_final"})
+        columns={"retiree_mort": "mort_final"}
+    )
 
     return CompactMortality(employee_rates, retiree_rates)
-
 
 
 def build_ann_factor_retire_table(
@@ -494,17 +529,19 @@ def build_ann_factor_retire_table(
             age = base_age + k
             year = start_year + k
             if year <= start_year + model_period:
-                rows.append({
-                    "base_age": base_age,
-                    "age": age,
-                    "year": year,
-                    "mort_final": mort[k],
-                    "cola": cola,
-                    "dr": dr,
-                    "cum_mort": cum_mort[k],
-                    "cum_dr": cum_dr[k],
-                    "cum_mort_dr": cum_mort_dr[k],
-                    "ann_factor_retire": ann_factor[k],
-                })
+                rows.append(
+                    {
+                        "base_age": base_age,
+                        "age": age,
+                        "year": year,
+                        "mort_final": mort[k],
+                        "cola": cola,
+                        "dr": dr,
+                        "cum_mort": cum_mort[k],
+                        "cum_dr": cum_dr[k],
+                        "cum_mort_dr": cum_mort_dr[k],
+                        "ann_factor_retire": ann_factor[k],
+                    }
+                )
 
     return pd.DataFrame(rows)

--- a/src/pension_model/core/pipeline.py
+++ b/src/pension_model/core/pipeline.py
@@ -18,24 +18,22 @@ import sys
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
+
 import numpy as np
 import pandas as pd
 
 from pension_model.config_schema import PlanConfig
 from pension_model.core.benefit_tables import (
     _resolve_sep_type_vec,
-    build_salary_headcount_table,
-    build_entrant_profile,
-    build_salary_benefit_table,
-    build_separation_rate_table,
     build_benefit_table,
-    build_final_benefit_table,
     build_benefit_val_table,
+    build_entrant_profile,
+    build_final_benefit_table,
+    build_salary_benefit_table,
+    build_salary_headcount_table,
+    build_separation_rate_table,
 )
-from pension_model.core.runtime_contracts import ClassRuntimeTables
 from pension_model.core.pipeline_current import (
-    _get_pmt,
     compute_current_retiree_liability,
     compute_current_term_vested_liability,
 )
@@ -45,6 +43,7 @@ from pension_model.core.pipeline_projected import (
     compute_retire_liability,
     compute_term_liability,
 )
+from pension_model.core.runtime_contracts import ClassRuntimeTables
 
 
 @dataclass(frozen=True)
@@ -58,13 +57,13 @@ class PreparedPlanRun:
 
     constants: PlanConfig
     inputs_by_class: dict
-    retained_plan_tables: Optional[dict]
+    retained_plan_tables: dict | None
     table_row_counts: dict[str, int]
     runtime_tables_by_class: dict[str, ClassRuntimeTables]
     stage_timings: dict[str, float]
 
     @property
-    def plan_tables(self) -> Optional[dict]:
+    def plan_tables(self) -> dict | None:
         """Backward-compatible alias for retained stacked plan tables."""
         return self.retained_plan_tables
 
@@ -93,8 +92,9 @@ def _mark_stage(stage_timings: dict[str, float], stage_name: str, started_at: fl
     return time.perf_counter()
 
 
-def compute_adjustment_ratio(class_or_inputs, headcount: pd.DataFrame | None = None,
-                             constants: PlanConfig | None = None) -> float:
+def compute_adjustment_ratio(
+    class_or_inputs, headcount: pd.DataFrame | None = None, constants: PlanConfig | None = None
+) -> float:
     """Return a class headcount adjustment ratio.
 
     Preferred path: pass a class input dict prepared by ``load_plan_inputs``,
@@ -243,20 +243,26 @@ def _build_active_benefit_lookup(
     """Build the active-liability lookup keyed by entry year, age, and service."""
     lookup_cols = ["entry_year", "entry_age", "yos", "salary"]
     if "db" in benefit_types:
-        lookup_cols.extend([
-            "pvfb_db_wealth_at_current_age",
-            "pvfnc_db",
-            "indv_norm_cost",
-        ])
+        lookup_cols.extend(
+            [
+                "pvfb_db_wealth_at_current_age",
+                "pvfnc_db",
+                "indv_norm_cost",
+            ]
+        )
     if "cb" in benefit_types and "pvfb_cb_at_current_age" in benefit_val.columns:
-        lookup_cols.extend([
-            "pvfb_cb_at_current_age",
-            "pvfnc_cb",
-            "indv_norm_cost_cb",
-        ])
-    return benefit_val[lookup_cols].drop_duplicates(
-        subset=["entry_year", "entry_age", "yos"]
-    ).reset_index(drop=True)
+        lookup_cols.extend(
+            [
+                "pvfb_cb_at_current_age",
+                "pvfnc_cb",
+                "indv_norm_cost_cb",
+            ]
+        )
+    return (
+        benefit_val[lookup_cols]
+        .drop_duplicates(subset=["entry_year", "entry_age", "yos"])
+        .reset_index(drop=True)
+    )
 
 
 def _build_term_benefit_lookup(benefit_val: pd.DataFrame) -> pd.DataFrame:
@@ -294,9 +300,13 @@ def _build_current_liability_tables(
 
 def _build_term_discount_lookup(term_discount_rows: pd.DataFrame) -> pd.DataFrame:
     """Normalize terminated-vested discount lookup keys to runtime names."""
-    return term_discount_rows[
-        ["entry_age", "entry_year", "dist_age", "dist_year", "term_year", "cum_mort_dr"]
-    ].rename(columns={"dist_age": "age", "dist_year": "year"}).reset_index(drop=True)
+    return (
+        term_discount_rows[
+            ["entry_age", "entry_year", "dist_age", "dist_year", "term_year", "cum_mort_dr"]
+        ]
+        .rename(columns={"dist_age": "age", "dist_year": "year"})
+        .reset_index(drop=True)
+    )
 
 
 def _build_term_liability_lookup(
@@ -318,8 +328,10 @@ def _build_refund_lookup(refund_rows: pd.DataFrame) -> pd.DataFrame:
     lookup_cols = ["entry_age", "entry_year", "dist_age", "dist_year", "term_year", "db_ee_balance"]
     if "cb_balance" in refund_rows.columns:
         lookup_cols.append("cb_balance")
-    return refund_rows[lookup_cols].rename(columns={"dist_age": "age", "dist_year": "year"}).reset_index(
-        drop=True
+    return (
+        refund_rows[lookup_cols]
+        .rename(columns={"dist_age": "age", "dist_year": "year"})
+        .reset_index(drop=True)
     )
 
 
@@ -328,16 +340,20 @@ def _build_retire_benefit_lookup(retire_benefit_rows: pd.DataFrame) -> pd.DataFr
     lookup_cols = ["entry_age", "entry_year", "dist_year", "term_year", "db_benefit", "cola"]
     if "cb_benefit" in retire_benefit_rows.columns:
         lookup_cols.append("cb_benefit")
-    return retire_benefit_rows[lookup_cols].rename(columns={"dist_year": "retire_year"}).reset_index(
-        drop=True
+    return (
+        retire_benefit_rows[lookup_cols]
+        .rename(columns={"dist_year": "retire_year"})
+        .reset_index(drop=True)
     )
 
 
 def _build_retire_annuity_lookup(retire_annuity_rows: pd.DataFrame) -> pd.DataFrame:
     """Normalize retiree-annuity lookup keys to runtime names."""
-    return retire_annuity_rows[
-        ["entry_age", "entry_year", "dist_year", "term_year", "ann_factor"]
-    ].rename(columns={"dist_year": "year"}).reset_index(drop=True)
+    return (
+        retire_annuity_rows[["entry_age", "entry_year", "dist_year", "term_year", "ann_factor"]]
+        .rename(columns={"dist_year": "year"})
+        .reset_index(drop=True)
+    )
 
 
 def _build_benefit_decision_lookup(
@@ -360,7 +376,6 @@ def _build_benefit_decision_lookup(
     decisions["dist_age"] = decisions["dist_age"].fillna(decisions["term_age"]).astype(int)
     decisions = decisions[decisions["ben_decision"].notna()].reset_index(drop=True)
     return decisions[["entry_year", "entry_age", "yos", "term_age", "dist_age", "ben_decision"]]
-
 
 
 def build_plan_benefit_tables(
@@ -446,7 +461,8 @@ def build_plan_benefit_tables(
     )
     benefit = build_benefit_table(ann_factor_full, salary_benefit, constants)
     final_benefit = build_final_benefit_table(
-        benefit, use_earliest_retire=constants.use_earliest_retire,
+        benefit,
+        use_earliest_retire=constants.use_earliest_retire,
     )
 
     # build_benefit_val_table takes a scalar expected_icr. Multi-class CB
@@ -457,8 +473,12 @@ def build_plan_benefit_tables(
     else:
         scalar_icr = None
     benefit_val = build_benefit_val_table(
-        salary_benefit, final_benefit, separation_rate, constants,
-        expected_icr=scalar_icr, ann_factor_table=ann_factor_full,
+        salary_benefit,
+        final_benefit,
+        separation_rate,
+        constants,
+        expected_icr=scalar_icr,
+        ann_factor_table=ann_factor_full,
     )
     ann_factor = _trim_runtime_ann_factor_table(ann_factor_full)
 
@@ -576,18 +596,27 @@ def _project_and_aggregate_class(
     # Initial active population from this class's salary_headcount
     sh = class_tables.salary_headcount
     valid_entry_ages = set(class_tables.entrant_profile["entry_age"].values)
-    initial_active = sh[sh["entry_age"].isin(valid_entry_ages)][
-        ["entry_age", "age", "count"]].rename(columns={"count": "n_active"}).copy()
+    initial_active = (
+        sh[sh["entry_age"].isin(valid_entry_ages)][["entry_age", "age", "count"]]
+        .rename(columns={"count": "n_active"})
+        .copy()
+    )
     initial_active = initial_active[initial_active["n_active"] > 0]
 
     if on_stage:
         on_stage("workforce")
     cm = class_inputs["_compact_mortality"]
     wf = project_workforce(
-        initial_active, class_tables.separation_rate, ben_decisions, cm,
-        class_tables.entrant_profile, class_name,
-        constants.ranges.start_year, constants.ranges.model_period,
-        constants.economic.pop_growth, constants.benefit.retire_refund_ratio,
+        initial_active,
+        class_tables.separation_rate,
+        ben_decisions,
+        cm,
+        class_tables.entrant_profile,
+        class_name,
+        constants.ranges.start_year,
+        constants.ranges.model_period,
+        constants.economic.pop_growth,
+        constants.benefit.retire_refund_ratio,
         no_new_entrants=no_new_entrants,
         constants=constants,
     )
@@ -595,20 +624,30 @@ def _project_and_aggregate_class(
     if on_stage:
         on_stage("liability")
     active = compute_active_liability(
-        wf["wf_active"], class_tables.active_benefit_lookup, class_name, constants)
+        wf["wf_active"], class_tables.active_benefit_lookup, class_name, constants
+    )
     term = compute_term_liability(
-        wf["wf_term"], class_tables.term_liability_lookup,
-        class_name, constants)
+        wf["wf_term"], class_tables.term_liability_lookup, class_name, constants
+    )
     refund = compute_refund_liability(
-        wf["wf_refund"], class_tables.refund_lookup, class_name, constants)
+        wf["wf_refund"], class_tables.refund_lookup, class_name, constants
+    )
     retire = compute_retire_liability(
-        wf["wf_retire"], class_tables.retire_benefit_lookup, class_tables.retire_annuity_lookup,
-        class_name, constants)
+        wf["wf_retire"],
+        class_tables.retire_benefit_lookup,
+        class_tables.retire_annuity_lookup,
+        class_name,
+        constants,
+    )
 
-    years = pd.DataFrame({"year": range(
-        constants.ranges.start_year,
-        constants.ranges.start_year + constants.ranges.model_period + 1,
-    )})
+    years = pd.DataFrame(
+        {
+            "year": range(
+                constants.ranges.start_year,
+                constants.ranges.start_year + constants.ranges.model_period + 1,
+            )
+        }
+    )
     result = _combine_yearly_liability_tables(
         years,
         [
@@ -648,12 +687,11 @@ def _split_plan_tables_by_class(plan_tables: dict, classes: list) -> dict:
                 for cn, g in groups.items()
             }
         else:
-            by_table_then_class[name] = {cn: df for cn in classes}
+            by_table_then_class[name] = dict.fromkeys(classes, df)
 
     result: dict = {}
     for cn in classes:
-        result[cn] = {name: slices.get(cn)
-                      for name, slices in by_table_then_class.items()}
+        result[cn] = {name: slices.get(cn) for name, slices in by_table_then_class.items()}
     return result
 
 
@@ -677,7 +715,9 @@ def _split_runtime_tables_by_class(
                     benefit_types,
                 )
 
-    final_benefit_slices = _split_plan_tables_by_class({"final_benefit": plan_tables["final_benefit"]}, classes)
+    final_benefit_slices = _split_plan_tables_by_class(
+        {"final_benefit": plan_tables["final_benefit"]}, classes
+    )
     for cn in classes:
         runtime_tables[cn]["benefit_decision_lookup"] = _build_benefit_decision_lookup(
             runtime_tables[cn]["benefit_val"],
@@ -687,18 +727,44 @@ def _split_runtime_tables_by_class(
     benefit = plan_tables["benefit"]
     ann_factor = plan_tables["ann_factor"]
 
-    term_discount_cols = ["class_name", "entry_age", "entry_year", "dist_age", "dist_year", "term_year", "cum_mort_dr"]
-    refund_cols = ["class_name", "entry_age", "entry_year", "dist_age", "dist_year", "term_year", "db_ee_balance"]
+    term_discount_cols = [
+        "class_name",
+        "entry_age",
+        "entry_year",
+        "dist_age",
+        "dist_year",
+        "term_year",
+        "cum_mort_dr",
+    ]
+    refund_cols = [
+        "class_name",
+        "entry_age",
+        "entry_year",
+        "dist_age",
+        "dist_year",
+        "term_year",
+        "db_ee_balance",
+    ]
     if "cb_balance" in benefit.columns:
         refund_cols.append("cb_balance")
-    retire_benefit_cols = ["class_name", "entry_age", "entry_year", "dist_year", "term_year", "db_benefit", "cola"]
+    retire_benefit_cols = [
+        "class_name",
+        "entry_age",
+        "entry_year",
+        "dist_year",
+        "term_year",
+        "db_benefit",
+        "cola",
+    ]
     if "cb_benefit" in benefit.columns:
         retire_benefit_cols.append("cb_benefit")
     annuity_cols = ["class_name", "entry_age", "entry_year", "dist_year", "term_year", "ann_factor"]
 
     benefit_term_groups = dict(tuple(benefit[term_discount_cols].groupby("class_name", sort=False)))
     benefit_refund_groups = dict(tuple(benefit[refund_cols].groupby("class_name", sort=False)))
-    benefit_retire_groups = dict(tuple(benefit[retire_benefit_cols].groupby("class_name", sort=False)))
+    benefit_retire_groups = dict(
+        tuple(benefit[retire_benefit_cols].groupby("class_name", sort=False))
+    )
     annuity_groups = dict(tuple(ann_factor[annuity_cols].groupby("class_name", sort=False)))
 
     for cn in classes:
@@ -706,9 +772,7 @@ def _split_runtime_tables_by_class(
             runtime_tables[cn]["benefit_val"],
             benefit_term_groups[cn],
         )
-        runtime_tables[cn]["refund_lookup"] = _build_refund_lookup(
-            benefit_refund_groups[cn]
-        )
+        runtime_tables[cn]["refund_lookup"] = _build_refund_lookup(benefit_refund_groups[cn])
         runtime_tables[cn]["retire_benefit_lookup"] = _build_retire_benefit_lookup(
             benefit_retire_groups[cn]
         )
@@ -768,11 +832,7 @@ def prepare_plan_run(
         on_stage("benefit_tables")
     plan_tables = build_plan_benefit_tables(inputs_by_class, constants)
     started_at = _mark_stage(stage_timings, "build_plan_benefit_tables", started_at)
-    plan_table_rows = {
-        name: len(df)
-        for name, df in plan_tables.items()
-        if hasattr(df, "__len__")
-    }
+    plan_table_rows = {name: len(df) for name, df in plan_tables.items() if hasattr(df, "__len__")}
 
     classes = list(constants.classes)
     runtime_tables_by_class = _split_runtime_tables_by_class(
@@ -823,11 +883,15 @@ def run_prepared_plan_pipeline(
             sys.stdout.write(f"\r    {pct:3d}%")
             sys.stdout.flush()
         liability[cn] = _project_and_aggregate_class(
-            cn, prepared.runtime_tables_by_class[cn], prepared.inputs_by_class[cn], constants,
-            no_new_entrants=no_new_entrants, on_stage=on_stage,
+            cn,
+            prepared.runtime_tables_by_class[cn],
+            prepared.inputs_by_class[cn],
+            constants,
+            no_new_entrants=no_new_entrants,
+            on_stage=on_stage,
         )
     if progress:
-        sys.stdout.write(f"\r    100% done\n")
+        sys.stdout.write("\r    100% done\n")
         sys.stdout.flush()
 
     return liability

--- a/src/pension_model/core/pipeline_current.py
+++ b/src/pension_model/core/pipeline_current.py
@@ -128,13 +128,17 @@ def compute_current_retiree_liability(
 
     projected = pd.concat(projected_groups, ignore_index=True)
 
-    return projected.groupby("year").agg(
-        retire_ben_current_est=("total_ben_current", "sum"),
-        aal_retire_current_est=pd.NamedAgg(
-            "pvfb_retire_current",
-            aggfunc=lambda x: (x * projected.loc[x.index, "n_retire_current"]).sum(),
-        ),
-    ).reset_index()
+    return (
+        projected.groupby("year")
+        .agg(
+            retire_ben_current_est=("total_ben_current", "sum"),
+            aal_retire_current_est=pd.NamedAgg(
+                "pvfb_retire_current",
+                aggfunc=lambda x: (x * projected.loc[x.index, "n_retire_current"]).sum(),
+            ),
+        )
+        .reset_index()
+    )
 
 
 def compute_current_term_vested_liability(

--- a/src/pension_model/core/pipeline_projected.py
+++ b/src/pension_model/core/pipeline_projected.py
@@ -9,7 +9,11 @@ from pension_model.config_schema import PlanConfig
 def _get_bt_columns(bt: str) -> dict:
     """Map benefit type to its column names in benefit_val_table."""
     if bt == "db":
-        return {"pvfb": "pvfb_db_wealth_at_current_age", "pvfnc": "pvfnc_db", "nc": "indv_norm_cost"}
+        return {
+            "pvfb": "pvfb_db_wealth_at_current_age",
+            "pvfnc": "pvfnc_db",
+            "nc": "indv_norm_cost",
+        }
     if bt == "cb":
         return {"pvfb": "pvfb_cb_at_current_age", "pvfnc": "pvfnc_cb", "nc": "indv_norm_cost_cb"}
     return {"pvfb": None, "pvfnc": None, "nc": None}
@@ -35,7 +39,8 @@ def _allocate_members(wf, benefit_types, design_ratios, legs, design_cutoff_year
     for bt in benefit_types:
         before, after, new = design_ratios[bt]
         wf[f"n_{bt}_{legacy_name}"] = np.where(
-            ey < cutoff, np.where(ey < design_cutoff_year, n * before, n * after), 0.0)
+            ey < cutoff, np.where(ey < design_cutoff_year, n * before, n * after), 0.0
+        )
         wf[f"n_{bt}_{new_name}"] = np.where(ey < cutoff, 0.0, n * new)
     return wf
 
@@ -45,7 +50,9 @@ def _get_design_ratios(constants: PlanConfig, class_name: str):
     return constants.get_design_ratios(class_name), list(constants.benefit_types)
 
 
-def _filter_lookup_to_runtime(lookup: pd.DataFrame, wf: pd.DataFrame, columns: list[str]) -> pd.DataFrame:
+def _filter_lookup_to_runtime(
+    lookup: pd.DataFrame, wf: pd.DataFrame, columns: list[str]
+) -> pd.DataFrame:
     """Trim a prepared lookup to the runtime year slices actually used."""
     if lookup.empty or wf.empty:
         return lookup
@@ -71,13 +78,15 @@ def _allocate_term(wf, pop_col, design_ratios, benefit_types, legs, design_cutof
     for bt in benefit_types:
         before, after, new = design_ratios[bt]
         wf[f"n_{base}_{bt}_{legacy_name}"] = np.where(
-            ey < cutoff, np.where(ey < design_cutoff_year, n * before, n * after), 0.0)
+            ey < cutoff, np.where(ey < design_cutoff_year, n * before, n * after), 0.0
+        )
         wf[f"n_{base}_{bt}_{new_name}"] = np.where(ey < cutoff, 0.0, n * new)
     return wf
 
 
-def compute_active_liability(wf_active: pd.DataFrame, active_benefit_lookup: pd.DataFrame,
-                             class_name: str, constants) -> pd.DataFrame:
+def compute_active_liability(
+    wf_active: pd.DataFrame, active_benefit_lookup: pd.DataFrame, class_name: str, constants
+) -> pd.DataFrame:
     """Compute active member liability by year."""
     r = constants.ranges
     design_cutoff = constants.plan_design_cutoff_year or r.new_year
@@ -133,7 +142,8 @@ def compute_active_liability(wf_active: pd.DataFrame, active_benefit_lookup: pd.
             payroll_arr = result[pay_col].values
             nc_num = result[f"_nc_num_{bt}_{period}"].values
             result[f"nc_rate_{bt}_{period}_est"] = np.divide(
-                nc_num, payroll_arr, out=np.zeros_like(payroll_arr), where=payroll_arr != 0)
+                nc_num, payroll_arr, out=np.zeros_like(payroll_arr), where=payroll_arr != 0
+            )
 
             pvfb_col = f"pvfb_active_{bt}_{period}_est"
             pvfnc_col = f"pvfnc_{bt}_{period}_est"
@@ -142,20 +152,27 @@ def compute_active_liability(wf_active: pd.DataFrame, active_benefit_lookup: pd.
             result = result.drop(columns=[f"_nc_num_{bt}_{period}"])
 
     if "payroll_db_legacy_est" in result.columns:
-        result["payroll_db_est"] = result["payroll_db_legacy_est"] + result.get("payroll_db_new_est", 0)
+        result["payroll_db_est"] = result["payroll_db_legacy_est"] + result.get(
+            "payroll_db_new_est", 0
+        )
 
     return result
 
 
-def compute_term_liability(wf_term: pd.DataFrame, term_liability_lookup: pd.DataFrame,
-                           class_name: str,
-                           constants: PlanConfig) -> pd.DataFrame:
+def compute_term_liability(
+    wf_term: pd.DataFrame,
+    term_liability_lookup: pd.DataFrame,
+    class_name: str,
+    constants: PlanConfig,
+) -> pd.DataFrame:
     """Compute projected terminated vested liability by year."""
     r = constants.ranges
     design_ratios, benefit_types = _get_design_ratios(constants, class_name)
     design_cutoff = constants.plan_design_cutoff_year or r.new_year
 
-    wf = wf_term[(wf_term["year"] <= r.start_year + r.model_period) & (wf_term["n_term"] > 0)].copy()
+    wf = wf_term[
+        (wf_term["year"] <= r.start_year + r.model_period) & (wf_term["n_term"] > 0)
+    ].copy()
     wf["entry_year"] = wf["year"] - (wf["age"] - wf["entry_age"])
     term_liability_lookup = _filter_lookup_to_runtime(
         term_liability_lookup,
@@ -170,7 +187,9 @@ def compute_term_liability(wf_term: pd.DataFrame, term_liability_lookup: pd.Data
     )
 
     wf["pvfb_db_term"] = wf["pvfb_db_at_term_age"] / wf["cum_mort_dr"]
-    wf = _allocate_term(wf, "n_term", design_ratios, benefit_types, constants.funding_legs, design_cutoff)
+    wf = _allocate_term(
+        wf, "n_term", design_ratios, benefit_types, constants.funding_legs, design_cutoff
+    )
     sum_cols = []
     for bt in benefit_types:
         if bt == "dc":
@@ -187,14 +206,17 @@ def compute_term_liability(wf_term: pd.DataFrame, term_liability_lookup: pd.Data
     return wf.groupby("year", as_index=False)[sum_cols].sum()
 
 
-def compute_refund_liability(wf_refund: pd.DataFrame, refund_lookup: pd.DataFrame,
-                             class_name: str, constants: PlanConfig) -> pd.DataFrame:
+def compute_refund_liability(
+    wf_refund: pd.DataFrame, refund_lookup: pd.DataFrame, class_name: str, constants: PlanConfig
+) -> pd.DataFrame:
     """Compute refund liability by year."""
     r = constants.ranges
     design_ratios, benefit_types = _get_design_ratios(constants, class_name)
     design_cutoff = constants.plan_design_cutoff_year or r.new_year
 
-    wf = wf_refund[(wf_refund["year"] <= r.start_year + r.model_period) & (wf_refund["n_refund"] > 0)].copy()
+    wf = wf_refund[
+        (wf_refund["year"] <= r.start_year + r.model_period) & (wf_refund["n_refund"] > 0)
+    ].copy()
     wf["entry_year"] = wf["year"] - (wf["age"] - wf["entry_age"])
     refund_lookup = _filter_lookup_to_runtime(
         refund_lookup,
@@ -209,7 +231,9 @@ def compute_refund_liability(wf_refund: pd.DataFrame, refund_lookup: pd.DataFram
         how="left",
     )
 
-    wf = _allocate_term(wf, "n_refund", design_ratios, benefit_types, constants.funding_legs, design_cutoff)
+    wf = _allocate_term(
+        wf, "n_refund", design_ratios, benefit_types, constants.funding_legs, design_cutoff
+    )
     sum_cols = []
     for bt in benefit_types:
         if bt == "dc":
@@ -227,9 +251,13 @@ def compute_refund_liability(wf_refund: pd.DataFrame, refund_lookup: pd.DataFram
     return wf.groupby("year", as_index=False)[sum_cols].sum()
 
 
-def compute_retire_liability(wf_retire: pd.DataFrame, retire_benefit_lookup: pd.DataFrame,
-                             retire_annuity_lookup: pd.DataFrame, class_name: str,
-                             constants: PlanConfig) -> pd.DataFrame:
+def compute_retire_liability(
+    wf_retire: pd.DataFrame,
+    retire_benefit_lookup: pd.DataFrame,
+    retire_annuity_lookup: pd.DataFrame,
+    class_name: str,
+    constants: PlanConfig,
+) -> pd.DataFrame:
     """Compute projected retiree liability by year."""
     r = constants.ranges
     design_ratios, benefit_types = _get_design_ratios(constants, class_name)
@@ -265,10 +293,14 @@ def compute_retire_liability(wf_retire: pd.DataFrame, retire_benefit_lookup: pd.
     wf["pvfb_db_retire"] = wf["db_benefit_final"] * (wf["ann_factor"] - 1)
 
     if has_cb_ben:
-        wf["cb_benefit_final"] = wf["cb_benefit"] * (1 + wf["cola"]) ** (wf["year"] - wf["retire_year"])
+        wf["cb_benefit_final"] = wf["cb_benefit"] * (1 + wf["cola"]) ** (
+            wf["year"] - wf["retire_year"]
+        )
         wf["pvfb_cb_retire"] = wf["cb_benefit_final"] * (wf["ann_factor"] - 1)
 
-    wf = _allocate_term(wf, "n_retire", design_ratios, benefit_types, constants.funding_legs, design_cutoff)
+    wf = _allocate_term(
+        wf, "n_retire", design_ratios, benefit_types, constants.funding_legs, design_cutoff
+    )
     sum_cols = []
     for bt in benefit_types:
         if bt == "dc":

--- a/src/pension_model/core/profiling.py
+++ b/src/pension_model/core/profiling.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import json
-import tracemalloc
 import time
+import tracemalloc
 from dataclasses import dataclass
 from pathlib import Path
 from statistics import median
@@ -97,7 +97,9 @@ def summarize_runtime_samples(samples: list[dict]) -> dict:
         "liability_timing": float(median(sample["liability_timing"] for sample in samples)),
         "funding_timing": _median_or_none([sample["funding_timing"] for sample in samples]),
         "prepare_peak_bytes": _median_or_none([sample["prepare_peak_bytes"] for sample in samples]),
-        "liability_peak_bytes": _median_or_none([sample["liability_peak_bytes"] for sample in samples]),
+        "liability_peak_bytes": _median_or_none(
+            [sample["liability_peak_bytes"] for sample in samples]
+        ),
         "funding_peak_bytes": _median_or_none([sample["funding_peak_bytes"] for sample in samples]),
     }
 

--- a/src/pension_model/core/runtime_contracts.py
+++ b/src/pension_model/core/runtime_contracts.py
@@ -43,7 +43,4 @@ class ClassRuntimeTables:
 
     def row_counts(self) -> dict[str, int]:
         """Return row counts for the contained runtime tables."""
-        return {
-            name: len(frame)
-            for name, frame in self.as_dict().items()
-        }
+        return {name: len(frame) for name, frame in self.as_dict().items()}

--- a/src/pension_model/core/workforce.py
+++ b/src/pension_model/core/workforce.py
@@ -15,6 +15,7 @@ R's flow each year:
 import numpy as np
 import pandas as pd
 
+
 def project_workforce(
     initial_active: pd.DataFrame,
     separation_rates: pd.DataFrame,
@@ -68,8 +69,11 @@ def project_workforce(
     if len(separation_rates) > 0:
         sr = separation_rates
         ea_vals = sr["entry_age"].values.astype(int)
-        ta_vals = sr["term_age"].values.astype(int) if "term_age" in sr.columns else (
-            ea_vals + sr["yos"].values.astype(int))
+        ta_vals = (
+            sr["term_age"].values.astype(int)
+            if "term_age" in sr.columns
+            else (ea_vals + sr["yos"].values.astype(int))
+        )
         ey_vals = sr["entry_year"].values.astype(int)
         sr_vals = sr["separation_rate"].values.astype(float)
         yr_vals = ey_vals + (ta_vals - ea_vals)
@@ -79,14 +83,16 @@ def project_workforce(
         ta_idx = ta_vals - min_age  # age_to_idx is contiguous from min_age
         yr_idx = yr_vals - start_year
 
-        valid = ((ea_idx >= 0) & (ta_idx >= 0) & (ta_idx < n_ages)
-                 & (yr_idx >= 0) & (yr_idx < n_years))
+        valid = (
+            (ea_idx >= 0) & (ta_idx >= 0) & (ta_idx < n_ages) & (yr_idx >= 0) & (yr_idx < n_years)
+        )
         sr_clean = np.where(np.isnan(sr_vals), 0.0, sr_vals)
         sep_lookup[ea_idx[valid], ta_idx[valid], yr_idx[valid]] = sr_clean[valid]
 
     # Build benefit decision lookups as numpy-indexed arrays.
     # refund_prob_arr[entry_age_idx, term_age_idx, term_year_idx] -> refund probability
-    # retire_prob_arr[term_year_idx, entry_age_idx, dist_age_idx, dist_year_idx] -> retire probability
+    # retire_prob_arr[term_year_idx, entry_age_idx, dist_age_idx, dist_year_idx]
+    #   -> retire probability
     refund_prob_arr = np.zeros((n_entry, n_ages, n_years))
     retire_prob_arr = np.zeros((n_years, n_entry, n_ages, n_years))
 
@@ -94,8 +100,11 @@ def project_workforce(
         bd = benefit_decisions
         bd_ey = bd["entry_year"].values.astype(int)
         bd_ea = bd["entry_age"].values.astype(int)
-        bd_ta = bd["term_age"].values.astype(int) if "term_age" in bd.columns else (
-            bd_ea + bd["yos"].values.astype(int))
+        bd_ta = (
+            bd["term_age"].values.astype(int)
+            if "term_age" in bd.columns
+            else (bd_ea + bd["yos"].values.astype(int))
+        )
         bd_da = bd["dist_age"].values.astype(int) if "dist_age" in bd.columns else bd_ta
         bd_dec = bd["ben_decision"].values
         bd_yos = bd["yos"].values.astype(int) if "yos" in bd.columns else (bd_ta - bd_ea)
@@ -125,7 +134,9 @@ def project_workforce(
             bd_ei[valid_refund & is_mix],
             bd_ta_idx[valid_refund & is_mix],
             bd_ty_idx[valid_refund & is_mix],
-        ] = 1 - retire_refund_ratio
+        ] = (
+            1 - retire_refund_ratio
+        )
 
         valid_retire = (
             (bd_ei >= 0)
@@ -205,7 +216,8 @@ def project_workforce(
     # Deferred vested members use employee mortality until they reach a
     # retirement-eligible tier (norm/early), then switch to retiree mortality.
     # We batch-resolve tiers per term stock using resolve_tiers_vec.
-    from pension_model.config_resolvers import resolve_tiers_vec as _resolve_tiers_vec, EARLY
+    from pension_model.config_resolvers import EARLY
+    from pension_model.config_resolvers import resolve_tiers_vec as _resolve_tiers_vec
 
     ea_arr_int = np.array(entry_ages, dtype=np.int64)
 
@@ -237,7 +249,7 @@ def project_workforce(
         store["age"].append(cur_ages)
         store["year"].append(year_arr)
         for col_name, col_value in extra_cols:
-            if isinstance(col_value, (int, np.integer)):
+            if isinstance(col_value, int | np.integer):
                 store[col_name].append(np.full(n, col_value, dtype=np.int64))
             else:
                 store[col_name].append(np.asarray(col_value))
@@ -314,7 +326,11 @@ def project_workforce(
             if constants is not None:
                 cn_arr = np.full(len(nz_ei), class_name, dtype=object)
                 _, ret_status = _resolve_tiers_vec(
-                    constants, cn_arr, entry_yr, nz_age, yos_at_term,
+                    constants,
+                    cn_arr,
+                    entry_yr,
+                    nz_age,
+                    yos_at_term,
                 )
                 is_ret = ret_status >= EARLY
             else:

--- a/src/pension_model/output_uniformity.py
+++ b/src/pension_model/output_uniformity.py
@@ -22,7 +22,7 @@ populate every column.
 
 from __future__ import annotations
 
-from typing import Iterable, Sequence
+from collections.abc import Iterable, Sequence
 
 import pandas as pd
 
@@ -35,9 +35,7 @@ def _missing_columns(df: pd.DataFrame, expected: Sequence[str]) -> list[str]:
     return [c for c in expected if c not in df.columns]
 
 
-def _columns_with_any_nan(
-    df: pd.DataFrame, columns: Iterable[str]
-) -> dict[str, list[int]]:
+def _columns_with_any_nan(df: pd.DataFrame, columns: Iterable[str]) -> dict[str, list[int]]:
     """Return ``{column: [row_indices_with_nan]}`` for columns containing NaN."""
     out: dict[str, list[int]] = {}
     for col in columns:
@@ -47,9 +45,7 @@ def _columns_with_any_nan(
     return out
 
 
-def _columns_not_all_nan(
-    df: pd.DataFrame, columns: Iterable[str]
-) -> list[str]:
+def _columns_not_all_nan(df: pd.DataFrame, columns: Iterable[str]) -> list[str]:
     return [col for col in columns if not df[col].isna().all()]
 
 
@@ -85,8 +81,7 @@ def assert_output_uniformity(
     missing = _missing_columns(df, canonical_columns)
     if missing:
         raise OutputUniformityError(
-            f"[{plan_name} {output_name}] missing canonical columns: "
-            f"{missing}"
+            f"[{plan_name} {output_name}] missing canonical columns: " f"{missing}"
         )
 
     inapplicable_set = set(inapplicable)

--- a/src/pension_model/plan_config.py
+++ b/src/pension_model/plan_config.py
@@ -24,7 +24,6 @@ from pension_model.config_resolvers import (
 )
 from pension_model.config_schema import EARLY, NON_VESTED, NORM, VESTED, PlanConfig
 
-
 __all__ = [
     "EARLY",
     "NON_VESTED",

--- a/src/pension_model/runners.py
+++ b/src/pension_model/runners.py
@@ -9,21 +9,19 @@ diagnostic scripts each go through here.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Optional
 
 import pandas as pd
-
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 
 
-def _scenario_path(scenario: Optional[str]) -> Optional[Path]:
+def _scenario_path(scenario: str | None) -> Path | None:
     if scenario is None or scenario == "baseline":
         return None
     return PROJECT_ROOT / "scenarios" / f"{scenario}.json"
 
 
-def run_truth_table(plan: str, scenario: Optional[str] = None) -> pd.DataFrame:
+def run_truth_table(plan: str, scenario: str | None = None) -> pd.DataFrame:
     """Run the full pipeline for ``(plan, scenario)`` and return its truth table.
 
     ``scenario=None`` and ``scenario="baseline"`` both mean "no scenario

--- a/src/pension_model/schemas/__init__.py
+++ b/src/pension_model/schemas/__init__.py
@@ -40,8 +40,8 @@ from pension_model.schemas.early_retire_reduction import (
     EarlyRetireRule,
     ReduceCondition,
 )
-from pension_model.schemas.eligibility import EligibilitySpec
 from pension_model.schemas.economic import Economic
+from pension_model.schemas.eligibility import EligibilitySpec
 from pension_model.schemas.funding import (
     AvaSmoothing,
     CorridorAvaSmoothing,
@@ -59,8 +59,8 @@ from pension_model.schemas.grandfathered import (
 )
 from pension_model.schemas.modeling import AgeGroup, Modeling
 from pension_model.schemas.mortality import MortalitySpec
-from pension_model.schemas.plan_design import PlanDesign, PlanDesignRatios
 from pension_model.schemas.partial import partial_model
+from pension_model.schemas.plan_design import PlanDesign, PlanDesignRatios
 from pension_model.schemas.ranges import Ranges
 from pension_model.schemas.term_vested import TermVested
 
@@ -71,7 +71,6 @@ from pension_model.schemas.term_vested import TermVested
 # directly from ``pension_model.schemas.scenario`` instead.
 from pension_model.schemas.tier import Tier, validate_tier_cross_references
 from pension_model.schemas.valuation_inputs import ClassData, ValuationInputs
-
 
 __all__ = [
     "AgeGroup",

--- a/src/pension_model/schemas/benefit.py
+++ b/src/pension_model/schemas/benefit.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Optional
-
 from pydantic import ConfigDict, Field
 
 from pension_model.schemas.base import StrictModel
@@ -36,7 +34,7 @@ class Cola(StrictModel):
     current_retire: float = 0.0
     current_retire_one_time: float = 0.0
     one_time_cola: bool = False
-    proration_cutoff_year: Optional[int] = None
+    proration_cutoff_year: int | None = None
 
 
 class CashBalance(StrictModel):
@@ -74,11 +72,11 @@ class Benefit(StrictModel):
     db_ee_interest_rate: float = 0.0
     retire_refund_ratio: float = 1.0
     fas_years_default: int
-    fas_years_grandfathered: Optional[int] = Field(
+    fas_years_grandfathered: int | None = Field(
         default=None,
         description="Override fas_years for grandfathered tiers (TXTRS).",
     )
-    min_benefit_monthly: Optional[float] = Field(
+    min_benefit_monthly: float | None = Field(
         default=None,
         description="Floor on monthly benefit at retirement (TXTRS).",
     )
@@ -89,5 +87,5 @@ class Benefit(StrictModel):
     )
     benefit_types: list[str] = Field(default_factory=lambda: ["db"])
     cola: Cola = Field(default_factory=Cola)
-    cash_balance: Optional[CashBalance] = None
-    dc: Optional[DcSpec] = None
+    cash_balance: CashBalance | None = None
+    dc: DcSpec | None = None

--- a/src/pension_model/schemas/benefit_multipliers.py
+++ b/src/pension_model/schemas/benefit_multipliers.py
@@ -18,8 +18,6 @@ promotes the raw extras to typed sub-models at parse time.
 
 from __future__ import annotations
 
-from typing import Optional, Union
-
 from pydantic import ConfigDict, Field, model_validator
 
 from pension_model.schemas.base import StrictModel
@@ -60,13 +58,13 @@ class MultiplierRules(StrictModel):
     ``status == "early"`` and no graded entry matched.
     """
 
-    flat: Optional[float] = None
-    flat_before_year: Optional[FlatBeforeYear] = None
-    graded: Optional[list[GradedRule]] = None
-    early_fallback: Optional[float] = None
+    flat: float | None = None
+    flat_before_year: FlatBeforeYear | None = None
+    graded: list[GradedRule] | None = None
+    early_fallback: float | None = None
 
     @model_validator(mode="after")
-    def _check_primary_rule(self) -> "MultiplierRules":
+    def _check_primary_rule(self) -> MultiplierRules:
         if self.flat is None and self.graded is None:
             raise ValueError(
                 "MultiplierRules: must declare either 'flat' or 'graded' "
@@ -79,14 +77,13 @@ class MultiplierRules(StrictModel):
             )
         if self.flat_before_year is not None and self.flat is None:
             raise ValueError(
-                "MultiplierRules: 'flat_before_year' requires 'flat' to "
-                "be the primary rule."
+                "MultiplierRules: 'flat_before_year' requires 'flat' to " "be the primary rule."
             )
         return self
 
 
 # Per-class entry: either typed rules or a string alias (``_same_as``).
-_PerClassEntry = Union[MultiplierRules, str]
+_PerClassEntry = MultiplierRules | str
 
 
 class ClassMultipliers(StrictModel):
@@ -102,7 +99,7 @@ class ClassMultipliers(StrictModel):
     model_config = ConfigDict(extra="allow", frozen=True)
 
     @model_validator(mode="after")
-    def _promote_entries(self) -> "ClassMultipliers":
+    def _promote_entries(self) -> ClassMultipliers:
         if not self.model_extra:
             return self
         promoted = {}
@@ -117,7 +114,7 @@ class ClassMultipliers(StrictModel):
         object.__setattr__(self, "__pydantic_extra__", promoted)
         return self
 
-    def resolve(self, tier_name: str) -> Optional[MultiplierRules]:
+    def resolve(self, tier_name: str) -> MultiplierRules | None:
         """Look up the multiplier rules for a tier.
 
         Resolution order:
@@ -148,7 +145,7 @@ class BenefitMultipliers(StrictModel):
     model_config = ConfigDict(extra="allow", frozen=True)
 
     @model_validator(mode="after")
-    def _promote_classes(self) -> "BenefitMultipliers":
+    def _promote_classes(self) -> BenefitMultipliers:
         if not self.model_extra:
             return self
         promoted = {}
@@ -160,7 +157,7 @@ class BenefitMultipliers(StrictModel):
         object.__setattr__(self, "__pydantic_extra__", promoted)
         return self
 
-    def resolve(self, class_name: str, tier_name: str) -> Optional[MultiplierRules]:
+    def resolve(self, class_name: str, tier_name: str) -> MultiplierRules | None:
         """Look up multiplier rules for a (class, tier) pair.
 
         Returns None if the class isn't declared or has no matching
@@ -171,7 +168,7 @@ class BenefitMultipliers(StrictModel):
             return None
         return class_rules.resolve(tier_name)
 
-    def class_multipliers(self, class_name: str) -> Optional[ClassMultipliers]:
+    def class_multipliers(self, class_name: str) -> ClassMultipliers | None:
         """Return the typed ClassMultipliers for ``class_name``,
         or None if absent."""
         return (self.model_extra or {}).get(class_name)

--- a/src/pension_model/schemas/calibration.py
+++ b/src/pension_model/schemas/calibration.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Optional
-
 from pydantic import ConfigDict, Field
 
 from pension_model.schemas.base import StrictModel
@@ -39,8 +37,8 @@ class Calibration(StrictModel):
     # entries the loader doesn't understand yet.
     model_config = ConfigDict(extra="allow", frozen=True)
 
-    description: Optional[str] = None
-    source: Optional[str] = None
-    notes: Optional[str] = None
-    cal_factor: Optional[float] = None
+    description: str | None = None
+    source: str | None = None
+    notes: str | None = None
+    cal_factor: float | None = None
     classes: dict[str, ClassCalibration] = Field(default_factory=dict)

--- a/src/pension_model/schemas/conditions.py
+++ b/src/pension_model/schemas/conditions.py
@@ -8,8 +8,6 @@ keeps a single :class:`Condition` model so both consumers can reuse it.
 
 from __future__ import annotations
 
-from typing import Optional
-
 import numpy as np
 
 from pension_model.schemas.base import StrictModel
@@ -35,9 +33,9 @@ class Condition(StrictModel):
     rules don't use the empty form.)
     """
 
-    min_age: Optional[int] = None
-    min_yos: Optional[int] = None
-    rule_of: Optional[int] = None
+    min_age: int | None = None
+    min_yos: int | None = None
+    rule_of: int | None = None
 
     def matches(self, age: int, yos: int) -> bool:
         """Scalar predicate evaluation. Returns True iff all declared

--- a/src/pension_model/schemas/early_retire_reduction.py
+++ b/src/pension_model/schemas/early_retire_reduction.py
@@ -20,7 +20,7 @@ attributes always exist.
 
 from __future__ import annotations
 
-from typing import Literal, Optional
+from typing import Literal
 
 import numpy as np
 from pydantic import Field, model_validator
@@ -49,11 +49,11 @@ class ReduceCondition(StrictModel):
 
     model_config = StrictModel.model_config | {"populate_by_name": True}
 
-    min_age: Optional[int] = None
-    min_yos: Optional[int] = None
-    rule_of: Optional[int] = None
-    grandfathered: Optional[bool] = None
-    or_: Optional[list["ReduceCondition"]] = Field(default=None, alias="or")
+    min_age: int | None = None
+    min_yos: int | None = None
+    rule_of: int | None = None
+    grandfathered: bool | None = None
+    or_: list[ReduceCondition] | None = Field(default=None, alias="or")
 
     def matches(self, dist_age: int, yos: int, tier_name: str) -> bool:
         """Scalar predicate evaluation."""
@@ -69,9 +69,7 @@ class ReduceCondition(StrictModel):
             return any(sub.matches(dist_age, yos, tier_name) for sub in self.or_)
         return True
 
-    def matches_vec(
-        self, dist_age: np.ndarray, yos: np.ndarray, tier_name: str
-    ) -> np.ndarray:
+    def matches_vec(self, dist_age: np.ndarray, yos: np.ndarray, tier_name: str) -> np.ndarray:
         """Vectorized predicate evaluation."""
         mask = np.ones(len(dist_age), dtype=bool)
         if self.min_age is not None:
@@ -101,24 +99,20 @@ class EarlyRetireRule(StrictModel):
 
     condition: ReduceCondition = ReduceCondition()
     formula: Literal["linear", "table"] = "linear"
-    rate_per_year: Optional[float] = None
-    nra: Optional[int] = None
-    table_key: Optional[str] = None
+    rate_per_year: float | None = None
+    nra: int | None = None
+    table_key: str | None = None
 
     @model_validator(mode="after")
     def _check_formula_fields(self):
         if self.formula == "linear":
             if self.rate_per_year is None or self.nra is None:
                 raise ValueError(
-                    "EarlyRetireRule with formula='linear' requires "
-                    "both rate_per_year and nra"
+                    "EarlyRetireRule with formula='linear' requires " "both rate_per_year and nra"
                 )
         elif self.formula == "table":
             if not self.table_key:
-                raise ValueError(
-                    "EarlyRetireRule with formula='table' requires "
-                    "table_key"
-                )
+                raise ValueError("EarlyRetireRule with formula='table' requires " "table_key")
         return self
 
 
@@ -130,9 +124,9 @@ class EarlyRetireReduction(StrictModel):
     populated, or neither, raises.
     """
 
-    rate_per_year: Optional[float] = None
-    nra: Optional[dict[str, int]] = None
-    rules: Optional[list[EarlyRetireRule]] = None
+    rate_per_year: float | None = None
+    nra: dict[str, int] | None = None
+    rules: list[EarlyRetireRule] | None = None
 
     @model_validator(mode="after")
     def _check_exactly_one_shape(self):
@@ -150,8 +144,7 @@ class EarlyRetireReduction(StrictModel):
             )
         if flat_present and (self.rate_per_year is None or self.nra is None):
             raise ValueError(
-                "EarlyRetireReduction flat shape requires both "
-                "rate_per_year and nra"
+                "EarlyRetireReduction flat shape requires both " "rate_per_year and nra"
             )
         return self
 

--- a/src/pension_model/schemas/economic.py
+++ b/src/pension_model/schemas/economic.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Optional
-
 from pydantic import Field, model_validator
 
 from pension_model.schemas.base import StrictModel
@@ -21,19 +19,18 @@ class Economic(StrictModel):
 
     dr_current: float = Field(description="Current discount rate.")
     dr_new: float = Field(description="Discount rate for new hires.")
-    dr_old: Optional[float] = Field(
+    dr_old: float | None = Field(
         default=None,
         description="Legacy discount rate (used in some amortization "
         "calcs). Defaults to dr_current.",
     )
     payroll_growth: float
     pop_growth: float = 0.0
-    model_return: Optional[float] = Field(
+    model_return: float | None = Field(
         default=None,
-        description="Asset return assumption for the funding model. "
-        "Defaults to dr_current.",
+        description="Asset return assumption for the funding model. " "Defaults to dr_current.",
     )
-    asset_return_path: Optional[dict] = None
+    asset_return_path: dict | None = None
 
     # Snapshots from before any scenario override. Not parsed from
     # raw["economic"]; populated by the loader.
@@ -41,7 +38,7 @@ class Economic(StrictModel):
     baseline_model_return: float
 
     @model_validator(mode="after")
-    def _apply_dr_defaults(self) -> "Economic":
+    def _apply_dr_defaults(self) -> Economic:
         # Frozen models need object.__setattr__ for back-fills.
         if self.dr_old is None:
             object.__setattr__(self, "dr_old", self.dr_current)

--- a/src/pension_model/schemas/eligibility.py
+++ b/src/pension_model/schemas/eligibility.py
@@ -41,14 +41,10 @@ class EligibilitySpec(StrictModel):
         """True if any early-retirement condition matches."""
         return any(c.matches(age, yos) for c in self.early)
 
-    def matches_normal_vec(
-        self, ages: np.ndarray, yos: np.ndarray
-    ) -> np.ndarray:
+    def matches_normal_vec(self, ages: np.ndarray, yos: np.ndarray) -> np.ndarray:
         """Vectorized normal-retirement match. Returns bool array."""
         return _any_match_vec(self.normal, ages, yos)
 
-    def matches_early_vec(
-        self, ages: np.ndarray, yos: np.ndarray
-    ) -> np.ndarray:
+    def matches_early_vec(self, ages: np.ndarray, yos: np.ndarray) -> np.ndarray:
         """Vectorized early-retirement match. Returns bool array."""
         return _any_match_vec(self.early, ages, yos)

--- a/src/pension_model/schemas/funding.py
+++ b/src/pension_model/schemas/funding.py
@@ -2,12 +2,11 @@
 
 from __future__ import annotations
 
-from typing import Annotated, Literal, Optional, Union
+from typing import Annotated, Literal
 
 from pydantic import Field, model_validator
 
 from pension_model.schemas.base import StrictModel
-
 
 # ---------------------------------------------------------------------------
 # AVA smoothing — method-discriminated union
@@ -41,7 +40,7 @@ class GainLossAvaSmoothing(StrictModel):
 # Discriminated union by ``method``. Pydantic dispatches to the right
 # concrete model based on the method tag.
 AvaSmoothing = Annotated[
-    Union[CorridorAvaSmoothing, GainLossAvaSmoothing],
+    CorridorAvaSmoothing | GainLossAvaSmoothing,
     Field(discriminator="method"),
 ]
 
@@ -75,13 +74,13 @@ class RateComponentSpec(StrictModel):
 
     name: str
     payroll_share: float = 1.0
-    schedule: Optional[list[RateScheduleEntry]] = None
-    initial_rate: Optional[float] = None
-    ramp: Optional[RampSpec] = None
-    start_year: Optional[int] = None
+    schedule: list[RateScheduleEntry] | None = None
+    initial_rate: float | None = None
+    ramp: RampSpec | None = None
+    start_year: int | None = None
 
     @model_validator(mode="after")
-    def _check_rate_form(self) -> "RateComponentSpec":
+    def _check_rate_form(self) -> RateComponentSpec:
         has_schedule = self.schedule is not None
         has_ramp = self.ramp is not None
         if not has_schedule and not has_ramp:
@@ -123,10 +122,10 @@ class LegDef(StrictModel):
     """
 
     name: str
-    entry_year_min: Optional[int] = None
-    entry_year_max: Optional[int] = None
-    entry_year_min_param: Optional[Literal["new_year"]] = None
-    entry_year_max_param: Optional[Literal["new_year"]] = None
+    entry_year_min: int | None = None
+    entry_year_max: int | None = None
+    entry_year_min_param: Literal["new_year"] | None = None
+    entry_year_max_param: Literal["new_year"] | None = None
 
 
 def _default_legs() -> list[LegDef]:
@@ -156,19 +155,19 @@ class Funding(StrictModel):
     amo_pay_growth: float
     funding_lag: int = 1
 
-    amo_period_current: Optional[int] = None
+    amo_period_current: int | None = None
     amo_period_term: int = 50
     amo_term_growth: float = 0.03
 
     has_drop: bool = False
-    drop_reference_class: Optional[str] = None
+    drop_reference_class: str | None = None
 
     ava_smoothing: AvaSmoothing
-    statutory_rates: Optional[StatutoryRates] = None
+    statutory_rates: StatutoryRates | None = None
     legs: list[LegDef] = Field(default_factory=_default_legs)
 
     @model_validator(mode="after")
-    def _check_statutory_rates_present(self) -> "Funding":
+    def _check_statutory_rates_present(self) -> Funding:
         if self.contribution_strategy == "statutory" and self.statutory_rates is None:
             raise ValueError(
                 "funding.contribution_strategy is 'statutory' but "

--- a/src/pension_model/schemas/grandfathered.py
+++ b/src/pension_model/schemas/grandfathered.py
@@ -9,8 +9,6 @@ isn't enough to identify the grandfathered cohort.
 
 from __future__ import annotations
 
-from typing import Optional
-
 import numpy as np
 from pydantic import model_validator
 
@@ -25,9 +23,9 @@ class GrandfatheredCondition(StrictModel):
     three fields per condition; the validator enforces that.
     """
 
-    min_age_at_cutoff: Optional[int] = None
-    rule_of_at_cutoff: Optional[int] = None
-    min_yos_at_cutoff: Optional[int] = None
+    min_age_at_cutoff: int | None = None
+    rule_of_at_cutoff: int | None = None
+    min_yos_at_cutoff: int | None = None
 
     @model_validator(mode="after")
     def _check_exactly_one_field(self):
@@ -67,15 +65,16 @@ class GrandfatheredParams(StrictModel):
         for cond in self.conditions:
             if cond.min_age_at_cutoff is not None and age_at_cutoff >= cond.min_age_at_cutoff:
                 return True
-            if cond.rule_of_at_cutoff is not None and (age_at_cutoff + yos_at_cutoff) >= cond.rule_of_at_cutoff:
+            if (
+                cond.rule_of_at_cutoff is not None
+                and (age_at_cutoff + yos_at_cutoff) >= cond.rule_of_at_cutoff
+            ):
                 return True
             if cond.min_yos_at_cutoff is not None and yos_at_cutoff >= cond.min_yos_at_cutoff:
                 return True
         return False
 
-    def matches_vec(
-        self, entry_year: np.ndarray, entry_age: np.ndarray
-    ) -> np.ndarray:
+    def matches_vec(self, entry_year: np.ndarray, entry_age: np.ndarray) -> np.ndarray:
         """Vectorized predicate. Returns bool array."""
         in_range = entry_year <= self.cutoff_year
         yos_at_cutoff = np.minimum(self.cutoff_year - entry_year, 70)

--- a/src/pension_model/schemas/modeling.py
+++ b/src/pension_model/schemas/modeling.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Optional
-
 from pension_model.schemas.base import StrictModel
 
 
@@ -16,8 +14,8 @@ class AgeGroup(StrictModel):
     """
 
     label: str
-    min_age: Optional[int] = None
-    max_age: Optional[int] = None
+    min_age: int | None = None
+    max_age: int | None = None
 
 
 class Modeling(StrictModel):
@@ -33,4 +31,4 @@ class Modeling(StrictModel):
     entrant_salary_at_start_year: bool = False
     use_earliest_retire: bool = False
     male_mp_forward_shift: int = 0
-    age_groups: Optional[list[AgeGroup]] = None
+    age_groups: list[AgeGroup] | None = None

--- a/src/pension_model/schemas/mortality.py
+++ b/src/pension_model/schemas/mortality.py
@@ -9,11 +9,9 @@ class-specific table check ``base_table_map`` first and fall back to
 
 from __future__ import annotations
 
-from typing import Optional
-
 from pension_model.schemas.base import StrictModel
 
 
 class MortalitySpec(StrictModel):
     base_table: str = "general"
-    improvement_scale: Optional[str] = None
+    improvement_scale: str | None = None

--- a/src/pension_model/schemas/partial.py
+++ b/src/pension_model/schemas/partial.py
@@ -36,7 +36,7 @@ Design notes:
 from __future__ import annotations
 
 import types
-from typing import Any, Optional, Union, get_args, get_origin
+from typing import Any, Union, get_args, get_origin
 
 from pydantic import BaseModel, ConfigDict, Field, create_model
 
@@ -44,8 +44,8 @@ from pydantic import BaseModel, ConfigDict, Field, create_model
 def partial_model(
     cls: type[BaseModel],
     *,
-    extra: Optional[str] = None,
-    _cache: Optional[dict[type[BaseModel], type[BaseModel]]] = None,
+    extra: str | None = None,
+    _cache: dict[type[BaseModel], type[BaseModel]] | None = None,
 ) -> type[BaseModel]:
     """Build a recursive partial of ``cls``.
 
@@ -76,7 +76,7 @@ def partial_model(
         kwargs: dict[str, Any] = {"default": None}
         if field_info.alias is not None:
             kwargs["alias"] = field_info.alias
-        fields[name] = (Optional[partial_ann], Field(**kwargs))
+        fields[name] = (partial_ann | None, Field(**kwargs))
 
     parent_extra = (cls.model_config or {}).get("extra", "ignore")
     final_extra = extra if extra is not None else parent_extra
@@ -107,6 +107,6 @@ def _partialize_annotation(
     origin = get_origin(annotation)
     if origin is Union or origin is types.UnionType:
         new_args = tuple(_partialize_annotation(a, cache) for a in get_args(annotation))
-        return Union[new_args]  # type: ignore[return-value]
+        return Union[new_args]  # type: ignore[return-value]  # noqa: UP007  (runtime Union construction)
 
     return annotation

--- a/src/pension_model/schemas/plan_design.py
+++ b/src/pension_model/schemas/plan_design.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Optional
-
 from pydantic import ConfigDict, Field, model_validator
 
 from pension_model.schemas.base import StrictModel
@@ -27,17 +25,17 @@ class PlanDesignRatios(StrictModel):
     or fall through to ``new_db`` (DB).
     """
 
-    before_cutoff: Optional[float] = None
-    after_cutoff: Optional[float] = Field(
+    before_cutoff: float | None = None
+    after_cutoff: float | None = Field(
         default=None,
         description="Defaults to before_cutoff if omitted (no cutoff).",
     )
-    new: Optional[float] = None
-    new_db: Optional[float] = None
-    before_cb: Optional[float] = None
-    after_cb: Optional[float] = None
-    new_cb: Optional[float] = None
-    new_dc: Optional[float] = None
+    new: float | None = None
+    new_db: float | None = None
+    before_cb: float | None = None
+    after_cb: float | None = None
+    new_cb: float | None = None
+    new_dc: float | None = None
 
     def db_triple(self) -> tuple[float, float, float]:
         """Return ``(before, after, new)`` DB ratios with defaults
@@ -47,8 +45,8 @@ class PlanDesignRatios(StrictModel):
         """
         before = self.before_cutoff if self.before_cutoff is not None else 1.0
         after = self.after_cutoff if self.after_cutoff is not None else before
-        new = self.new if self.new is not None else (
-            self.new_db if self.new_db is not None else 1.0
+        new = (
+            self.new if self.new is not None else (self.new_db if self.new_db is not None else 1.0)
         )
         return (before, after, new)
 
@@ -82,10 +80,10 @@ class PlanDesign(StrictModel):
     # the after-validator below.
     model_config = ConfigDict(extra="allow", frozen=True)
 
-    cutoff_year: Optional[int] = None
+    cutoff_year: int | None = None
 
     @model_validator(mode="after")
-    def _promote_groups_to_typed_ratios(self) -> "PlanDesign":
+    def _promote_groups_to_typed_ratios(self) -> PlanDesign:
         """Convert each extra (group) entry to ``PlanDesignRatios``."""
         if not self.model_extra:
             return self
@@ -100,7 +98,7 @@ class PlanDesign(StrictModel):
         object.__setattr__(self, "__pydantic_extra__", promoted)
         return self
 
-    def group(self, name: str) -> Optional[PlanDesignRatios]:
+    def group(self, name: str) -> PlanDesignRatios | None:
         """Look up a group's design ratios by name. Returns None if
         absent (caller decides whether to fall back to ``default``).
         """

--- a/src/pension_model/schemas/ranges.py
+++ b/src/pension_model/schemas/ranges.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Optional
-
 from pydantic import Field, model_validator
 
 from pension_model.schemas.base import StrictModel
@@ -17,7 +15,7 @@ class Ranges(StrictModel):
     min_age: int
     max_age: int
     start_year: int
-    new_year: Optional[int] = Field(
+    new_year: int | None = Field(
         default=None,
         description="Year boundary that separates legacy hires from "
         "new hires. Defaults to start_year if omitted.",
@@ -27,7 +25,7 @@ class Ranges(StrictModel):
     max_yos: int = 70
 
     @model_validator(mode="after")
-    def _default_new_year(self) -> "Ranges":
+    def _default_new_year(self) -> Ranges:
         if self.new_year is None:
             object.__setattr__(self, "new_year", self.start_year)
         return self

--- a/src/pension_model/schemas/scenario.py
+++ b/src/pension_model/schemas/scenario.py
@@ -24,14 +24,11 @@ the best" behavior.
 
 from __future__ import annotations
 
-from typing import Optional
-
 from pydantic import Field
 
 from pension_model.config_schema import PlanConfig
 from pension_model.schemas.base import StrictModel
 from pension_model.schemas.partial import partial_model
-
 
 # Recursive partial of PlanConfig. Built once at import; ``extra="forbid"``
 # at the top level catches typos there (PlanConfig itself uses

--- a/src/pension_model/schemas/term_vested.py
+++ b/src/pension_model/schemas/term_vested.py
@@ -9,7 +9,7 @@ Today this is TXTRS-AV only; other plans omit it.
 
 from __future__ import annotations
 
-from typing import Literal, Optional
+from typing import Literal
 
 from pension_model.schemas.base import StrictModel
 
@@ -18,4 +18,4 @@ class TermVested(StrictModel):
     avg_deferral_years: int
     avg_payout_years: int
     method: Literal["deferred_annuity"]
-    notes: Optional[str] = None
+    notes: str | None = None

--- a/src/pension_model/schemas/tier.py
+++ b/src/pension_model/schemas/tier.py
@@ -21,7 +21,8 @@ the loader so misspelled references fail at parse time.
 
 from __future__ import annotations
 
-from typing import Literal, Optional, Sequence
+from collections.abc import Sequence
+from typing import Literal
 
 import numpy as np
 from pydantic import model_validator
@@ -54,19 +55,19 @@ class Tier(StrictModel):
     discount_rate_key: str = "dr_current"
     prorate_cola: bool = False
 
-    entry_year_min: Optional[int] = None
-    entry_year_max: Optional[int] = None
-    entry_year_min_param: Optional[Literal["new_year"]] = None
-    entry_year_max_param: Optional[Literal["new_year"]] = None
+    entry_year_min: int | None = None
+    entry_year_max: int | None = None
+    entry_year_min_param: Literal["new_year"] | None = None
+    entry_year_max_param: Literal["new_year"] | None = None
 
-    eligibility: Optional[dict[str, EligibilitySpec]] = None
-    eligibility_same_as: Optional[str] = None
+    eligibility: dict[str, EligibilitySpec] | None = None
+    eligibility_same_as: str | None = None
 
-    early_retire_reduction: Optional[EarlyRetireReduction] = None
-    early_retire_reduction_same_as: Optional[str] = None
+    early_retire_reduction: EarlyRetireReduction | None = None
+    early_retire_reduction_same_as: str | None = None
 
-    assignment: Optional[Literal["grandfathered_rule"]] = None
-    grandfathered_params: Optional[GrandfatheredParams] = None
+    assignment: Literal["grandfathered_rule"] | None = None
+    grandfathered_params: GrandfatheredParams | None = None
     not_grandfathered: bool = False
 
     @model_validator(mode="after")
@@ -87,7 +88,10 @@ class Tier(StrictModel):
                 f"'early_retire_reduction' or "
                 f"'early_retire_reduction_same_as'"
             )
-        if self.early_retire_reduction is not None and self.early_retire_reduction_same_as is not None:
+        if (
+            self.early_retire_reduction is not None
+            and self.early_retire_reduction_same_as is not None
+        ):
             raise ValueError(
                 f"Tier {self.name!r}: cannot declare both "
                 f"'early_retire_reduction' and "
@@ -108,7 +112,7 @@ class Tier(StrictModel):
                 )
         return self
 
-    def entry_year_lo(self, new_year: int) -> Optional[int]:
+    def entry_year_lo(self, new_year: int) -> int | None:
         """Resolved lower bound (inclusive) of this tier's entry-year
         window. ``None`` means unbounded below.
         """
@@ -116,7 +120,7 @@ class Tier(StrictModel):
             return new_year
         return self.entry_year_min
 
-    def entry_year_hi(self, new_year: int) -> Optional[int]:
+    def entry_year_hi(self, new_year: int) -> int | None:
         """Resolved upper bound (exclusive) of this tier's entry-year
         window. ``None`` means unbounded above.
         """
@@ -141,9 +145,7 @@ class Tier(StrictModel):
             return False
         return True
 
-    def entry_year_in_window_vec(
-        self, entry_year: np.ndarray, new_year: int
-    ) -> np.ndarray:
+    def entry_year_in_window_vec(self, entry_year: np.ndarray, new_year: int) -> np.ndarray:
         """Vectorized version of :meth:`entry_year_in_window`."""
         if self.assignment == "grandfathered_rule":
             return np.zeros(len(entry_year), dtype=bool)
@@ -159,8 +161,8 @@ class Tier(StrictModel):
     def resolve_eligibility(
         self,
         group: str,
-        all_tiers: Sequence["Tier"],
-    ) -> Optional[EligibilitySpec]:
+        all_tiers: Sequence[Tier],
+    ) -> EligibilitySpec | None:
         """Resolve this tier's eligibility for ``group``.
 
         Walks ``eligibility_same_as`` references (cycle-checked), then
@@ -174,8 +176,7 @@ class Tier(StrictModel):
             ref = current.eligibility_same_as
             if ref in seen:
                 raise ValueError(
-                    f"Tier {self.name!r}: circular eligibility_same_as "
-                    f"chain at {ref!r}"
+                    f"Tier {self.name!r}: circular eligibility_same_as " f"chain at {ref!r}"
                 )
             seen.add(ref)
             current = _find_tier(ref, all_tiers, source_field="eligibility_same_as")
@@ -185,8 +186,8 @@ class Tier(StrictModel):
 
     def resolve_early_retire_reduction(
         self,
-        all_tiers: Sequence["Tier"],
-    ) -> Optional[EarlyRetireReduction]:
+        all_tiers: Sequence[Tier],
+    ) -> EarlyRetireReduction | None:
         """Resolve this tier's early-retire-reduction spec.
 
         Walks ``early_retire_reduction_same_as`` references
@@ -204,21 +205,16 @@ class Tier(StrictModel):
                     f"early_retire_reduction_same_as chain at {ref!r}"
                 )
             seen.add(ref)
-            current = _find_tier(
-                ref, all_tiers, source_field="early_retire_reduction_same_as"
-            )
+            current = _find_tier(ref, all_tiers, source_field="early_retire_reduction_same_as")
         return current.early_retire_reduction
 
 
-def _find_tier(
-    name: str, tiers: Sequence[Tier], *, source_field: str
-) -> Tier:
+def _find_tier(name: str, tiers: Sequence[Tier], *, source_field: str) -> Tier:
     for t in tiers:
         if t.name == name:
             return t
     raise ValueError(
-        f"{source_field}={name!r} does not match any tier name in "
-        f"{[t.name for t in tiers]}"
+        f"{source_field}={name!r} does not match any tier name in " f"{[t.name for t in tiers]}"
     )
 
 

--- a/src/pension_model/schemas/valuation_inputs.py
+++ b/src/pension_model/schemas/valuation_inputs.py
@@ -3,8 +3,6 @@ plus the merged ``class_data`` view used at runtime."""
 
 from __future__ import annotations
 
-from typing import Optional
-
 from pydantic import Field
 
 from pension_model.schemas.base import StrictModel
@@ -26,21 +24,19 @@ class ValuationInputs(StrictModel):
     total_active_member: int
     er_dc_cont_rate: float = Field(
         default=0.0,
-        description="Employer DC contribution rate (used when "
-        "benefit_types includes 'dc').",
+        description="Employer DC contribution rate (used when " "benefit_types includes 'dc').",
     )
     val_norm_cost: float
-    val_aal: Optional[float] = Field(
+    val_aal: float | None = Field(
         default=None,
         description="AV-published actuarial accrued liability (used "
         "for component-by-component calibration; optional).",
     )
-    val_payroll: Optional[float] = Field(
+    val_payroll: float | None = Field(
         default=None,
-        description="AV-published payroll for this class (FRS-only "
-        "today).",
+        description="AV-published payroll for this class (FRS-only " "today).",
     )
-    headcount_group: Optional[list[str]] = Field(
+    headcount_group: list[str] | None = Field(
         default=None,
         description="Classes whose headcount totals must agree (FRS "
         "uses this to enforce eco/eso/judges share total_active_member).",

--- a/src/pension_model/truth_table.py
+++ b/src/pension_model/truth_table.py
@@ -61,10 +61,9 @@ both CSV and Excel.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Dict
 
+import numpy as np
 import pandas as pd
-
 
 # Canonical column order for every truth table (R and Python, FRS and TRS).
 TRUTH_TABLE_COLUMNS = [
@@ -93,8 +92,6 @@ TRUTH_TABLE_COLUMNS = [
     "er_cont_total",
 ]
 
-import numpy as np
-
 
 def _actual_invest_income(mva, net_cf):
     """Compute actual investment income so the MVA balance identity holds.
@@ -118,6 +115,7 @@ def _actual_invest_income(mva, net_cf):
 # ---------------------------------------------------------------------------
 # R-side builder — read from R output CSVs, produce a truth table
 # ---------------------------------------------------------------------------
+
 
 def _read_metric(funding_df: pd.DataFrame, spec) -> np.ndarray:
     """Resolve a metric spec from the manifest into a numeric array.
@@ -183,25 +181,27 @@ def build_r_truth_table(plan_name: str, baseline_dir: Path) -> pd.DataFrame:
     invest_income = _actual_invest_income(mva, net_cf)
     n_active = _read_n_active(manifest["n_active"], baseline_dir)
 
-    df = pd.DataFrame({
-        "plan": plan_name,
-        "year": f[manifest["year_column"]].astype(int).values,
-        "mva_boy": mva,
-        "er_db_cont": _read_metric(f, metrics["er_db_cont"]),
-        "ee_cont": _read_metric(f, metrics["ee_cont"]),
-        "invest_income": invest_income,
-        "benefits": _read_metric(f, metrics["benefits"]),
-        "refunds": _read_metric(f, metrics["refunds"]),
-        "admin_exp": _read_metric(f, metrics["admin_exp"]),
-        "mva_eoy": mva + net_cf + invest_income,
-        "aal_boy": _read_metric(f, metrics["aal"]),
-        "ava_boy": _read_metric(f, metrics["ava"]),
-        "fr_mva_boy": _read_metric(f, metrics["fr_mva"]),
-        "fr_ava_boy": _read_metric(f, metrics["fr_ava"]),
-        "n_active_boy": n_active,
-        "payroll": _read_metric(f, metrics["payroll"]),
-        "er_cont_total": _read_metric(f, metrics["er_cont_total"]),
-    })
+    df = pd.DataFrame(
+        {
+            "plan": plan_name,
+            "year": f[manifest["year_column"]].astype(int).values,
+            "mva_boy": mva,
+            "er_db_cont": _read_metric(f, metrics["er_db_cont"]),
+            "ee_cont": _read_metric(f, metrics["ee_cont"]),
+            "invest_income": invest_income,
+            "benefits": _read_metric(f, metrics["benefits"]),
+            "refunds": _read_metric(f, metrics["refunds"]),
+            "admin_exp": _read_metric(f, metrics["admin_exp"]),
+            "mva_eoy": mva + net_cf + invest_income,
+            "aal_boy": _read_metric(f, metrics["aal"]),
+            "ava_boy": _read_metric(f, metrics["ava"]),
+            "fr_mva_boy": _read_metric(f, metrics["fr_mva"]),
+            "fr_ava_boy": _read_metric(f, metrics["fr_ava"]),
+            "n_active_boy": n_active,
+            "payroll": _read_metric(f, metrics["payroll"]),
+            "er_cont_total": _read_metric(f, metrics["er_cont_total"]),
+        }
+    )
     return df[TRUTH_TABLE_COLUMNS]
 
 
@@ -209,9 +209,10 @@ def build_r_truth_table(plan_name: str, baseline_dir: Path) -> pd.DataFrame:
 # Python-side builder — take live pipeline output, produce a truth table
 # ---------------------------------------------------------------------------
 
+
 def build_python_truth_table(
     plan_name: str,
-    liability: Dict[str, pd.DataFrame],
+    liability: dict[str, pd.DataFrame],
     funding,
     constants,
 ) -> pd.DataFrame:
@@ -272,35 +273,37 @@ def build_python_truth_table(
     admin = _sum(col(f, "admin_exp_legacy"), col(f, "admin_exp_new"))
     net_cf = _sum(col(f, "net_cf_legacy"), col(f, "net_cf_new"))
     invest_income = (
-        _actual_invest_income(mva, net_cf)
-        if mva is not None and net_cf is not None else None
+        _actual_invest_income(mva, net_cf) if mva is not None and net_cf is not None else None
     )
 
-    df = pd.DataFrame({
-        "plan": plan_name,
-        "year": pd.Series(year).astype(int).values,
-        "mva_boy": mva,
-        "er_db_cont": _or_z(er_db),
-        "ee_cont": _or_z(ee),
-        "invest_income": _or_z(invest_income),
-        "benefits": _or_z(benefits),
-        "refunds": _or_z(refunds),
-        "admin_exp": _or_z(admin),
-        "mva_eoy": _or_z(mva) + _or_z(net_cf) + _or_z(invest_income),
-        "aal_boy": col(f, "total_aal"),
-        "ava_boy": col(f, "total_ava"),
-        "fr_mva_boy": col(f, "fr_mva"),
-        "fr_ava_boy": col(f, "fr_ava"),
-        "n_active_boy": n_active,
-        "payroll": col(f, "total_payroll"),
-        "er_cont_total": col(f, "total_er_cont"),
-    })
+    df = pd.DataFrame(
+        {
+            "plan": plan_name,
+            "year": pd.Series(year).astype(int).values,
+            "mva_boy": mva,
+            "er_db_cont": _or_z(er_db),
+            "ee_cont": _or_z(ee),
+            "invest_income": _or_z(invest_income),
+            "benefits": _or_z(benefits),
+            "refunds": _or_z(refunds),
+            "admin_exp": _or_z(admin),
+            "mva_eoy": _or_z(mva) + _or_z(net_cf) + _or_z(invest_income),
+            "aal_boy": col(f, "total_aal"),
+            "ava_boy": col(f, "total_ava"),
+            "fr_mva_boy": col(f, "fr_mva"),
+            "fr_ava_boy": col(f, "fr_ava"),
+            "n_active_boy": n_active,
+            "payroll": col(f, "total_payroll"),
+            "er_cont_total": col(f, "total_er_cont"),
+        }
+    )
     return df[TRUTH_TABLE_COLUMNS]
 
 
 # ---------------------------------------------------------------------------
 # Output helpers
 # ---------------------------------------------------------------------------
+
 
 def format_truth_table_for_log(df: pd.DataFrame, max_rows: int = 31) -> str:
     """Render a truth table as a human-readable text block for stdout/logs.
@@ -378,8 +381,10 @@ def upsert_sheet_to_excel(df: pd.DataFrame, xlsx_path: Path, sheet_name: str) ->
 
     if xlsx_path.exists():
         with pd.ExcelWriter(
-            xlsx_path, engine="openpyxl",
-            mode="a", if_sheet_exists="replace",
+            xlsx_path,
+            engine="openpyxl",
+            mode="a",
+            if_sheet_exists="replace",
         ) as w:
             df.to_excel(w, sheet_name=sheet_name, index=False)
             _freeze_panes(w.sheets[sheet_name], df)
@@ -434,9 +439,9 @@ def write_diff_sheet_with_formulas(
     Diff is an ABSOLUTE difference (Py - R), not a percentage.
     """
     from openpyxl import load_workbook
-    from openpyxl.utils import get_column_letter
-    from openpyxl.styles import Font, PatternFill, Alignment, NamedStyle
     from openpyxl.formatting.rule import CellIsRule
+    from openpyxl.styles import Alignment, Font, PatternFill
+    from openpyxl.utils import get_column_letter
 
     wb = load_workbook(xlsx_path)
 
@@ -454,15 +459,13 @@ def write_diff_sheet_with_formulas(
     ws.cell(row=2, column=2, value="year").font = Font(bold=True)
 
     for i, (_src_col, label) in enumerate(_DIFF_METRICS):
-        c_r = 3 + i * 3        # R column
-        c_py = c_r + 1         # Py column
-        c_diff = c_r + 2       # diff column
+        c_r = 3 + i * 3  # R column
+        c_py = c_r + 1  # Py column
+        c_diff = c_r + 2  # diff column
         # Merge three cells in header row 1 for the metric label
         ws.cell(row=1, column=c_r, value=label).font = Font(bold=True)
         ws.cell(row=1, column=c_r).alignment = Alignment(horizontal="center")
-        ws.merge_cells(
-            start_row=1, start_column=c_r, end_row=1, end_column=c_diff
-        )
+        ws.merge_cells(start_row=1, start_column=c_r, end_row=1, end_column=c_diff)
         # Row 2 sub-labels
         ws.cell(row=2, column=c_r, value="R").font = Font(bold=True, italic=True)
         ws.cell(row=2, column=c_py, value="Py").font = Font(bold=True, italic=True)
@@ -477,30 +480,27 @@ def write_diff_sheet_with_formulas(
     #
     # Source col C is metric index 0, D is metric index 1, etc.
     for row_idx in range(n_rows):
-        src_row = row_idx + 2       # source data starts at row 2
-        dst_row = row_idx + 3       # diff data starts at row 3 (after 2 header rows)
+        src_row = row_idx + 2  # source data starts at row 2
+        dst_row = row_idx + 3  # diff data starts at row 3 (after 2 header rows)
 
         # plan and year — pull from R sheet by formula
-        ws.cell(row=dst_row, column=1,
-                value=f"='{r_sheet_name}'!A{src_row}")
-        ws.cell(row=dst_row, column=2,
-                value=f"='{r_sheet_name}'!B{src_row}")
+        ws.cell(row=dst_row, column=1, value=f"='{r_sheet_name}'!A{src_row}")
+        ws.cell(row=dst_row, column=2, value=f"='{r_sheet_name}'!B{src_row}")
 
         for i, _ in enumerate(_DIFF_METRICS):
-            src_col_letter = get_column_letter(3 + i)   # C, D, E, ...
+            src_col_letter = get_column_letter(3 + i)  # C, D, E, ...
             c_r = 3 + i * 3
             c_py = c_r + 1
             c_diff = c_r + 2
 
-            ws.cell(row=dst_row, column=c_r,
-                    value=f"='{r_sheet_name}'!{src_col_letter}{src_row}")
-            ws.cell(row=dst_row, column=c_py,
-                    value=f"='{py_sheet_name}'!{src_col_letter}{src_row}")
+            ws.cell(row=dst_row, column=c_r, value=f"='{r_sheet_name}'!{src_col_letter}{src_row}")
+            ws.cell(row=dst_row, column=c_py, value=f"='{py_sheet_name}'!{src_col_letter}{src_row}")
             # IFERROR wraps NA handling (blank cell in either side -> blank diff)
             ws.cell(
-                row=dst_row, column=c_diff,
+                row=dst_row,
+                column=c_diff,
                 value=(
-                    f'=IFERROR('
+                    f"=IFERROR("
                     f"'{py_sheet_name}'!{src_col_letter}{src_row}"
                     f"-'{r_sheet_name}'!{src_col_letter}{src_row}"
                     f',"")'

--- a/tests/test_pension_model/_vectorized_resolver_test_support.py
+++ b/tests/test_pension_model/_vectorized_resolver_test_support.py
@@ -4,7 +4,6 @@ import numpy as np
 
 from pension_model.config_schema import EARLY, NON_VESTED, NORM, VESTED
 
-
 # Map ret_status integer codes to the same status strings emitted by
 # scalar get_tier. Used to compare scalar (tier_name, status) tuples
 # against vectorized (tier_id, ret_status) results.
@@ -26,19 +25,14 @@ def vec_tier_components(config, cn, ey, age, yos, entry_age=None):
     from pension_model.plan_config import resolve_tiers_vec
 
     tier_id, ret_status = resolve_tiers_vec(config, cn, ey, age, yos, entry_age)
-    tier_names = np.array(
-        [config.tier_id_to_name[t] for t in tier_id], dtype=object
-    )
-    statuses = np.array(
-        [_STATUS_INT_TO_STR[s] for s in ret_status], dtype=object
-    )
+    tier_names = np.array([config.tier_id_to_name[t] for t in tier_id], dtype=object)
+    statuses = np.array([_STATUS_INT_TO_STR[s] for s in ret_status], dtype=object)
     return tier_names, statuses
 
 
 def build_frs_grid():
     """Dense grid of inputs covering FRS tier boundaries and class variations."""
-    classes = ["regular", "special", "admin", "eco", "eso", "judges",
-               "senior_management"]
+    classes = ["regular", "special", "admin", "eco", "eso", "judges", "senior_management"]
     entry_years = [1970, 1990, 2000, 2010, 2011, 2015, 2020, 2021, 2022, 2025, 2030, 2040]
     ages = [20, 25, 30, 40, 50, 55, 58, 60, 62, 65, 68, 70, 75]
     yos_list = [0, 1, 5, 6, 8, 10, 15, 20, 25, 28, 30, 33, 35, 40]
@@ -56,8 +50,24 @@ def build_frs_grid():
 def build_txtrs_grid():
     """Grid for TXTRS covering grandfathering and tier boundaries."""
     classes = ["all"]
-    entry_years = [1970, 1980, 1990, 1995, 2000, 2003, 2004, 2005, 2006,
-                   2008, 2010, 2011, 2015, 2020, 2024, 2030]
+    entry_years = [
+        1970,
+        1980,
+        1990,
+        1995,
+        2000,
+        2003,
+        2004,
+        2005,
+        2006,
+        2008,
+        2010,
+        2011,
+        2015,
+        2020,
+        2024,
+        2030,
+    ]
     ages = [20, 25, 30, 40, 50, 55, 60, 62, 65, 70]
     yos_list = [0, 1, 5, 10, 15, 20, 25, 30, 35, 40]
 
@@ -87,10 +97,13 @@ def scalar_cola(config, tier_name, entry_year, yos):
         if td.name == tier_name:
             cola_key = td.cola_key
             raw_cola = getattr(config.cola, cola_key, 0.0)
-            if (cola_key == "tier_1_active"
-                    and not getattr(config.cola, "tier_1_active_constant", False)
-                    and cola_cutoff is not None
-                    and raw_cola > 0 and yos > 0):
+            if (
+                cola_key == "tier_1_active"
+                and not getattr(config.cola, "tier_1_active_constant", False)
+                and cola_cutoff is not None
+                and raw_cola > 0
+                and yos > 0
+            ):
                 yos_b4 = min(max(cola_cutoff - entry_year, 0), yos)
                 return raw_cola * yos_b4 / yos
             return raw_cola

--- a/tests/test_pension_model/test_av_vs_r_twin.py
+++ b/tests/test_pension_model/test_av_vs_r_twin.py
@@ -29,12 +29,10 @@ import numpy as np
 import pandas as pd
 import pytest
 
-
 REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO_ROOT / "src"))
 
-from pension_model.runners import run_truth_table
-
+from pension_model.runners import run_truth_table  # noqa: E402  (after sys.path.insert)
 
 PAIRS = [
     ("txtrs", "txtrs-av"),
@@ -118,8 +116,7 @@ def test_year0_anchor_agreement(truth_tables, plan_a, plan_b, scenario):
             )
     assert not failures, (
         f"Year-{y0_year} anchors diverge beyond {Y0_ANCHOR_REL_TOL*100:.2f}% "
-        f"for {plan_a} vs {plan_b} in {scenario}:\n  "
-        + "\n  ".join(failures)
+        f"for {plan_a} vs {plan_b} in {scenario}:\n  " + "\n  ".join(failures)
     )
 
 

--- a/tests/test_pension_model/test_benefit_table_contracts.py
+++ b/tests/test_pension_model/test_benefit_table_contracts.py
@@ -1,16 +1,16 @@
 """Regression tests for benefit-table merge-key contracts."""
 
-from pathlib import Path
 import sys
+from pathlib import Path
 
 import pytest
 
-pytestmark = [pytest.mark.regression]
-
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
 
-from pension_model.core.pipeline import prepare_plan_run
-from pension_model.plan_config import load_plan_config_by_name
+from pension_model.core.pipeline import prepare_plan_run  # noqa: E402
+from pension_model.plan_config import load_plan_config_by_name  # noqa: E402
+
+pytestmark = [pytest.mark.regression]
 
 
 @pytest.fixture(scope="module", params=["frs", "txtrs"], ids=["frs", "txtrs"])
@@ -25,34 +25,44 @@ def test_plan_tables_keep_unique_merge_keys(prepared_plan_tables):
     assert plan_tables is not None
 
     salary_benefit = plan_tables["salary_benefit"]
-    assert salary_benefit.duplicated(
-        ["class_name", "entry_year", "entry_age", "yos", "term_age"]
-    ).sum() == 0, f"{plan_name}: salary_benefit merge key must stay unique"
+    assert (
+        salary_benefit.duplicated(
+            ["class_name", "entry_year", "entry_age", "yos", "term_age"]
+        ).sum()
+        == 0
+    ), f"{plan_name}: salary_benefit merge key must stay unique"
 
     ann_factor = plan_tables["ann_factor"]
-    assert ann_factor.duplicated(
-        ["class_name", "entry_year", "entry_age", "dist_year", "dist_age", "yos", "term_year"]
-    ).sum() == 0, f"{plan_name}: ann_factor merge key must stay unique"
+    assert (
+        ann_factor.duplicated(
+            ["class_name", "entry_year", "entry_age", "dist_year", "dist_age", "yos", "term_year"]
+        ).sum()
+        == 0
+    ), f"{plan_name}: ann_factor merge key must stay unique"
 
     benefit = plan_tables["benefit"]
-    assert benefit.duplicated(
-        ["class_name", "entry_year", "entry_age", "term_age", "dist_age"]
-    ).sum() == 0, f"{plan_name}: benefit merge key must stay unique"
+    assert (
+        benefit.duplicated(["class_name", "entry_year", "entry_age", "term_age", "dist_age"]).sum()
+        == 0
+    ), f"{plan_name}: benefit merge key must stay unique"
 
     final_benefit = plan_tables["final_benefit"]
-    assert final_benefit.duplicated(
-        ["class_name", "entry_year", "entry_age", "term_age"]
-    ).sum() == 0, f"{plan_name}: final_benefit merge key must stay unique"
+    assert (
+        final_benefit.duplicated(["class_name", "entry_year", "entry_age", "term_age"]).sum() == 0
+    ), f"{plan_name}: final_benefit merge key must stay unique"
 
     separation_rate = plan_tables["separation_rate"]
-    assert separation_rate.duplicated(
-        ["class_name", "entry_year", "entry_age", "term_age", "yos", "term_year"]
-    ).sum() == 0, f"{plan_name}: separation_rate merge key must stay unique"
+    assert (
+        separation_rate.duplicated(
+            ["class_name", "entry_year", "entry_age", "term_age", "yos", "term_year"]
+        ).sum()
+        == 0
+    ), f"{plan_name}: separation_rate merge key must stay unique"
 
     aft_term = ann_factor[ann_factor["dist_age"] == ann_factor["entry_age"] + ann_factor["yos"]]
-    assert aft_term.duplicated(
-        ["class_name", "entry_year", "entry_age", "yos"]
-    ).sum() == 0, f"{plan_name}: term-age annuity key must stay unique"
+    assert (
+        aft_term.duplicated(["class_name", "entry_year", "entry_age", "yos"]).sum() == 0
+    ), f"{plan_name}: term-age annuity key must stay unique"
 
 
 def test_benefit_rows_stay_contiguous_and_ordered(prepared_plan_tables):
@@ -61,17 +71,19 @@ def test_benefit_rows_stay_contiguous_and_ordered(prepared_plan_tables):
     grp_keys = ["class_name", "entry_year", "entry_age", "term_age"]
 
     key_frame = benefit[grp_keys]
-    separated_duplicate_groups = key_frame.duplicated() & key_frame.ne(key_frame.shift()).any(axis=1)
-    assert not separated_duplicate_groups.any(), (
-        f"{plan_name}: benefit rows for one cohort must remain contiguous"
+    separated_duplicate_groups = key_frame.duplicated() & key_frame.ne(key_frame.shift()).any(
+        axis=1
     )
+    assert (
+        not separated_duplicate_groups.any()
+    ), f"{plan_name}: benefit rows for one cohort must remain contiguous"
 
-    dist_age_monotone = benefit.groupby(
-        grp_keys, sort=False, observed=True
-    )["dist_age"].apply(lambda s: s.is_monotonic_increasing)
-    assert bool(dist_age_monotone.all()), (
-        f"{plan_name}: dist_age must stay monotone within each benefit cohort"
+    dist_age_monotone = benefit.groupby(grp_keys, sort=False, observed=True)["dist_age"].apply(
+        lambda s: s.is_monotonic_increasing
     )
+    assert bool(
+        dist_age_monotone.all()
+    ), f"{plan_name}: dist_age must stay monotone within each benefit cohort"
 
 
 def test_ann_factor_term_rows_align_with_salary_benefit(prepared_plan_tables):
@@ -91,9 +103,9 @@ def test_ann_factor_term_rows_align_with_salary_benefit(prepared_plan_tables):
     ].reset_index(drop=True)
     ann_term_keys["term_age"] = ann_term_keys["entry_age"] + ann_term_keys["yos"]
 
-    assert len(ann_term_keys) == len(sbt_keys), (
-        f"{plan_name}: ann_factor term rows must match eligible salary_benefit rows"
-    )
-    assert ann_term_keys.equals(sbt_keys), (
-        f"{plan_name}: ann_factor term rows must stay aligned with salary_benefit order"
-    )
+    assert len(ann_term_keys) == len(
+        sbt_keys
+    ), f"{plan_name}: ann_factor term rows must match eligible salary_benefit rows"
+    assert ann_term_keys.equals(
+        sbt_keys
+    ), f"{plan_name}: ann_factor term rows must stay aligned with salary_benefit order"

--- a/tests/test_pension_model/test_benefit_tables.py
+++ b/tests/test_pension_model/test_benefit_tables.py
@@ -7,8 +7,9 @@ This ensures end-to-end correctness from raw inputs to final outputs.
 
 import sys
 from pathlib import Path
-import pytest
+
 import pandas as pd
+import pytest
 
 pytestmark = [
     pytest.mark.regression,
@@ -43,6 +44,7 @@ class TestSalaryHeadcountTable:
     def _get_adjustment_ratio(self, class_name):
         """Compute headcount adjustment ratio matching R model."""
         from pension_model.plan_config import load_plan_config_by_name
+
         c = load_plan_config_by_name("frs")
 
         if class_name in ("eco", "eso", "judges"):
@@ -51,9 +53,11 @@ class TestSalaryHeadcountTable:
             eco_hc = pd.read_csv(FRS_BASELINES / "eco_headcount.csv")
             eso_hc = pd.read_csv(FRS_BASELINES / "eso_headcount.csv")
             judges_hc = pd.read_csv(FRS_BASELINES / "judges_headcount.csv")
-            raw = (eco_hc.iloc[:, 1:].sum().sum()
-                   + eso_hc.iloc[:, 1:].sum().sum()
-                   + judges_hc.iloc[:, 1:].sum().sum())
+            raw = (
+                eco_hc.iloc[:, 1:].sum().sum()
+                + eso_hc.iloc[:, 1:].sum().sum()
+                + judges_hc.iloc[:, 1:].sum().sum()
+            )
             return combined_total / raw
         else:
             total = c.class_data[class_name].total_active_member
@@ -96,9 +100,7 @@ class TestSalaryHeadcountTable:
                 * 100
             )
             max_diff = pct_diff.max()
-            assert max_diff < 0.01, (
-                f"{class_name}: entry_salary max diff {max_diff:.4f}%"
-            )
+            assert max_diff < 0.01, f"{class_name}: entry_salary max diff {max_diff:.4f}%"
 
         # count should match
         mask_c = merged["count_r"].notna() & (merged["count_r"].abs() > 0)
@@ -109,9 +111,7 @@ class TestSalaryHeadcountTable:
                 * 100
             )
             max_diff_c = pct_diff_c.max()
-            assert max_diff_c < 0.01, (
-                f"{class_name}: count max diff {max_diff_c:.4f}%"
-            )
+            assert max_diff_c < 0.01, f"{class_name}: count max diff {max_diff_c:.4f}%"
 
 
 class TestSeparationRateTable:
@@ -119,8 +119,12 @@ class TestSeparationRateTable:
 
     # R's separation table class mapping (benefit model line 584-590)
     SEP_CLASS_MAP = {
-        "regular": "regular", "special": "special", "admin": "admin",
-        "eco": "eco", "eso": "regular", "judges": "judges",
+        "regular": "regular",
+        "special": "special",
+        "admin": "admin",
+        "eco": "eco",
+        "eso": "regular",
+        "judges": "judges",
         "senior_management": "senior_management",
     }
 
@@ -128,8 +132,8 @@ class TestSeparationRateTable:
     def test_separation_rate_matches_r(self, class_name):
         """Verify separation rates match R for each class."""
         from pension_model.core.benefit_tables import (
-            build_salary_headcount_table,
             build_entrant_profile,
+            build_salary_headcount_table,
             build_separation_rate_table,
         )
         from pension_model.plan_config import load_plan_config_by_name
@@ -149,9 +153,13 @@ class TestSeparationRateTable:
             )
             adj_ratio = 2075 / combined_raw
         else:
-            adj_ratio = constants.class_data[sep_class].total_active_member / hc.iloc[:, 1:].sum().sum()
+            adj_ratio = (
+                constants.class_data[sep_class].total_active_member / hc.iloc[:, 1:].sum().sum()
+            )
 
-        sh = build_salary_headcount_table(sal, hc, sg, sep_class, adj_ratio, 2022, constants=constants)
+        sh = build_salary_headcount_table(
+            sal, hc, sg, sep_class, adj_ratio, 2022, constants=constants
+        )
         ep = build_entrant_profile(sh)
 
         dt = FRS_BASELINES / "decrement_tables"
@@ -160,11 +168,11 @@ class TestSeparationRateTable:
         sep = build_separation_rate_table(
             term_rate_avg=pd.read_csv(dt / f"{sep_class}_term_rate_avg.csv"),
             normal_retire_rate_by_set={
-                "before_2011":   pd.read_csv(dt / f"{sep_class}_normal_retire_rate_tier1.csv"),
+                "before_2011": pd.read_csv(dt / f"{sep_class}_normal_retire_rate_tier1.csv"),
                 "2011_or_later": pd.read_csv(dt / f"{sep_class}_normal_retire_rate_tier2.csv"),
             },
             early_retire_rate_by_set={
-                "before_2011":   pd.read_csv(dt / f"{sep_class}_early_retire_rate_tier1.csv"),
+                "before_2011": pd.read_csv(dt / f"{sep_class}_early_retire_rate_tier1.csv"),
                 "2011_or_later": pd.read_csv(dt / f"{sep_class}_early_retire_rate_tier2.csv"),
             },
             entrant_profile=ep,
@@ -179,17 +187,30 @@ class TestSeparationRateTable:
         if mask.any():
             pct = (
                 (m.loc[mask, "separation_rate_py"] - m.loc[mask, "separation_rate_r"]).abs()
-                / m.loc[mask, "separation_rate_r"].abs() * 100
+                / m.loc[mask, "separation_rate_r"].abs()
+                * 100
             )
             assert pct.max() < 0.01, f"{class_name}: separation_rate max diff {pct.max():.4f}%"
 
 
-_EXCEL_MORT = Path(__file__).parent.parent.parent / "R_model" / "R_model_frs" / "pub-2010-headcount-mort-rates.xlsx"
-_EXCEL_IMP = Path(__file__).parent.parent.parent / "R_model" / "R_model_frs" / "mortality-improvement-scale-mp-2018-rates.xlsx"
+_EXCEL_MORT = (
+    Path(__file__).parent.parent.parent
+    / "R_model"
+    / "R_model_frs"
+    / "pub-2010-headcount-mort-rates.xlsx"
+)
+_EXCEL_IMP = (
+    Path(__file__).parent.parent.parent
+    / "R_model"
+    / "R_model_frs"
+    / "mortality-improvement-scale-mp-2018-rates.xlsx"
+)
 _EXCEL_AVAILABLE = _EXCEL_MORT.exists() and _EXCEL_IMP.exists()
 
 
-@pytest.mark.skipif(not _EXCEL_AVAILABLE, reason="R_model/R_model_frs Excel mortality files not available")
+@pytest.mark.skipif(
+    not _EXCEL_AVAILABLE, reason="R_model/R_model_frs Excel mortality files not available"
+)
 class TestAnnFactorTable:
     """Test build_ann_factor_table against R's extracted cum_mort_dr and ann_factor."""
 
@@ -198,8 +219,10 @@ class TestAnnFactorTable:
     def _build_compact_aft(self):
         """Build ann_factor_table from raw Excel for Regular, entry_year=2000 only."""
         from pension_model.core.benefit_tables import (
-            build_ann_factor_table, build_salary_headcount_table,
-            build_entrant_profile, build_salary_benefit_table,
+            build_ann_factor_table,
+            build_entrant_profile,
+            build_salary_benefit_table,
+            build_salary_headcount_table,
         )
         from pension_model.core.mortality_builder import build_compact_mortality_from_excel
         from pension_model.plan_config import load_plan_config_by_name
@@ -241,7 +264,8 @@ class TestAnnFactorTable:
         if mask.any():
             pct = (
                 (m.loc[mask, "cum_mort_dr_py"] - m.loc[mask, "cum_mort_dr_r"]).abs()
-                / m.loc[mask, "cum_mort_dr_r"].abs() * 100
+                / m.loc[mask, "cum_mort_dr_r"].abs()
+                * 100
             )
             assert pct.max() < 0.01, f"cum_mort_dr max diff {pct.max():.4f}%"
 
@@ -262,7 +286,8 @@ class TestAnnFactorTable:
         if mask.any():
             pct = (
                 (m.loc[mask, "ann_factor_py"] - m.loc[mask, "ann_factor_r"]).abs()
-                / m.loc[mask, "ann_factor_r"].abs() * 100
+                / m.loc[mask, "ann_factor_r"].abs()
+                * 100
             )
             assert pct.max() < 0.01, f"ann_factor max diff {pct.max():.4f}%"
 
@@ -274,9 +299,9 @@ class TestSalaryBenefitTable:
     def test_salary_fas_match_r(self, class_name):
         """Verify salary and FAS match R's benefit_data for Regular class."""
         from pension_model.core.benefit_tables import (
-            build_salary_headcount_table,
             build_entrant_profile,
             build_salary_benefit_table,
+            build_salary_headcount_table,
         )
         from pension_model.plan_config import load_plan_config_by_name
 
@@ -286,14 +311,22 @@ class TestSalaryBenefitTable:
         hc = pd.read_csv(FRS_BASELINES / f"{class_name}_headcount.csv")
 
         sh = build_salary_headcount_table(
-            sal, hc, salary_growth, class_name,
-            constants.class_data[class_name].total_active_member, 2022,
+            sal,
+            hc,
+            salary_growth,
+            class_name,
+            constants.class_data[class_name].total_active_member,
+            2022,
             constants=constants,
         )
         ep = build_entrant_profile(sh)
 
         sbt = build_salary_benefit_table(
-            sh, ep, salary_growth, class_name, constants,
+            sh,
+            ep,
+            salary_growth,
+            class_name,
+            constants,
         )
 
         # Load R's benefit_data for comparison

--- a/tests/test_pension_model/test_calibration.py
+++ b/tests/test_pension_model/test_calibration.py
@@ -9,8 +9,8 @@ Verifies that:
 
 import sys
 from pathlib import Path
+
 import pytest
-import numpy as np
 
 pytestmark = [pytest.mark.regression, pytest.mark.plan_frs]
 
@@ -24,11 +24,12 @@ CLASSES = ["regular", "special", "admin", "eco", "eso", "judges", "senior_manage
 @pytest.fixture(scope="module")
 def calibration_results():
     """Run calibration and return (results, targets, constants)."""
+    from pension_model.core.calibration import (
+        build_targets_from_config,
+        run_calibration,
+    )
     from pension_model.core.pipeline import run_plan_pipeline
     from pension_model.plan_config import load_plan_config_by_name
-    from pension_model.core.calibration import (
-        build_targets_from_config, run_calibration,
-    )
 
     # Load with calibration file to get cal_factor (a calibration parameter,
     # not plan design), but neutralize nc_cal and pvfb_term_current so the
@@ -53,6 +54,7 @@ def calibration_results():
 def test_nc_cal_matches_json(calibration_results, class_name):
     """Computed nc_cal should match the value in calibration.json."""
     import json
+
     results, _, _ = calibration_results
 
     json_path = FRS_CONFIG_DIR / "calibration.json"
@@ -62,15 +64,16 @@ def test_nc_cal_matches_json(calibration_results, class_name):
     computed = results[class_name].nc_cal
     expected = cal_json["classes"][class_name]["nc_cal"]
     # JSON serialization introduces small rounding; allow 1e-6 tolerance
-    assert abs(computed - expected) < 1e-6, (
-        f"{class_name}: computed nc_cal={computed:.10f} vs JSON={expected:.10f}"
-    )
+    assert (
+        abs(computed - expected) < 1e-6
+    ), f"{class_name}: computed nc_cal={computed:.10f} vs JSON={expected:.10f}"
 
 
 @pytest.mark.parametrize("class_name", CLASSES)
 def test_pvfb_term_matches_json(calibration_results, class_name):
     """Computed pvfb_term_current should match JSON value (within rounding)."""
     import json
+
     results, _, _ = calibration_results
 
     json_path = FRS_CONFIG_DIR / "calibration.json"
@@ -80,9 +83,9 @@ def test_pvfb_term_matches_json(calibration_results, class_name):
     computed = results[class_name].pvfb_term_current
     expected = cal_json["classes"][class_name]["pvfb_term_current"]
     # Allow $1 tolerance (float precision vs integer in JSON)
-    assert abs(computed - expected) < 1.0, (
-        f"{class_name}: computed pvfb_term={computed:.2f} vs JSON={expected:.2f}"
-    )
+    assert (
+        abs(computed - expected) < 1.0
+    ), f"{class_name}: computed pvfb_term={computed:.2f} vs JSON={expected:.2f}"
 
 
 @pytest.mark.parametrize("class_name", ["regular", "special"])
@@ -99,6 +102,7 @@ def test_nc_cal_near_one_for_large_classes(calibration_results, class_name):
 def test_diagnostics_format(calibration_results):
     """Diagnostics string should contain expected sections."""
     from pension_model.core.calibration import format_diagnostics
+
     results, targets, constants = calibration_results
     output = format_diagnostics(results, targets, constants.benefit.cal_factor)
     assert "Calibration Diagnostics" in output

--- a/tests/test_pension_model/test_cli_subcommands.py
+++ b/tests/test_pension_model/test_cli_subcommands.py
@@ -8,7 +8,6 @@ import pytest
 
 from pension_model.cli import _discover_scenarios, _get_test_targets
 
-
 pytestmark = [pytest.mark.unit]
 
 
@@ -27,18 +26,18 @@ def test_validate_scenarios_subcommand_passes_for_existing_scenarios():
     """All shipped (plan, scenario) pairs must validate cleanly."""
     result = subprocess.run(
         ["pension-model", "validate-scenarios"],
-        capture_output=True, text=True,
+        capture_output=True,
+        text=True,
     )
-    assert result.returncode == 0, (
-        f"validate-scenarios failed:\n{result.stdout}\n{result.stderr}"
-    )
+    assert result.returncode == 0, f"validate-scenarios failed:\n{result.stdout}\n{result.stderr}"
     assert "All" in result.stdout and "validated" in result.stdout
 
 
 def test_validate_scenarios_filters_by_plan():
     result = subprocess.run(
         ["pension-model", "validate-scenarios", "--plan", "txtrs"],
-        capture_output=True, text=True,
+        capture_output=True,
+        text=True,
     )
     assert result.returncode == 0
     assert "txtrs" in result.stdout

--- a/tests/test_pension_model/test_config_top_level_strict.py
+++ b/tests/test_pension_model/test_config_top_level_strict.py
@@ -20,7 +20,6 @@ from pension_model.config_loading import (
     load_plan_config_by_name,
 )
 
-
 pytestmark = [pytest.mark.unit]
 
 

--- a/tests/test_pension_model/test_consistency.py
+++ b/tests/test_pension_model/test_consistency.py
@@ -7,8 +7,9 @@ the model output, independent of calibration or R baseline matching.
 
 import sys
 from pathlib import Path
-import pytest
+
 import numpy as np
+import pytest
 
 pytestmark = [pytest.mark.invariant, pytest.mark.plan_frs]
 
@@ -21,8 +22,8 @@ CLASSES_PLUS_DROP = CLASSES + ["drop"]
 @pytest.fixture(scope="module")
 def model_results():
     """Run full pipeline once and return (liability, funding, constants)."""
-    from pension_model.core.pipeline import run_plan_pipeline
     from pension_model.core.funding_model import load_funding_inputs, run_funding_model
+    from pension_model.core.pipeline import run_plan_pipeline
     from pension_model.plan_config import load_plan_config_by_name
 
     constants = load_plan_config_by_name("frs")
@@ -37,6 +38,7 @@ def model_results():
 # Liability pipeline: AAL composition
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.parametrize("class_name", CLASSES)
 def test_liability_aal_composition_legacy(class_name, model_results):
     """AAL legacy = active + term + retire + current_retire + current_term."""
@@ -48,8 +50,12 @@ def test_liability_aal_composition_legacy(class_name, model_results):
         + liab["aal_retire_current_est"]
         + liab["aal_term_current_est"]
     )
-    np.testing.assert_allclose(liab["aal_legacy_est"].values, computed.values,
-                               atol=1e-6, err_msg=f"{class_name}: legacy AAL composition")
+    np.testing.assert_allclose(
+        liab["aal_legacy_est"].values,
+        computed.values,
+        atol=1e-6,
+        err_msg=f"{class_name}: legacy AAL composition",
+    )
 
 
 @pytest.mark.parametrize("class_name", CLASSES)
@@ -57,12 +63,14 @@ def test_liability_aal_composition_new(class_name, model_results):
     """AAL new = active_new + term_new + retire_new."""
     liab = model_results[0][class_name]
     computed = (
-        liab["aal_active_db_new_est"]
-        + liab["aal_term_db_new_est"]
-        + liab["aal_retire_db_new_est"]
+        liab["aal_active_db_new_est"] + liab["aal_term_db_new_est"] + liab["aal_retire_db_new_est"]
     )
-    np.testing.assert_allclose(liab["aal_new_est"].values, computed.values,
-                               atol=1e-6, err_msg=f"{class_name}: new AAL composition")
+    np.testing.assert_allclose(
+        liab["aal_new_est"].values,
+        computed.values,
+        atol=1e-6,
+        err_msg=f"{class_name}: new AAL composition",
+    )
 
 
 @pytest.mark.parametrize("class_name", CLASSES)
@@ -72,7 +80,9 @@ def test_liability_total_aal(class_name, model_results):
     np.testing.assert_allclose(
         liab["total_aal_est"].values,
         (liab["aal_legacy_est"] + liab["aal_new_est"]).values,
-        atol=1e-6, err_msg=f"{class_name}: total AAL = legacy + new")
+        atol=1e-6,
+        err_msg=f"{class_name}: total AAL = legacy + new",
+    )
 
 
 @pytest.mark.parametrize("class_name", CLASSES)
@@ -82,8 +92,11 @@ def test_liability_active_aal_eq_pvfb_minus_pvfnc(class_name, model_results):
     for tier in ["legacy", "new"]:
         computed = liab[f"pvfb_active_db_{tier}_est"] - liab[f"pvfnc_db_{tier}_est"]
         np.testing.assert_allclose(
-            liab[f"aal_active_db_{tier}_est"].values, computed.values,
-            atol=1e-6, err_msg=f"{class_name}: active AAL {tier} = PVFB - PVFNC")
+            liab[f"aal_active_db_{tier}_est"].values,
+            computed.values,
+            atol=1e-6,
+            err_msg=f"{class_name}: active AAL {tier} = PVFB - PVFNC",
+        )
 
 
 @pytest.mark.parametrize("class_name", CLASSES)
@@ -98,21 +111,28 @@ def test_liability_benefit_outflow_composition(class_name, model_results):
     )
     new = liab["refund_db_new_est"] + liab["retire_ben_db_new_est"]
     np.testing.assert_allclose(
-        liab["tot_ben_refund_est"].values, (legacy + new).values,
-        atol=1e-6, err_msg=f"{class_name}: total benefit outflow composition")
+        liab["tot_ben_refund_est"].values,
+        (legacy + new).values,
+        atol=1e-6,
+        err_msg=f"{class_name}: total benefit outflow composition",
+    )
 
 
 # ---------------------------------------------------------------------------
 # Funding: algebraic identities (per class, per year)
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.parametrize("class_name", CLASSES_PLUS_DROP)
 def test_funding_total_aal_eq_legacy_plus_new(class_name, model_results):
     """total_aal = aal_legacy + aal_new."""
     f = model_results[1][class_name]
     np.testing.assert_allclose(
-        f["total_aal"].values, (f["aal_legacy"] + f["aal_new"]).values,
-        atol=1e-2, err_msg=f"{class_name}: funding total_aal = legacy + new")
+        f["total_aal"].values,
+        (f["aal_legacy"] + f["aal_new"]).values,
+        atol=1e-2,
+        err_msg=f"{class_name}: funding total_aal = legacy + new",
+    )
 
 
 @pytest.mark.parametrize("class_name", CLASSES_PLUS_DROP)
@@ -120,8 +140,11 @@ def test_funding_total_mva_eq_legacy_plus_new(class_name, model_results):
     """total_mva = mva_legacy + mva_new."""
     f = model_results[1][class_name]
     np.testing.assert_allclose(
-        f["total_mva"].values, (f["mva_legacy"] + f["mva_new"]).values,
-        atol=1e-2, err_msg=f"{class_name}: funding total_mva = legacy + new")
+        f["total_mva"].values,
+        (f["mva_legacy"] + f["mva_new"]).values,
+        atol=1e-2,
+        err_msg=f"{class_name}: funding total_mva = legacy + new",
+    )
 
 
 @pytest.mark.parametrize("class_name", CLASSES_PLUS_DROP)
@@ -132,11 +155,15 @@ def test_funding_ual_eq_aal_minus_ava(class_name, model_results):
         np.testing.assert_allclose(
             f[f"ual_ava_{tier}"].values,
             (f[f"aal_{tier}"] - f[f"ava_{tier}"]).values,
-            atol=1e-2, err_msg=f"{class_name}: UAL {tier} = AAL - AVA")
+            atol=1e-2,
+            err_msg=f"{class_name}: UAL {tier} = AAL - AVA",
+        )
     np.testing.assert_allclose(
         f["total_ual_ava"].values,
         (f["total_aal"] - f["total_ava"]).values,
-        atol=1e-2, err_msg=f"{class_name}: total UAL = total AAL - total AVA")
+        atol=1e-2,
+        err_msg=f"{class_name}: total UAL = total AAL - total AVA",
+    )
 
 
 @pytest.mark.parametrize("class_name", CLASSES_PLUS_DROP)
@@ -146,19 +173,30 @@ def test_funding_funded_ratio(class_name, model_results):
     mask = f["total_aal"].values > 1e-6
     expected = f["total_ava"].values[mask] / f["total_aal"].values[mask]
     np.testing.assert_allclose(
-        f["fr_ava"].values[mask], expected,
-        atol=1e-8, err_msg=f"{class_name}: funded ratio = AVA / AAL")
+        f["fr_ava"].values[mask],
+        expected,
+        atol=1e-8,
+        err_msg=f"{class_name}: funded ratio = AVA / AAL",
+    )
 
 
 # ---------------------------------------------------------------------------
 # Funding: FRS plan-wide = sum of classes + DROP
 # ---------------------------------------------------------------------------
 
-@pytest.mark.parametrize("col", [
-    "total_aal", "total_mva", "total_payroll",
-    "nc_legacy", "nc_new",
-    "total_ben_payment", "total_refund",
-])
+
+@pytest.mark.parametrize(
+    "col",
+    [
+        "total_aal",
+        "total_mva",
+        "total_payroll",
+        "nc_legacy",
+        "nc_new",
+        "total_ben_payment",
+        "total_refund",
+    ],
+)
 def test_frs_is_sum_of_classes(col, model_results):
     """FRS plan-wide totals = sum across 7 classes + DROP (years 1+).
 
@@ -169,13 +207,14 @@ def test_frs_is_sum_of_classes(col, model_results):
     class_sum = sum(funding[cn][col].values for cn in CLASSES_PLUS_DROP)
     # Skip year 0 (index 0) — seed data from ACFR, not computed
     np.testing.assert_allclose(
-        frs[col].values[1:], class_sum[1:],
-        atol=1e-2, err_msg=f"frs[{col}] != sum of classes")
+        frs[col].values[1:], class_sum[1:], atol=1e-2, err_msg=f"frs[{col}] != sum of classes"
+    )
 
 
 # ---------------------------------------------------------------------------
 # Funding: AAL roll-forward
 # ---------------------------------------------------------------------------
+
 
 @pytest.mark.parametrize("class_name", CLASSES)
 def test_aal_roll_forward_legacy(class_name, model_results):
@@ -188,15 +227,16 @@ def test_aal_roll_forward_legacy(class_name, model_results):
     for i in range(1, len(f)):
         expected = (
             f.loc[i - 1, "aal_legacy"] * (1 + dr)
-            + (f.loc[i, "nc_legacy"] - f.loc[i, "ben_payment_legacy"]
-               - f.loc[i, "refund_legacy"]) * (1 + dr) ** 0.5
+            + (f.loc[i, "nc_legacy"] - f.loc[i, "ben_payment_legacy"] - f.loc[i, "refund_legacy"])
+            * (1 + dr) ** 0.5
             + f.loc[i, "liability_gain_loss_legacy"]
         )
         actual = f.loc[i, "aal_legacy"]
         if abs(expected) > 1e-6:
             pct_diff = abs(actual - expected) / abs(expected) * 100
-            assert pct_diff < 0.01, (
-                f"{class_name} year {i}: AAL legacy roll-forward off by {pct_diff:.4f}%")
+            assert (
+                pct_diff < 0.01
+            ), f"{class_name} year {i}: AAL legacy roll-forward off by {pct_diff:.4f}%"
 
 
 @pytest.mark.parametrize("class_name", CLASSES)
@@ -210,20 +250,22 @@ def test_aal_roll_forward_new(class_name, model_results):
     for i in range(1, len(f)):
         expected = (
             f.loc[i - 1, "aal_new"] * (1 + dr)
-            + (f.loc[i, "nc_new"] - f.loc[i, "ben_payment_new"]
-               - f.loc[i, "refund_new"]) * (1 + dr) ** 0.5
+            + (f.loc[i, "nc_new"] - f.loc[i, "ben_payment_new"] - f.loc[i, "refund_new"])
+            * (1 + dr) ** 0.5
             + f.loc[i, "liability_gain_loss_new"]
         )
         actual = f.loc[i, "aal_new"]
         if abs(expected) > 1e-6:
             pct_diff = abs(actual - expected) / abs(expected) * 100
-            assert pct_diff < 0.01, (
-                f"{class_name} year {i}: AAL new roll-forward off by {pct_diff:.4f}%")
+            assert (
+                pct_diff < 0.01
+            ), f"{class_name} year {i}: AAL new roll-forward off by {pct_diff:.4f}%"
 
 
 # ---------------------------------------------------------------------------
 # Funding: MVA roll-forward
 # ---------------------------------------------------------------------------
+
 
 @pytest.mark.parametrize("class_name", CLASSES_PLUS_DROP)
 def test_mva_roll_forward(class_name, model_results):
@@ -240,13 +282,15 @@ def test_mva_roll_forward(class_name, model_results):
             actual = f.loc[i, f"mva_{tier}"]
             if abs(expected) > 1e-6:
                 pct_diff = abs(actual - expected) / abs(expected) * 100
-                assert pct_diff < 0.01, (
-                    f"{class_name} year {i}: MVA {tier} roll-forward off by {pct_diff:.4f}%")
+                assert (
+                    pct_diff < 0.01
+                ), f"{class_name} year {i}: MVA {tier} roll-forward off by {pct_diff:.4f}%"
 
 
 # ---------------------------------------------------------------------------
 # Funding: contribution components
 # ---------------------------------------------------------------------------
+
 
 @pytest.mark.parametrize("class_name", CLASSES_PLUS_DROP)
 def test_er_contribution_composition(class_name, model_results):
@@ -254,18 +298,20 @@ def test_er_contribution_composition(class_name, model_results):
     f = model_results[1][class_name]
     for i in range(1, len(f)):
         expected = (
-            f.loc[i, "total_er_db_cont"]
-            + f.loc[i, "total_er_dc_cont"]
-            + f.loc[i, "solv_cont"]
+            f.loc[i, "total_er_db_cont"] + f.loc[i, "total_er_dc_cont"] + f.loc[i, "solv_cont"]
         )
         np.testing.assert_allclose(
-            f.loc[i, "total_er_cont"], expected, atol=1e-2,
-            err_msg=f"{class_name} year {i}: ER cont = DB + DC + solvency")
+            f.loc[i, "total_er_cont"],
+            expected,
+            atol=1e-2,
+            err_msg=f"{class_name} year {i}: ER cont = DB + DC + solvency",
+        )
 
 
 # ---------------------------------------------------------------------------
 # Funding: payroll ratio sanity
 # ---------------------------------------------------------------------------
+
 
 @pytest.mark.parametrize("class_name", CLASSES)
 def test_payroll_ratios_sum_to_one(class_name, model_results):
@@ -279,26 +325,30 @@ def test_payroll_ratios_sum_to_one(class_name, model_results):
             + f.loc[i, "payroll_dc_new_ratio"]
         )
         # Ratios should be close to 1.0 (may not be exact due to rounding)
-        assert abs(ratio_sum - 1.0) < 0.02, (
-            f"{class_name} year {i}: payroll ratios sum to {ratio_sum:.4f}, expected ~1.0")
+        assert (
+            abs(ratio_sum - 1.0) < 0.02
+        ), f"{class_name} year {i}: payroll ratios sum to {ratio_sum:.4f}, expected ~1.0"
 
 
 # ---------------------------------------------------------------------------
 # Funding: benefit payments are positive
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.parametrize("class_name", CLASSES)
 def test_benefit_payments_positive(class_name, model_results):
     """Total benefit payments should be positive for years 1+."""
     f = model_results[1][class_name]
     for i in range(1, len(f)):
-        assert f.loc[i, "total_ben_payment"] >= 0, (
-            f"{class_name} year {i}: negative benefit payment {f.loc[i, 'total_ben_payment']}")
+        assert (
+            f.loc[i, "total_ben_payment"] >= 0
+        ), f"{class_name} year {i}: negative benefit payment {f.loc[i, 'total_ben_payment']}"
 
 
 # ---------------------------------------------------------------------------
 # Funding: payroll grows at expected rate
 # ---------------------------------------------------------------------------
+
 
 @pytest.mark.parametrize("class_name", CLASSES)
 def test_payroll_growth_rate(class_name, model_results):
@@ -311,5 +361,8 @@ def test_payroll_growth_rate(class_name, model_results):
         if f.loc[i - 1, "total_payroll"] > 0:
             expected = f.loc[i - 1, "total_payroll"] * (1 + g)
             np.testing.assert_allclose(
-                f.loc[i, "total_payroll"], expected, rtol=1e-10,
-                err_msg=f"{class_name} year {i}: payroll growth")
+                f.loc[i, "total_payroll"],
+                expected,
+                rtol=1e-10,
+                err_msg=f"{class_name} year {i}: payroll growth",
+            )

--- a/tests/test_pension_model/test_data_integrity.py
+++ b/tests/test_pension_model/test_data_integrity.py
@@ -4,6 +4,7 @@ Verifies that classes sharing the same underlying decrement source have
 byte-identical data files. This catches accidental drift if someone
 edits one copy and forgets to update the others.
 """
+
 import hashlib
 from pathlib import Path
 

--- a/tests/test_pension_model/test_data_manifest.py
+++ b/tests/test_pension_model/test_data_manifest.py
@@ -8,7 +8,6 @@ templates, and returns missing required files.
 from __future__ import annotations
 
 import json
-from pathlib import Path
 
 import pytest
 
@@ -18,7 +17,6 @@ from pension_model.config_validation import (
     _resolve_manifest_path,
     validate_data_manifest,
 )
-
 
 pytestmark = [pytest.mark.unit]
 
@@ -52,22 +50,25 @@ def test_missing_required_file_reported(tmp_path):
     data_dir = plan_root / "data"
     (data_dir / "demographics").mkdir(parents=True)
     (plan_root / "data_manifest.json").write_text(
-        json.dumps({
-            "schema_version": 1,
-            "files": [
-                {
-                    "path": "demographics/retiree_distribution.csv",
-                    "scope": "plan",
-                    "required": True,
-                    "purpose": "test",
-                },
-            ],
-        })
+        json.dumps(
+            {
+                "schema_version": 1,
+                "files": [
+                    {
+                        "path": "demographics/retiree_distribution.csv",
+                        "scope": "plan",
+                        "required": True,
+                        "purpose": "test",
+                    },
+                ],
+            }
+        )
     )
 
     class FakeConfig:
         classes = ("all",)
         plan_name = "plan_x"
+
         def resolve_data_dir(self):
             return data_dir
 
@@ -85,23 +86,26 @@ def test_fallback_path_satisfies_requirement(tmp_path):
     # Only the fallback file exists, not the per-class primary
     (data_dir / "demographics" / "salary_growth.csv").write_text("yos,growth\n")
     (plan_root / "data_manifest.json").write_text(
-        json.dumps({
-            "schema_version": 1,
-            "files": [
-                {
-                    "path": "demographics/{class_name}_salary_growth.csv",
-                    "scope": "per_class",
-                    "required": True,
-                    "fallback": "demographics/salary_growth.csv",
-                    "purpose": "test",
-                },
-            ],
-        })
+        json.dumps(
+            {
+                "schema_version": 1,
+                "files": [
+                    {
+                        "path": "demographics/{class_name}_salary_growth.csv",
+                        "scope": "per_class",
+                        "required": True,
+                        "fallback": "demographics/salary_growth.csv",
+                        "purpose": "test",
+                    },
+                ],
+            }
+        )
     )
 
     class FakeConfig:
         classes = ("all",)
         plan_name = "plan_x"
+
         def resolve_data_dir(self):
             return data_dir
 
@@ -114,22 +118,25 @@ def test_optional_files_are_not_required(tmp_path):
     data_dir = plan_root / "data"
     data_dir.mkdir(parents=True)
     (plan_root / "data_manifest.json").write_text(
-        json.dumps({
-            "schema_version": 1,
-            "files": [
-                {
-                    "path": "demographics/entrant_profile.csv",
-                    "scope": "plan",
-                    "required": False,
-                    "purpose": "test",
-                },
-            ],
-        })
+        json.dumps(
+            {
+                "schema_version": 1,
+                "files": [
+                    {
+                        "path": "demographics/entrant_profile.csv",
+                        "scope": "plan",
+                        "required": False,
+                        "purpose": "test",
+                    },
+                ],
+            }
+        )
     )
 
     class FakeConfig:
         classes = ("all",)
         plan_name = "plan_x"
+
         def resolve_data_dir(self):
             return data_dir
 

--- a/tests/test_pension_model/test_funding_baseline.py
+++ b/tests/test_pension_model/test_funding_baseline.py
@@ -7,9 +7,10 @@ key funding columns against R's extracted funding CSVs.
 
 import sys
 from pathlib import Path
-import pytest
+
 import numpy as np
 import pandas as pd
+import pytest
 
 pytestmark = [
     pytest.mark.regression,
@@ -23,16 +24,22 @@ FRS_BASELINES = Path(__file__).parent.parent.parent / "plans" / "frs" / "baselin
 CLASSES = ["regular", "special", "admin", "eco", "eso", "judges", "senior_management"]
 
 FUNDING_COLS = [
-    "total_aal", "total_ava", "total_mva", "total_er_cont", "fr_ava",
-    "total_payroll", "nc_rate_db_legacy", "er_amo_cont_legacy",
+    "total_aal",
+    "total_ava",
+    "total_mva",
+    "total_er_cont",
+    "fr_ava",
+    "total_payroll",
+    "nc_rate_db_legacy",
+    "er_amo_cont_legacy",
 ]
 
 
 @pytest.fixture(scope="module")
 def funding_results():
     """Run the full pipeline once and cache results for all tests."""
-    from pension_model.core.pipeline import run_plan_pipeline
     from pension_model.core.funding_model import load_funding_inputs, run_funding_model
+    from pension_model.core.pipeline import run_plan_pipeline
     from pension_model.plan_config import load_plan_config_by_name
 
     constants = load_plan_config_by_name("frs")
@@ -55,7 +62,7 @@ def test_funding_matches_r_baseline(class_name, funding_results):
             mask = np.abs(rv) > 1e-6
             n = min(mask.sum(), len(pv))
             if n > 0:
-                pct = np.abs(pv[mask[:len(pv)]][:n] - rv[mask][:n]) / np.abs(rv[mask][:n]) * 100
+                pct = np.abs(pv[mask[: len(pv)]][:n] - rv[mask][:n]) / np.abs(rv[mask][:n]) * 100
                 max_diff = max(max_diff, pct.max())
 
     assert max_diff < 0.01, f"{class_name}: funding max diff {max_diff:.4f}%"

--- a/tests/test_pension_model/test_funding_snapshots.py
+++ b/tests/test_pension_model/test_funding_snapshots.py
@@ -50,8 +50,8 @@ def _running_in_update_mode() -> bool:
 
 def _run_funding(plan_name: str) -> dict:
     """Run the full pipeline and return the funding dict for ``plan_name``."""
-    from pension_model.core.pipeline import run_plan_pipeline
     from pension_model.core.funding_model import load_funding_inputs, run_funding_model
+    from pension_model.core.pipeline import run_plan_pipeline
     from pension_model.plan_config import load_plan_config_by_name
 
     if plan_name not in ("frs", "txtrs"):
@@ -97,9 +97,7 @@ def _write_snapshot(plan_name: str, funding: dict) -> None:
     meta = {
         "keys": keys,
         "aliases": {
-            key: seen_ids[id(funding[key])]
-            for key in keys
-            if seen_ids[id(funding[key])] != key
+            key: seen_ids[id(funding[key])] for key in keys if seen_ids[id(funding[key])] != key
         },
     }
     _meta_path(plan_name).write_text(json.dumps(meta, indent=2, sort_keys=True))

--- a/tests/test_pension_model/test_identity_checks.py
+++ b/tests/test_pension_model/test_identity_checks.py
@@ -21,7 +21,6 @@ from pension_model.core.identity_checks import (
 )
 from pension_model.core.pipeline import run_plan_pipeline
 
-
 pytestmark = [pytest.mark.integration]
 
 
@@ -86,8 +85,10 @@ def test_mva_break_is_caught(txtrs_funding):
     with pytest.raises(IdentityCheckError) as excinfo:
         check_funding_identities(
             perturbed,
-            dr_current=ctx.dr_current, dr_new=ctx.dr_new,
-            ret_scen=ctx.ret_scen, has_cb=ctx.has_cb,
+            dr_current=ctx.dr_current,
+            dr_new=ctx.dr_new,
+            ret_scen=ctx.ret_scen,
+            has_cb=ctx.has_cb,
             skip_classes={"drop"} if ctx.has_drop else set(),
         )
 
@@ -108,8 +109,10 @@ def test_aal_break_is_caught(txtrs_funding):
     with pytest.raises(IdentityCheckError) as excinfo:
         check_funding_identities(
             perturbed,
-            dr_current=ctx.dr_current, dr_new=ctx.dr_new,
-            ret_scen=ctx.ret_scen, has_cb=ctx.has_cb,
+            dr_current=ctx.dr_current,
+            dr_new=ctx.dr_new,
+            ret_scen=ctx.ret_scen,
+            has_cb=ctx.has_cb,
             skip_classes={"drop"} if ctx.has_drop else set(),
         )
 
@@ -125,8 +128,10 @@ def test_nc_dollar_break_is_caught(txtrs_funding):
     with pytest.raises(IdentityCheckError) as excinfo:
         check_funding_identities(
             perturbed,
-            dr_current=ctx.dr_current, dr_new=ctx.dr_new,
-            ret_scen=ctx.ret_scen, has_cb=ctx.has_cb,
+            dr_current=ctx.dr_current,
+            dr_new=ctx.dr_new,
+            ret_scen=ctx.ret_scen,
+            has_cb=ctx.has_cb,
             skip_classes={"drop"} if ctx.has_drop else set(),
         )
 

--- a/tests/test_pension_model/test_multi_class_gainloss.py
+++ b/tests/test_pension_model/test_multi_class_gainloss.py
@@ -27,8 +27,8 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
 
 @pytest.fixture(scope="module")
 def two_class_gainloss_outputs():
-    from pension_model.core.pipeline import run_plan_pipeline
     from pension_model.core.funding_model import load_funding_inputs, run_funding_model
+    from pension_model.core.pipeline import run_plan_pipeline
     from pension_model.plan_config import load_plan_config_by_name
 
     constants = load_plan_config_by_name("txtrs")
@@ -43,11 +43,13 @@ def two_class_gainloss_outputs():
     one_cal = constants.calibration.get(sole_class) or ClassCalibration()
     init_row = funding_inputs["init_funding"].iloc[0].to_dict()
 
-    new_constants = constants.model_copy(update={
-        "classes": ("a", "b"),
-        "valuation_inputs": {"a": one_vi, "b": one_vi},
-        "calibration": {"a": one_cal, "b": one_cal},
-    })
+    new_constants = constants.model_copy(
+        update={
+            "classes": ("a", "b"),
+            "valuation_inputs": {"a": one_vi, "b": one_vi},
+            "calibration": {"a": one_cal, "b": one_cal},
+        }
+    )
 
     new_liability = {"a": one_liab.copy(), "b": one_liab.copy()}
 
@@ -55,14 +57,16 @@ def two_class_gainloss_outputs():
     # plan_name. Values are 2x the per-class init (both classes share
     # the same TRS starting values).
     agg_row = {
-        k: (2 * v if isinstance(v, (int, float, np.integer, np.floating)) else v)
+        k: (2 * v if isinstance(v, int | float | np.integer | np.floating) else v)
         for k, v in init_row.items()
     }
-    new_init = pd.DataFrame([
-        {**init_row, "class": "a"},
-        {**init_row, "class": "b"},
-        {**agg_row, "class": constants.plan_name},
-    ])
+    new_init = pd.DataFrame(
+        [
+            {**init_row, "class": "a"},
+            {**init_row, "class": "b"},
+            {**agg_row, "class": constants.plan_name},
+        ]
+    )
     new_funding_inputs = {**funding_inputs, "init_funding": new_init}
 
     return run_funding_model(new_liability, new_funding_inputs, new_constants), new_constants
@@ -80,16 +84,19 @@ def test_multi_class_gainloss_class_frames_identical(two_class_gainloss_outputs)
     assert_frame_equal(funding["a"], funding["b"], check_exact=True, check_dtype=True)
 
 
-@pytest.mark.parametrize("col", [
-    "total_payroll",
-    "nc_legacy",
-    "nc_new",
-    "aal_legacy",
-    "total_aal",
-    "ben_payment_legacy",
-    "total_mva",
-    "total_er_cont",
-])
+@pytest.mark.parametrize(
+    "col",
+    [
+        "total_payroll",
+        "nc_legacy",
+        "nc_new",
+        "aal_legacy",
+        "total_aal",
+        "ben_payment_legacy",
+        "total_mva",
+        "total_er_cont",
+    ],
+)
 @pytest.mark.parametrize("i", [1, 5, 15])
 def test_multi_class_gainloss_aggregate_sums_flow_cols(two_class_gainloss_outputs, col, i):
     """Aggregate flow columns accumulate to the sum of per-class values."""

--- a/tests/test_pension_model/test_output_uniformity.py
+++ b/tests/test_pension_model/test_output_uniformity.py
@@ -16,7 +16,6 @@ from pension_model.output_uniformity import (
     assert_output_uniformity,
 )
 
-
 pytestmark = [pytest.mark.unit]
 
 
@@ -24,19 +23,24 @@ CANONICAL = ["plan", "year", "aal", "mva"]
 
 
 def _good_frame():
-    return pd.DataFrame({
-        "plan": ["frs"] * 3,
-        "year": [2024, 2025, 2026],
-        "aal": [1.0, 2.0, 3.0],
-        "mva": [4.0, 5.0, 6.0],
-    })
+    return pd.DataFrame(
+        {
+            "plan": ["frs"] * 3,
+            "year": [2024, 2025, 2026],
+            "aal": [1.0, 2.0, 3.0],
+            "mva": [4.0, 5.0, 6.0],
+        }
+    )
 
 
 def test_passes_when_all_columns_populated():
     df = _good_frame()
     assert_output_uniformity(
-        df, CANONICAL, inapplicable=(),
-        plan_name="frs", output_name="summary",
+        df,
+        CANONICAL,
+        inapplicable=(),
+        plan_name="frs",
+        output_name="summary",
     )
 
 
@@ -44,8 +48,11 @@ def test_missing_canonical_column_caught():
     df = _good_frame().drop(columns=["aal"])
     with pytest.raises(OutputUniformityError) as excinfo:
         assert_output_uniformity(
-            df, CANONICAL, inapplicable=(),
-            plan_name="frs", output_name="summary",
+            df,
+            CANONICAL,
+            inapplicable=(),
+            plan_name="frs",
+            output_name="summary",
         )
     assert "missing canonical columns" in str(excinfo.value)
     assert "aal" in str(excinfo.value)
@@ -56,8 +63,11 @@ def test_nan_in_required_column_caught():
     df.loc[1, "aal"] = np.nan
     with pytest.raises(OutputUniformityError) as excinfo:
         assert_output_uniformity(
-            df, CANONICAL, inapplicable=(),
-            plan_name="frs", output_name="summary",
+            df,
+            CANONICAL,
+            inapplicable=(),
+            plan_name="frs",
+            output_name="summary",
         )
     msg = str(excinfo.value)
     assert "aal" in msg
@@ -68,8 +78,11 @@ def test_nan_allowed_when_column_declared_inapplicable():
     df = _good_frame()
     df["aal"] = np.nan
     assert_output_uniformity(
-        df, CANONICAL, inapplicable=("aal",),
-        plan_name="dc_only_plan", output_name="summary",
+        df,
+        CANONICAL,
+        inapplicable=("aal",),
+        plan_name="dc_only_plan",
+        output_name="summary",
     )
 
 
@@ -78,8 +91,11 @@ def test_inapplicable_column_must_be_all_nan():
     df.loc[0, "aal"] = np.nan  # one NaN, rest populated
     with pytest.raises(OutputUniformityError) as excinfo:
         assert_output_uniformity(
-            df, CANONICAL, inapplicable=("aal",),
-            plan_name="dc_only_plan", output_name="summary",
+            df,
+            CANONICAL,
+            inapplicable=("aal",),
+            plan_name="dc_only_plan",
+            output_name="summary",
         )
     assert "declared inapplicable but populated" in str(excinfo.value)
 
@@ -88,7 +104,10 @@ def test_inapplicable_must_be_in_canonical_list():
     df = _good_frame()
     with pytest.raises(OutputUniformityError) as excinfo:
         assert_output_uniformity(
-            df, CANONICAL, inapplicable=("not_a_real_column",),
-            plan_name="frs", output_name="summary",
+            df,
+            CANONICAL,
+            inapplicable=("not_a_real_column",),
+            plan_name="frs",
+            output_name="summary",
         )
     assert "non-canonical" in str(excinfo.value)

--- a/tests/test_pension_model/test_plan_config_frs.py
+++ b/tests/test_pension_model/test_plan_config_frs.py
@@ -4,10 +4,10 @@ from pathlib import Path
 
 import pytest
 
-pytestmark = [pytest.mark.unit]
-
 from pension_model.config_loading import load_plan_config
 from pension_model.plan_config import load_plan_config_by_name
+
+pytestmark = [pytest.mark.unit]
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_pension_model/test_plan_config_txtrs.py
+++ b/tests/test_pension_model/test_plan_config_txtrs.py
@@ -2,9 +2,9 @@
 
 import pytest
 
-pytestmark = [pytest.mark.unit]
-
 from pension_model.plan_config import load_plan_config_by_name
+
+pytestmark = [pytest.mark.unit]
 
 
 def test_txtrs_loads():

--- a/tests/test_pension_model/test_rundown.py
+++ b/tests/test_pension_model/test_rundown.py
@@ -25,9 +25,10 @@ The test verifies:
 
 import sys
 from pathlib import Path
-import pytest
+
 import numpy as np
 import pandas as pd
+import pytest
 
 pytestmark = [pytest.mark.invariant, pytest.mark.slow, pytest.mark.plan_frs]
 
@@ -45,8 +46,8 @@ def rundown_results():
 
     Returns (liability_dict, funding_dict, constants).
     """
-    from pension_model.core.pipeline import run_plan_pipeline
     from pension_model.core.funding_model import load_funding_inputs, run_funding_model
+    from pension_model.core.pipeline import run_plan_pipeline
     from pension_model.plan_config import load_plan_config_by_name
 
     constants = load_plan_config_by_name("frs")
@@ -69,6 +70,7 @@ def rundown_results():
 # Demographics (liability pipeline)
 # ---------------------------------------------------------------------------
 
+
 class TestRundownDemographics:
     """Verify the population runs down to zero."""
 
@@ -80,7 +82,8 @@ class TestRundownDemographics:
         for i in range(1, len(actives)):
             assert actives[i] <= actives[i - 1] + 1e-6, (
                 f"{class_name} year {i}: active count increased "
-                f"from {actives[i-1]:.1f} to {actives[i]:.1f}")
+                f"from {actives[i-1]:.1f} to {actives[i]:.1f}"
+            )
 
     @pytest.mark.parametrize("class_name", CLASSES)
     def test_active_count_reaches_near_zero(self, class_name, rundown_results):
@@ -91,12 +94,14 @@ class TestRundownDemographics:
         pct_remaining = final / initial * 100 if initial > 0 else 0
         assert pct_remaining < 1.0, (
             f"{class_name}: active count still {pct_remaining:.2f}% "
-            f"of initial after {RUNDOWN_PERIOD} years")
+            f"of initial after {RUNDOWN_PERIOD} years"
+        )
 
 
 # ---------------------------------------------------------------------------
 # Liability AAL rundown
 # ---------------------------------------------------------------------------
+
 
 class TestRundownLiabilities:
     """Verify liabilities run down."""
@@ -111,7 +116,8 @@ class TestRundownLiabilities:
         assert pct_remaining < 0.001, (
             f"{class_name}: AAL still {pct_remaining:.6f}% "
             f"of initial after {RUNDOWN_PERIOD} years "
-            f"(${final:,.0f} remaining)")
+            f"(${final:,.0f} remaining)"
+        )
 
     def test_benefit_payments_eventually_decline(self, rundown_results):
         """Benefits should peak and then decline as retirees die (regular class)."""
@@ -124,7 +130,8 @@ class TestRundownLiabilities:
         if peak_val > 0:
             assert last_quarter_avg < peak_val, (
                 f"Benefits not declining: peak={peak_val:.0f} at year {peak_idx}, "
-                f"last quarter avg={last_quarter_avg:.0f}")
+                f"last quarter avg={last_quarter_avg:.0f}"
+            )
 
     def test_benefits_reach_zero(self, rundown_results):
         """Benefit payments should reach zero — no participants left to pay."""
@@ -134,12 +141,14 @@ class TestRundownLiabilities:
         pct = abs(final_ben) / abs(initial_aal) * 100 if abs(initial_aal) > 0 else 0
         assert pct < 0.001, (
             f"Benefits still {pct:.6f}% of initial AAL after {RUNDOWN_PERIOD} years "
-            f"(${final_ben:,.0f} remaining)")
+            f"(${final_ben:,.0f} remaining)"
+        )
 
 
 # ---------------------------------------------------------------------------
 # Funding model stability
 # ---------------------------------------------------------------------------
+
 
 class TestRundownFundingStability:
     """Verify the funding model doesn't crash or produce NaN over long horizons."""
@@ -149,8 +158,7 @@ class TestRundownFundingStability:
         """Funding output should not contain NaN."""
         f = rundown_results[1][class_name]
         for col in ["total_aal", "total_mva", "total_payroll"]:
-            assert not f[col].isna().any(), (
-                f"{class_name}: NaN in {col}")
+            assert not f[col].isna().any(), f"{class_name}: NaN in {col}"
 
     def test_mva_roll_forward_consistent(self, rundown_results):
         """MVA roll-forward should be internally consistent."""
@@ -165,13 +173,15 @@ class TestRundownFundingStability:
                 actual = f.loc[i, f"mva_{tier}"]
                 if abs(expected) > 1.0:
                     pct_diff = abs(actual - expected) / abs(expected) * 100
-                    assert pct_diff < 0.01, (
-                        f"Year {i}: MVA {tier} roll-forward off by {pct_diff:.4f}%")
+                    assert (
+                        pct_diff < 0.01
+                    ), f"Year {i}: MVA {tier} roll-forward off by {pct_diff:.4f}%"
 
 
 # ---------------------------------------------------------------------------
 # Simplified asset projection (uses actual benefit cash flows)
 # ---------------------------------------------------------------------------
+
 
 class TestRundownAssetProjection:
     """Test a simplified asset projection using actual liability cash flows.
@@ -187,6 +197,7 @@ class TestRundownAssetProjection:
         constants = rundown_results[2]
 
         from pension_model.core.funding_model import load_funding_inputs
+
         funding_dir = constants.resolve_data_dir() / "funding"
         funding_inputs = load_funding_inputs(funding_dir)
         init_funding = funding_inputs["init_funding"]
@@ -208,13 +219,13 @@ class TestRundownAssetProjection:
             ben = liab["tot_ben_refund_est"].iloc[i]
             benefits_paid[i] = ben
 
-            payroll_db = (liab["payroll_db_legacy_est"].iloc[i]
-                          + liab["payroll_db_new_est"].iloc[i])
+            payroll_db = liab["payroll_db_legacy_est"].iloc[i] + liab["payroll_db_new_est"].iloc[i]
             nc_rate_leg = liab["nc_rate_db_legacy_est"].iloc[i] * nc_cal
             nc_rate_new = liab["nc_rate_db_new_est"].iloc[i] * nc_cal
             ee_cont = ee_rate * payroll_db
-            er_nc = ((nc_rate_leg - ee_rate) * liab["payroll_db_legacy_est"].iloc[i]
-                     + max(nc_rate_new - ee_rate, 0) * liab["payroll_db_new_est"].iloc[i])
+            er_nc = (nc_rate_leg - ee_rate) * liab["payroll_db_legacy_est"].iloc[i] + max(
+                nc_rate_new - ee_rate, 0
+            ) * liab["payroll_db_new_est"].iloc[i]
             cont = ee_cont + max(er_nc, 0)
             contributions[i] = cont
 
@@ -222,15 +233,17 @@ class TestRundownAssetProjection:
             mva[i] = mva[i - 1] * (1 + dr) + net_cf * (1 + dr) ** 0.5
             inv_earnings[i] = mva[i] - mva[i - 1] - net_cf
 
-        return pd.DataFrame({
-            "year": liab["year"].values,
-            "mva": mva,
-            "benefits_paid": benefits_paid,
-            "contributions": contributions,
-            "inv_earnings": inv_earnings,
-            "n_active": liab["total_n_active"].values,
-            "total_aal": liab["total_aal_est"].values,
-        })
+        return pd.DataFrame(
+            {
+                "year": liab["year"].values,
+                "mva": mva,
+                "benefits_paid": benefits_paid,
+                "contributions": contributions,
+                "inv_earnings": inv_earnings,
+                "n_active": liab["total_n_active"].values,
+                "total_aal": liab["total_aal_est"].values,
+            }
+        )
 
     def test_cumulative_cash_flow_balance(self, asset_projection):
         """Conservation of value: initial + contrib + earnings = benefits + final."""
@@ -244,8 +257,7 @@ class TestRundownAssetProjection:
         lhs = initial + total_contributions + total_earnings
         rhs = total_benefits + final
         diff_pct = abs(lhs - rhs) / abs(lhs) * 100 if abs(lhs) > 0 else 0
-        assert diff_pct < 0.01, (
-            f"Cash flow imbalance: {diff_pct:.4f}%")
+        assert diff_pct < 0.01, f"Cash flow imbalance: {diff_pct:.4f}%"
 
     def test_nc_only_insufficient_for_underfunded_plan(self, asset_projection):
         """NC-only contributions cannot cover all benefits for an underfunded plan."""
@@ -253,8 +265,9 @@ class TestRundownAssetProjection:
         total_benefits = adf["benefits_paid"].sum()
         initial_mva = adf["mva"].iloc[0]
         total_contributions = adf["contributions"].sum()
-        assert total_benefits > initial_mva + total_contributions, (
-            "Expected underfunded plan to have benefit shortfall with NC-only contributions")
+        assert (
+            total_benefits > initial_mva + total_contributions
+        ), "Expected underfunded plan to have benefit shortfall with NC-only contributions"
 
     def test_asset_trajectory_peaks_and_declines(self, asset_projection):
         """Assets should peak and then decline as benefits exceed contributions."""
@@ -262,13 +275,15 @@ class TestRundownAssetProjection:
         mva = adf["mva"].values
         peak_idx = np.argmax(mva)
         if peak_idx < len(mva) - 10:
-            assert mva[-1] < mva[peak_idx], (
-                f"Assets still growing: peak={mva[peak_idx]:,.0f}, final={mva[-1]:,.0f}")
+            assert (
+                mva[-1] < mva[peak_idx]
+            ), f"Assets still growing: peak={mva[peak_idx]:,.0f}, final={mva[-1]:,.0f}"
 
 
 # ---------------------------------------------------------------------------
 # Diagnostic report (always passes, prints year-by-year summary)
 # ---------------------------------------------------------------------------
+
 
 class TestRundownReport:
     """Print a year-by-year summary table for manual inspection."""
@@ -282,9 +297,13 @@ class TestRundownReport:
         f = funding["regular"]
 
         print(f"\n{'='*120}")
-        print(f"CLOSED-PLAN RUNDOWN: regular class, {RUNDOWN_PERIOD}-year projection, no new entrants")
-        print(f"Discount rate: {constants.economic.dr_current:.1%}, "
-              f"Payroll growth (funding model): {constants.economic.payroll_growth:.2%}")
+        print(
+            f"CLOSED-PLAN RUNDOWN: regular class, {RUNDOWN_PERIOD}-year projection, no new entrants"
+        )
+        print(
+            f"Discount rate: {constants.economic.dr_current:.1%}, "
+            f"Payroll growth (funding model): {constants.economic.payroll_growth:.2%}"
+        )
         print(f"{'='*120}")
 
         header = (
@@ -297,9 +316,7 @@ class TestRundownReport:
         print("-" * len(header))
 
         n = len(f)
-        years_to_print = sorted(set(
-            [0, 1, 2, 5] + list(range(10, n, 10)) + [n - 1]
-        ))
+        years_to_print = sorted(set([0, 1, 2, 5] + list(range(10, n, 10)) + [n - 1]))
 
         for i in years_to_print:
             if i >= n or i >= len(liab):
@@ -335,8 +352,10 @@ class TestRundownReport:
         print(f"  Final AAL (fund):      {f.loc[n-1, 'total_aal']:>18,.0f}")
         print(f"  Final active count:    {liab['total_n_active'].iloc[-1]:>18,.1f}")
 
-        print(f"\n  NOTE: Funding model payroll grows at {constants.economic.payroll_growth:.2%}/yr")
-        print(f"  regardless of actual headcount — this causes funding AAL and MVA")
-        print(f"  to diverge from liability values after actives reach zero.")
+        print(
+            f"\n  NOTE: Funding model payroll grows at {constants.economic.payroll_growth:.2%}/yr"
+        )
+        print("  regardless of actual headcount — this causes funding AAL and MVA")
+        print("  to diverge from liability values after actives reach zero.")
 
         assert True

--- a/tests/test_pension_model/test_runtime_contracts.py
+++ b/tests/test_pension_model/test_runtime_contracts.py
@@ -1,22 +1,20 @@
 """Prepared-run runtime-contract and profiling regression tests."""
 
-from pathlib import Path
 import sys
+from pathlib import Path
 
 import pytest
 from pandas.testing import assert_frame_equal
 
-pytestmark = [pytest.mark.regression]
-
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
 
-from pension_model.core.pipeline import (
+from pension_model.core.pipeline import (  # noqa: E402
     prepare_plan_run,
     run_plan_pipeline,
     run_prepared_plan_pipeline,
     summarize_prepared_plan_run,
 )
-from pension_model.core.profiling import (
+from pension_model.core.profiling import (  # noqa: E402
     build_runtime_baseline,
     compare_runtime_baselines,
     load_runtime_baseline,
@@ -24,8 +22,10 @@ from pension_model.core.profiling import (
     summarize_runtime_samples,
     write_runtime_baseline,
 )
-from pension_model.core.runtime_contracts import ClassRuntimeTables
-from pension_model.plan_config import load_plan_config_by_name
+from pension_model.core.runtime_contracts import ClassRuntimeTables  # noqa: E402
+from pension_model.plan_config import load_plan_config_by_name  # noqa: E402
+
+pytestmark = [pytest.mark.regression]
 
 
 @pytest.fixture(scope="module")
@@ -83,21 +83,34 @@ def test_summarize_prepared_plan_run_reports_runtime_table_rows(prepared_txtrs):
 
 def test_prepared_lookup_tables_keep_unique_merge_keys(prepared_txtrs):
     runtime_tables = prepared_txtrs.runtime_tables_by_class["all"]
-    assert runtime_tables.active_benefit_lookup.duplicated(
-        ["entry_year", "entry_age", "yos"]
-    ).sum() == 0
-    assert runtime_tables.term_liability_lookup.duplicated(
-        ["entry_age", "entry_year", "age", "year", "term_year"]
-    ).sum() == 0
-    assert runtime_tables.refund_lookup.duplicated(
-        ["entry_age", "entry_year", "age", "year", "term_year"]
-    ).sum() == 0
-    assert runtime_tables.retire_benefit_lookup.duplicated(
-        ["entry_age", "entry_year", "retire_year", "term_year"]
-    ).sum() == 0
-    assert runtime_tables.retire_annuity_lookup.duplicated(
-        ["entry_age", "entry_year", "year", "term_year"]
-    ).sum() == 0
+    assert (
+        runtime_tables.active_benefit_lookup.duplicated(["entry_year", "entry_age", "yos"]).sum()
+        == 0
+    )
+    assert (
+        runtime_tables.term_liability_lookup.duplicated(
+            ["entry_age", "entry_year", "age", "year", "term_year"]
+        ).sum()
+        == 0
+    )
+    assert (
+        runtime_tables.refund_lookup.duplicated(
+            ["entry_age", "entry_year", "age", "year", "term_year"]
+        ).sum()
+        == 0
+    )
+    assert (
+        runtime_tables.retire_benefit_lookup.duplicated(
+            ["entry_age", "entry_year", "retire_year", "term_year"]
+        ).sum()
+        == 0
+    )
+    assert (
+        runtime_tables.retire_annuity_lookup.duplicated(
+            ["entry_age", "entry_year", "year", "term_year"]
+        ).sum()
+        == 0
+    )
 
 
 def test_prepared_pipeline_matches_direct_pipeline(txtrs_constants, prepared_txtrs):

--- a/tests/test_pension_model/test_schemas.py
+++ b/tests/test_pension_model/test_schemas.py
@@ -5,13 +5,9 @@ For each model: missing required field raises, extra field raises
 under strict mode, defaults apply correctly, computed properties work.
 """
 
-import pytest
-
-pytestmark = [pytest.mark.unit]
-
-from pydantic import ValidationError
-
 import numpy as np
+import pytest
+from pydantic import ValidationError
 
 from pension_model.schemas import (
     AgeGroup,
@@ -46,6 +42,8 @@ from pension_model.schemas import (
     ValuationInputs,
     validate_tier_cross_references,
 )
+
+pytestmark = [pytest.mark.unit]
 
 
 # ---------------------------------------------------------------------------
@@ -180,13 +178,15 @@ class TestModeling:
         assert m.age_groups is None
 
     def test_age_groups_typed(self):
-        m = Modeling.model_validate({
-            "age_groups": [
-                {"label": "young", "max_age": 30},
-                {"label": "mid", "min_age": 31, "max_age": 50},
-                {"label": "old", "min_age": 51},
-            ],
-        })
+        m = Modeling.model_validate(
+            {
+                "age_groups": [
+                    {"label": "young", "max_age": 30},
+                    {"label": "mid", "min_age": 31, "max_age": 50},
+                    {"label": "old", "min_age": 51},
+                ],
+            }
+        )
         assert m.age_groups is not None
         assert len(m.age_groups) == 3
         assert isinstance(m.age_groups[0], AgeGroup)
@@ -197,9 +197,11 @@ class TestModeling:
 
     def test_extra_field_in_age_group_raises(self):
         with pytest.raises(ValidationError, match="lable"):
-            Modeling.model_validate({
-                "age_groups": [{"lable": "young"}],  # typo
-            })
+            Modeling.model_validate(
+                {
+                    "age_groups": [{"lable": "young"}],  # typo
+                }
+            )
 
     def test_extra_top_level_field_raises(self):
         with pytest.raises(ValidationError, match="bogus"):
@@ -219,20 +221,24 @@ class TestAvaSmoothing:
         assert sm.recognition_fraction == 0.2
 
     def test_corridor_with_explicit_values(self):
-        sm = CorridorAvaSmoothing.model_validate({
-            "method": "corridor",
-            "corridor_low": 0.7,
-            "corridor_high": 1.3,
-            "recognition_fraction": 0.25,
-        })
+        sm = CorridorAvaSmoothing.model_validate(
+            {
+                "method": "corridor",
+                "corridor_low": 0.7,
+                "corridor_high": 1.3,
+                "recognition_fraction": 0.25,
+            }
+        )
         assert sm.corridor_low == 0.7
         assert sm.recognition_fraction == 0.25
 
     def test_gain_loss_method(self):
-        sm = GainLossAvaSmoothing.model_validate({
-            "method": "gain_loss",
-            "recognition_period": 4,
-        })
+        sm = GainLossAvaSmoothing.model_validate(
+            {
+                "method": "gain_loss",
+                "recognition_period": 4,
+            }
+        )
         assert sm.recognition_period == 4
 
     def test_gain_loss_missing_recognition_period_raises(self):
@@ -247,37 +253,45 @@ class TestAvaSmoothing:
 
 class TestRateComponentSpec:
     def test_schedule_form_loads(self):
-        c = RateComponentSpec.model_validate({
-            "name": "base",
-            "payroll_share": 1.0,
-            "schedule": [{"from_year": 0, "rate": 0.08}],
-        })
+        c = RateComponentSpec.model_validate(
+            {
+                "name": "base",
+                "payroll_share": 1.0,
+                "schedule": [{"from_year": 0, "rate": 0.08}],
+            }
+        )
         assert c.schedule is not None
         assert c.ramp is None
 
     def test_ramp_form_loads(self):
-        c = RateComponentSpec.model_validate({
-            "name": "surcharge",
-            "payroll_share": 0.5,
-            "initial_rate": 0.0,
-            "ramp": {"rate_per_year": 0.001, "end_year": 2030},
-        })
+        c = RateComponentSpec.model_validate(
+            {
+                "name": "surcharge",
+                "payroll_share": 0.5,
+                "initial_rate": 0.0,
+                "ramp": {"rate_per_year": 0.001, "end_year": 2030},
+            }
+        )
         assert c.ramp is not None
         assert c.schedule is None
 
     def test_neither_schedule_nor_ramp_raises(self):
         with pytest.raises(ValidationError, match="must specify either"):
-            RateComponentSpec.model_validate({
-                "name": "no_rate",
-            })
+            RateComponentSpec.model_validate(
+                {
+                    "name": "no_rate",
+                }
+            )
 
     def test_both_schedule_and_ramp_raises(self):
         with pytest.raises(ValidationError, match="mutually exclusive"):
-            RateComponentSpec.model_validate({
-                "name": "both",
-                "schedule": [{"from_year": 0, "rate": 0.08}],
-                "ramp": {"rate_per_year": 0.001, "end_year": 2030},
-            })
+            RateComponentSpec.model_validate(
+                {
+                    "name": "both",
+                    "schedule": [{"from_year": 0, "rate": 0.08}],
+                    "ramp": {"rate_per_year": 0.001, "end_year": 2030},
+                }
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -300,19 +314,21 @@ class TestFunding:
 
     def _valid_statutory(self, **overrides):
         base = self._valid_actuarial()
-        base.update({
-            "contribution_strategy": "statutory",
-            "ava_smoothing": {"method": "gain_loss", "recognition_period": 4},
-            "statutory_rates": {
-                "ee_rate_schedule": [{"from_year": 0, "rate": 0.08}],
-                "er_rate_components": [
-                    {
-                        "name": "base",
-                        "schedule": [{"from_year": 0, "rate": 0.08}],
-                    },
-                ],
-            },
-        })
+        base.update(
+            {
+                "contribution_strategy": "statutory",
+                "ava_smoothing": {"method": "gain_loss", "recognition_period": 4},
+                "statutory_rates": {
+                    "ee_rate_schedule": [{"from_year": 0, "rate": 0.08}],
+                    "er_rate_components": [
+                        {
+                            "name": "base",
+                            "schedule": [{"from_year": 0, "rate": 0.08}],
+                        },
+                    ],
+                },
+            }
+        )
         base.update(overrides)
         return base
 
@@ -348,10 +364,14 @@ class TestFunding:
         assert f.legs[1].entry_year_min_param == "new_year"
 
     def test_explicit_legs_override_default(self):
-        f = Funding.model_validate(self._valid_actuarial(legs=[
-            {"name": "before_2011", "entry_year_max": 2011},
-            {"name": "from_2011", "entry_year_min": 2011},
-        ]))
+        f = Funding.model_validate(
+            self._valid_actuarial(
+                legs=[
+                    {"name": "before_2011", "entry_year_max": 2011},
+                    {"name": "from_2011", "entry_year_min": 2011},
+                ]
+            )
+        )
         assert [leg.name for leg in f.legs] == ["before_2011", "from_2011"]
 
     def test_extra_field_raises(self):
@@ -371,17 +391,19 @@ class TestCola:
         assert c.proration_cutoff_year is None
 
     def test_per_tier_keys_admitted_as_extras(self):
-        c = Cola.model_validate({
-            "current_retire": 0.03,
-            "tier_1_active": 0.03,
-            "tier_2_active": 0.0,
-            "tier_1_active_constant": False,
-        })
+        c = Cola.model_validate(
+            {
+                "current_retire": 0.03,
+                "tier_1_active": 0.03,
+                "tier_2_active": 0.0,
+                "tier_1_active_constant": False,
+            }
+        )
         assert c.current_retire == 0.03
         # Per-tier keys readable via getattr (not part of typed fields).
-        assert getattr(c, "tier_1_active") == 0.03
-        assert getattr(c, "tier_2_active") == 0.0
-        assert getattr(c, "tier_1_active_constant") is False
+        assert c.tier_1_active == 0.03
+        assert c.tier_2_active == 0.0
+        assert c.tier_1_active_constant is False
         assert getattr(c, "missing_key", "fallback") == "fallback"
 
 
@@ -392,34 +414,8 @@ class TestCola:
 
 class TestCashBalance:
     def test_required_fields(self):
-        cb = CashBalance.model_validate({
-            "ee_pay_credit": 0.06,
-            "er_pay_credit": 0.09,
-            "vesting_yos": 5,
-            "icr_smooth_period": 5,
-            "icr_floor": 0.04,
-            "icr_cap": 0.07,
-            "icr_upside_share": 0.5,
-            "annuity_conversion_rate": 0.04,
-        })
-        assert cb.ee_pay_credit == 0.06
-        assert cb.return_volatility == 0.12  # default
-
-    def test_missing_required_raises(self):
-        with pytest.raises(ValidationError, match="vesting_yos"):
-            CashBalance.model_validate({
-                "ee_pay_credit": 0.06,
-                "er_pay_credit": 0.09,
-                "icr_smooth_period": 5,
-                "icr_floor": 0.04,
-                "icr_cap": 0.07,
-                "icr_upside_share": 0.5,
-                "annuity_conversion_rate": 0.04,
-            })
-
-    def test_extra_field_raises(self):
-        with pytest.raises(ValidationError, match="extra_thing"):
-            CashBalance.model_validate({
+        cb = CashBalance.model_validate(
+            {
                 "ee_pay_credit": 0.06,
                 "er_pay_credit": 0.09,
                 "vesting_yos": 5,
@@ -428,8 +424,40 @@ class TestCashBalance:
                 "icr_cap": 0.07,
                 "icr_upside_share": 0.5,
                 "annuity_conversion_rate": 0.04,
-                "extra_thing": True,
-            })
+            }
+        )
+        assert cb.ee_pay_credit == 0.06
+        assert cb.return_volatility == 0.12  # default
+
+    def test_missing_required_raises(self):
+        with pytest.raises(ValidationError, match="vesting_yos"):
+            CashBalance.model_validate(
+                {
+                    "ee_pay_credit": 0.06,
+                    "er_pay_credit": 0.09,
+                    "icr_smooth_period": 5,
+                    "icr_floor": 0.04,
+                    "icr_cap": 0.07,
+                    "icr_upside_share": 0.5,
+                    "annuity_conversion_rate": 0.04,
+                }
+            )
+
+    def test_extra_field_raises(self):
+        with pytest.raises(ValidationError, match="extra_thing"):
+            CashBalance.model_validate(
+                {
+                    "ee_pay_credit": 0.06,
+                    "er_pay_credit": 0.09,
+                    "vesting_yos": 5,
+                    "icr_smooth_period": 5,
+                    "icr_floor": 0.04,
+                    "icr_cap": 0.07,
+                    "icr_upside_share": 0.5,
+                    "annuity_conversion_rate": 0.04,
+                    "extra_thing": True,
+                }
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -455,21 +483,23 @@ class TestBenefit:
         assert b.dc is None
 
     def test_with_cola_and_cb(self):
-        b = Benefit.model_validate(self._valid(
-            cola={"current_retire": 0.03, "tier_1_active": 0.03},
-            cash_balance={
-                "ee_pay_credit": 0.06,
-                "er_pay_credit": 0.09,
-                "vesting_yos": 5,
-                "icr_smooth_period": 5,
-                "icr_floor": 0.04,
-                "icr_cap": 0.07,
-                "icr_upside_share": 0.5,
-                "annuity_conversion_rate": 0.04,
-            },
-        ))
+        b = Benefit.model_validate(
+            self._valid(
+                cola={"current_retire": 0.03, "tier_1_active": 0.03},
+                cash_balance={
+                    "ee_pay_credit": 0.06,
+                    "er_pay_credit": 0.09,
+                    "vesting_yos": 5,
+                    "icr_smooth_period": 5,
+                    "icr_floor": 0.04,
+                    "icr_cap": 0.07,
+                    "icr_upside_share": 0.5,
+                    "annuity_conversion_rate": 0.04,
+                },
+            )
+        )
         assert b.cola.current_retire == 0.03
-        assert getattr(b.cola, "tier_1_active") == 0.03
+        assert b.cola.tier_1_active == 0.03
         assert b.cash_balance is not None
         assert b.cash_balance.ee_pay_credit == 0.06
 
@@ -505,18 +535,18 @@ class TestValuationInputs:
         assert v.headcount_group is None
 
     def test_with_headcount_group(self):
-        v = ValuationInputs.model_validate(
-            self._valid(headcount_group=["a", "b", "c"])
-        )
+        v = ValuationInputs.model_validate(self._valid(headcount_group=["a", "b", "c"]))
         assert v.headcount_group == ["a", "b", "c"]
 
     def test_missing_required_raises(self):
         with pytest.raises(ValidationError, match="ben_payment"):
-            ValuationInputs.model_validate({
-                "retiree_pop": 1000,
-                "total_active_member": 5000,
-                "val_norm_cost": 0.10,
-            })
+            ValuationInputs.model_validate(
+                {
+                    "retiree_pop": 1000,
+                    "total_active_member": 5000,
+                    "val_norm_cost": 0.10,
+                }
+            )
 
     def test_extra_field_raises(self):
         with pytest.raises(ValidationError, match="extra_thing"):
@@ -535,22 +565,26 @@ class TestCalibration:
         assert c.pvfb_term_current == 0.0
 
     def test_calibration_loads_classes_dict(self):
-        c = Calibration.model_validate({
-            "cal_factor": 0.9,
-            "classes": {
-                "regular": {"nc_cal": 0.985, "pvfb_term_current": 6e9},
-                "special": {"nc_cal": 1.0, "pvfb_term_current": 0.0},
-            },
-        })
+        c = Calibration.model_validate(
+            {
+                "cal_factor": 0.9,
+                "classes": {
+                    "regular": {"nc_cal": 0.985, "pvfb_term_current": 6e9},
+                    "special": {"nc_cal": 1.0, "pvfb_term_current": 0.0},
+                },
+            }
+        )
         assert c.cal_factor == 0.9
         assert isinstance(c.classes["regular"], ClassCalibration)
         assert c.classes["regular"].nc_cal == 0.985
 
     def test_documentation_fields_optional(self):
-        c = Calibration.model_validate({
-            "description": "FRS 2022 calibration",
-            "cal_factor": 0.9,
-        })
+        c = Calibration.model_validate(
+            {
+                "description": "FRS 2022 calibration",
+                "cal_factor": 0.9,
+            }
+        )
         assert c.description == "FRS 2022 calibration"
 
     def test_extra_admitted(self):
@@ -566,11 +600,13 @@ class TestCalibration:
 
 class TestPlanDesign:
     def test_db_triple_with_full_fields(self):
-        r = PlanDesignRatios.model_validate({
-            "before_cutoff": 0.95,
-            "after_cutoff": 0.85,
-            "new": 0.75,
-        })
+        r = PlanDesignRatios.model_validate(
+            {
+                "before_cutoff": 0.95,
+                "after_cutoff": 0.85,
+                "new": 0.75,
+            }
+        )
         assert r.db_triple() == (0.95, 0.85, 0.75)
 
     def test_db_triple_after_defaults_to_before(self):
@@ -586,11 +622,13 @@ class TestPlanDesign:
         assert r.cb_triple() == (0.0, 0.0, 0.0)
 
     def test_groups_promoted_to_typed_at_parse(self):
-        pd = PlanDesign.model_validate({
-            "cutoff_year": 2018,
-            "regular_group": {"before_cutoff": 0.75, "new": 0.25},
-            "special_group": {"before_cutoff": 0.95, "after_cutoff": 0.85, "new": 0.75},
-        })
+        pd = PlanDesign.model_validate(
+            {
+                "cutoff_year": 2018,
+                "regular_group": {"before_cutoff": 0.75, "new": 0.25},
+                "special_group": {"before_cutoff": 0.95, "after_cutoff": 0.85, "new": 0.75},
+            }
+        )
         assert pd.cutoff_year == 2018
         assert isinstance(pd.group("regular_group"), PlanDesignRatios)
         assert pd.group("regular_group").before_cutoff == 0.75
@@ -629,21 +667,25 @@ class TestMultiplierRules:
         assert r.flat == 0.023
 
     def test_graded_only_loads(self):
-        r = MultiplierRules.model_validate({
-            "graded": [
-                {"or": [{"min_age": 65}], "mult": 0.02},
-            ],
-        })
+        r = MultiplierRules.model_validate(
+            {
+                "graded": [
+                    {"or": [{"min_age": 65}], "mult": 0.02},
+                ],
+            }
+        )
         assert r.graded is not None
         assert len(r.graded) == 1
         assert r.graded[0].mult == 0.02
         assert r.graded[0].or_[0].min_age == 65
 
     def test_flat_with_flat_before_year(self):
-        r = MultiplierRules.model_validate({
-            "flat": 0.03,
-            "flat_before_year": {"year": 1974, "mult": 0.02},
-        })
+        r = MultiplierRules.model_validate(
+            {
+                "flat": 0.03,
+                "flat_before_year": {"year": 1974, "mult": 0.02},
+            }
+        )
         assert r.flat_before_year is not None
         assert r.flat_before_year.year == 1974
 
@@ -653,17 +695,21 @@ class TestMultiplierRules:
 
     def test_both_flat_and_graded_raises(self):
         with pytest.raises(ValidationError, match="mutually exclusive"):
-            MultiplierRules.model_validate({
-                "flat": 0.02,
-                "graded": [{"or": [{"min_age": 65}], "mult": 0.02}],
-            })
+            MultiplierRules.model_validate(
+                {
+                    "flat": 0.02,
+                    "graded": [{"or": [{"min_age": 65}], "mult": 0.02}],
+                }
+            )
 
     def test_flat_before_year_without_flat_raises(self):
         with pytest.raises(ValidationError, match="requires 'flat'"):
-            MultiplierRules.model_validate({
-                "graded": [{"or": [{"min_age": 65}], "mult": 0.02}],
-                "flat_before_year": {"year": 1974, "mult": 0.02},
-            })
+            MultiplierRules.model_validate(
+                {
+                    "graded": [{"or": [{"min_age": 65}], "mult": 0.02}],
+                    "flat_before_year": {"year": 1974, "mult": 0.02},
+                }
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -707,9 +753,11 @@ class TestBenefitMultipliers:
         assert bm.resolve("nonexistent", "tier_1") is None
 
     def test_resolve_unknown_tier(self):
-        bm = BenefitMultipliers.model_validate({
-            "regular": {"tier_1": {"flat": 0.02}},
-        })
+        bm = BenefitMultipliers.model_validate(
+            {
+                "regular": {"tier_1": {"flat": 0.02}},
+            }
+        )
         assert bm.resolve("regular", "tier_2") is None
 
 
@@ -758,11 +806,13 @@ class TestConditionMatches:
 
 class TestEligibilitySpec:
     def _frs_tier_1_regular(self):
-        return EligibilitySpec.model_validate({
-            "normal": [{"min_yos": 30}, {"min_age": 62, "min_yos": 6}],
-            "early": [{"min_age": 58, "min_yos": 6}],
-            "vesting_yos": 6,
-        })
+        return EligibilitySpec.model_validate(
+            {
+                "normal": [{"min_yos": 30}, {"min_age": 62, "min_yos": 6}],
+                "early": [{"min_age": 58, "min_yos": 6}],
+                "vesting_yos": 6,
+            }
+        )
 
     def test_loads_with_typed_conditions(self):
         e = self._frs_tier_1_regular()
@@ -799,9 +849,11 @@ class TestEligibilitySpec:
 
     def test_missing_vesting_yos_raises(self):
         with pytest.raises(ValidationError, match="vesting_yos"):
-            EligibilitySpec.model_validate({
-                "normal": [{"min_yos": 30}],
-            })
+            EligibilitySpec.model_validate(
+                {
+                    "normal": [{"min_yos": 30}],
+                }
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -811,14 +863,16 @@ class TestEligibilitySpec:
 
 class TestGrandfatheredParams:
     def _txtrs_params(self):
-        return GrandfatheredParams.model_validate({
-            "cutoff_year": 2005,
-            "conditions": [
-                {"min_age_at_cutoff": 50},
-                {"rule_of_at_cutoff": 70},
-                {"min_yos_at_cutoff": 25},
-            ],
-        })
+        return GrandfatheredParams.model_validate(
+            {
+                "cutoff_year": 2005,
+                "conditions": [
+                    {"min_age_at_cutoff": 50},
+                    {"rule_of_at_cutoff": 70},
+                    {"min_yos_at_cutoff": 25},
+                ],
+            }
+        )
 
     def test_loads(self):
         gf = self._txtrs_params()
@@ -852,10 +906,12 @@ class TestGrandfatheredParams:
         with pytest.raises(ValidationError, match="exactly one"):
             GrandfatheredCondition.model_validate({})  # no fields → not exactly one
         with pytest.raises(ValidationError, match="exactly one"):
-            GrandfatheredCondition.model_validate({
-                "min_age_at_cutoff": 50,
-                "min_yos_at_cutoff": 25,
-            })
+            GrandfatheredCondition.model_validate(
+                {
+                    "min_age_at_cutoff": 50,
+                    "min_yos_at_cutoff": 25,
+                }
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -866,17 +922,21 @@ class TestGrandfatheredParams:
 class TestReduceCondition:
     def test_or_field_uses_alias(self):
         # JSON ``or`` keyword maps to ``or_`` Python attribute.
-        c = ReduceCondition.model_validate({
-            "or": [{"rule_of": 80}, {"min_yos": 30}],
-        })
+        c = ReduceCondition.model_validate(
+            {
+                "or": [{"rule_of": 80}, {"min_yos": 30}],
+            }
+        )
         assert c.or_ is not None
         assert len(c.or_) == 2
         assert c.or_[0].rule_of == 80
 
     def test_matches_or_combinator(self):
-        c = ReduceCondition.model_validate({
-            "or": [{"rule_of": 80}, {"min_yos": 30}],
-        })
+        c = ReduceCondition.model_validate(
+            {
+                "or": [{"rule_of": 80}, {"min_yos": 30}],
+            }
+        )
         # Either rule of 80 or min_yos 30 satisfies.
         assert c.matches(dist_age=50, yos=30, tier_name="x") is True
         assert c.matches(dist_age=55, yos=25, tier_name="x") is True  # 55+25 = 80
@@ -901,26 +961,34 @@ class TestReduceCondition:
 class TestEarlyRetireRule:
     def test_linear_rule_requires_nra(self):
         with pytest.raises(ValidationError, match="rate_per_year and nra"):
-            EarlyRetireRule.model_validate({
-                "formula": "linear",
-                "rate_per_year": 0.05,
-            })
+            EarlyRetireRule.model_validate(
+                {
+                    "formula": "linear",
+                    "rate_per_year": 0.05,
+                }
+            )
 
     def test_linear_rule_requires_rate(self):
         with pytest.raises(ValidationError, match="rate_per_year and nra"):
-            EarlyRetireRule.model_validate({
-                "formula": "linear",
-                "nra": 60,
-            })
+            EarlyRetireRule.model_validate(
+                {
+                    "formula": "linear",
+                    "nra": 60,
+                }
+            )
 
     def test_table_rule_requires_table_key(self):
         with pytest.raises(ValidationError, match="table_key"):
             EarlyRetireRule.model_validate({"formula": "table"})
 
     def test_linear_rule_loads(self):
-        r = EarlyRetireRule.model_validate({
-            "formula": "linear", "rate_per_year": 0.05, "nra": 60,
-        })
+        r = EarlyRetireRule.model_validate(
+            {
+                "formula": "linear",
+                "rate_per_year": 0.05,
+                "nra": 60,
+            }
+        )
         assert r.formula == "linear"
         assert r.condition.matches(50, 5, "x") is True  # default empty cond
 
@@ -931,38 +999,52 @@ class TestEarlyRetireRule:
 
 class TestEarlyRetireReduction:
     def test_flat_shape(self):
-        err = EarlyRetireReduction.model_validate({
-            "rate_per_year": 0.05,
-            "nra": {"special": 55, "default": 62},
-        })
+        err = EarlyRetireReduction.model_validate(
+            {
+                "rate_per_year": 0.05,
+                "nra": {"special": 55, "default": 62},
+            }
+        )
         assert err.is_flat is True
         assert err.lookup_nra("special", "frs", "tier_1") == 55
         assert err.lookup_nra("regular", "frs", "tier_1") == 62  # default fallback
 
     def test_flat_lookup_missing_class_no_default_raises(self):
-        err = EarlyRetireReduction.model_validate({
-            "rate_per_year": 0.05,
-            "nra": {"special": 55},
-        })
+        err = EarlyRetireReduction.model_validate(
+            {
+                "rate_per_year": 0.05,
+                "nra": {"special": 55},
+            }
+        )
         with pytest.raises(ValueError, match="no 'default'"):
             err.lookup_nra("regular", "frs", "tier_1")
 
     def test_rule_list_shape(self):
-        err = EarlyRetireReduction.model_validate({
-            "rules": [
-                {"condition": {"min_yos": 30}, "formula": "linear",
-                 "rate_per_year": 0.02, "nra": 50},
-                {"condition": {}, "formula": "table", "table_key": "reduced_others"},
-            ]
-        })
+        err = EarlyRetireReduction.model_validate(
+            {
+                "rules": [
+                    {
+                        "condition": {"min_yos": 30},
+                        "formula": "linear",
+                        "rate_per_year": 0.02,
+                        "nra": 50,
+                    },
+                    {"condition": {}, "formula": "table", "table_key": "reduced_others"},
+                ]
+            }
+        )
         assert err.is_flat is False
         assert err.rules is not None and len(err.rules) == 2
 
     def test_mixing_shapes_raises(self):
         with pytest.raises(ValidationError, match="cannot mix"):
-            EarlyRetireReduction.model_validate({
-                "rate_per_year": 0.05, "nra": {"default": 60}, "rules": [],
-            })
+            EarlyRetireReduction.model_validate(
+                {
+                    "rate_per_year": 0.05,
+                    "nra": {"default": 60},
+                    "rules": [],
+                }
+            )
 
     def test_neither_shape_raises(self):
         with pytest.raises(ValidationError, match="must declare either"):
@@ -980,25 +1062,27 @@ class TestEarlyRetireReduction:
 
 class TestTier:
     def _frs_tier_1(self):
-        return Tier.model_validate({
-            "name": "tier_1",
-            "cola_key": "tier_1_active",
-            "fas_years": 5,
-            "retirement_rate_set": "before_2011",
-            "entry_year_max": 2011,
-            "prorate_cola": True,
-            "eligibility": {
-                "regular_group": {
-                    "normal": [{"min_yos": 30}],
-                    "early": [{"min_age": 55}],
-                    "vesting_yos": 6,
+        return Tier.model_validate(
+            {
+                "name": "tier_1",
+                "cola_key": "tier_1_active",
+                "fas_years": 5,
+                "retirement_rate_set": "before_2011",
+                "entry_year_max": 2011,
+                "prorate_cola": True,
+                "eligibility": {
+                    "regular_group": {
+                        "normal": [{"min_yos": 30}],
+                        "early": [{"min_age": 55}],
+                        "vesting_yos": 6,
+                    },
                 },
-            },
-            "early_retire_reduction": {
-                "rate_per_year": 0.05,
-                "nra": {"special": 55, "default": 62},
-            },
-        })
+                "early_retire_reduction": {
+                    "rate_per_year": 0.05,
+                    "nra": {"special": 55, "default": 62},
+                },
+            }
+        )
 
     def test_loads(self):
         t = self._frs_tier_1()
@@ -1014,118 +1098,185 @@ class TestTier:
         assert t.entry_year_in_window(entry_year=2010, new_year=2024) is True
 
     def test_entry_year_min_param_resolves_to_new_year(self):
-        t = Tier.model_validate({
-            "name": "x", "cola_key": "k", "fas_years": 5, "retirement_rate_set": "r",
-            "entry_year_min_param": "new_year",
-            "eligibility": {"default": {"normal": [], "early": [], "vesting_yos": 5}},
-            "early_retire_reduction": {"rate_per_year": 0.05, "nra": {"default": 60}},
-        })
+        t = Tier.model_validate(
+            {
+                "name": "x",
+                "cola_key": "k",
+                "fas_years": 5,
+                "retirement_rate_set": "r",
+                "entry_year_min_param": "new_year",
+                "eligibility": {"default": {"normal": [], "early": [], "vesting_yos": 5}},
+                "early_retire_reduction": {"rate_per_year": 0.05, "nra": {"default": 60}},
+            }
+        )
         assert t.entry_year_lo(new_year=2030) == 2030
 
     def test_grandfathered_tier_skips_window(self):
-        t = Tier.model_validate({
-            "name": "gf", "cola_key": "k", "fas_years": 5, "retirement_rate_set": "r",
-            "assignment": "grandfathered_rule",
-            "grandfathered_params": {
-                "cutoff_year": 2005,
-                "conditions": [{"min_age_at_cutoff": 50}],
-            },
-            "eligibility": {"default": {"normal": [], "early": [], "vesting_yos": 5}},
-            "early_retire_reduction": {"rate_per_year": 0.05, "nra": {"default": 60}},
-        })
-        # grandfathered tiers always return False from entry_year_in_window —
-        # they're matched by GrandfatheredParams.matches instead.
-        assert t.entry_year_in_window(entry_year=1990, new_year=2024) is False
-
-    def test_eligibility_xor_required(self):
-        with pytest.raises(ValidationError, match="must declare either"):
-            Tier.model_validate({
-                "name": "x", "cola_key": "k", "fas_years": 5, "retirement_rate_set": "r",
-                "early_retire_reduction": {"rate_per_year": 0.05, "nra": {"default": 60}},
-            })
-
-    def test_eligibility_xor_not_both(self):
-        with pytest.raises(ValidationError, match="cannot declare both"):
-            Tier.model_validate({
-                "name": "x", "cola_key": "k", "fas_years": 5, "retirement_rate_set": "r",
-                "eligibility": {"default": {"normal": [], "early": [], "vesting_yos": 5}},
-                "eligibility_same_as": "other",
-                "early_retire_reduction": {"rate_per_year": 0.05, "nra": {"default": 60}},
-            })
-
-    def test_grandfathered_params_requires_assignment(self):
-        with pytest.raises(ValidationError, match="only valid when"):
-            Tier.model_validate({
-                "name": "x", "cola_key": "k", "fas_years": 5, "retirement_rate_set": "r",
+        t = Tier.model_validate(
+            {
+                "name": "gf",
+                "cola_key": "k",
+                "fas_years": 5,
+                "retirement_rate_set": "r",
+                "assignment": "grandfathered_rule",
                 "grandfathered_params": {
                     "cutoff_year": 2005,
                     "conditions": [{"min_age_at_cutoff": 50}],
                 },
                 "eligibility": {"default": {"normal": [], "early": [], "vesting_yos": 5}},
                 "early_retire_reduction": {"rate_per_year": 0.05, "nra": {"default": 60}},
-            })
+            }
+        )
+        # grandfathered tiers always return False from entry_year_in_window —
+        # they're matched by GrandfatheredParams.matches instead.
+        assert t.entry_year_in_window(entry_year=1990, new_year=2024) is False
+
+    def test_eligibility_xor_required(self):
+        with pytest.raises(ValidationError, match="must declare either"):
+            Tier.model_validate(
+                {
+                    "name": "x",
+                    "cola_key": "k",
+                    "fas_years": 5,
+                    "retirement_rate_set": "r",
+                    "early_retire_reduction": {"rate_per_year": 0.05, "nra": {"default": 60}},
+                }
+            )
+
+    def test_eligibility_xor_not_both(self):
+        with pytest.raises(ValidationError, match="cannot declare both"):
+            Tier.model_validate(
+                {
+                    "name": "x",
+                    "cola_key": "k",
+                    "fas_years": 5,
+                    "retirement_rate_set": "r",
+                    "eligibility": {"default": {"normal": [], "early": [], "vesting_yos": 5}},
+                    "eligibility_same_as": "other",
+                    "early_retire_reduction": {"rate_per_year": 0.05, "nra": {"default": 60}},
+                }
+            )
+
+    def test_grandfathered_params_requires_assignment(self):
+        with pytest.raises(ValidationError, match="only valid when"):
+            Tier.model_validate(
+                {
+                    "name": "x",
+                    "cola_key": "k",
+                    "fas_years": 5,
+                    "retirement_rate_set": "r",
+                    "grandfathered_params": {
+                        "cutoff_year": 2005,
+                        "conditions": [{"min_age_at_cutoff": 50}],
+                    },
+                    "eligibility": {"default": {"normal": [], "early": [], "vesting_yos": 5}},
+                    "early_retire_reduction": {"rate_per_year": 0.05, "nra": {"default": 60}},
+                }
+            )
 
     def test_grandfathered_assignment_requires_params(self):
         with pytest.raises(ValidationError, match="requires grandfathered_params"):
-            Tier.model_validate({
-                "name": "x", "cola_key": "k", "fas_years": 5, "retirement_rate_set": "r",
-                "assignment": "grandfathered_rule",
-                "eligibility": {"default": {"normal": [], "early": [], "vesting_yos": 5}},
-                "early_retire_reduction": {"rate_per_year": 0.05, "nra": {"default": 60}},
-            })
+            Tier.model_validate(
+                {
+                    "name": "x",
+                    "cola_key": "k",
+                    "fas_years": 5,
+                    "retirement_rate_set": "r",
+                    "assignment": "grandfathered_rule",
+                    "eligibility": {"default": {"normal": [], "early": [], "vesting_yos": 5}},
+                    "early_retire_reduction": {"rate_per_year": 0.05, "nra": {"default": 60}},
+                }
+            )
 
     def test_resolve_eligibility_walks_same_as(self):
-        t1 = Tier.model_validate({
-            "name": "tier_1", "cola_key": "k", "fas_years": 5, "retirement_rate_set": "r",
-            "eligibility": {"default": {"normal": [{"min_age": 65}], "early": [], "vesting_yos": 5}},
-            "early_retire_reduction": {"rate_per_year": 0.05, "nra": {"default": 60}},
-        })
-        t2 = Tier.model_validate({
-            "name": "tier_2", "cola_key": "k", "fas_years": 5, "retirement_rate_set": "r",
-            "eligibility_same_as": "tier_1",
-            "early_retire_reduction": {"rate_per_year": 0.05, "nra": {"default": 60}},
-        })
+        t1 = Tier.model_validate(
+            {
+                "name": "tier_1",
+                "cola_key": "k",
+                "fas_years": 5,
+                "retirement_rate_set": "r",
+                "eligibility": {
+                    "default": {"normal": [{"min_age": 65}], "early": [], "vesting_yos": 5}
+                },
+                "early_retire_reduction": {"rate_per_year": 0.05, "nra": {"default": 60}},
+            }
+        )
+        t2 = Tier.model_validate(
+            {
+                "name": "tier_2",
+                "cola_key": "k",
+                "fas_years": 5,
+                "retirement_rate_set": "r",
+                "eligibility_same_as": "tier_1",
+                "early_retire_reduction": {"rate_per_year": 0.05, "nra": {"default": 60}},
+            }
+        )
         elig = t2.resolve_eligibility("default", [t1, t2])
         assert elig is not None
         assert elig.vesting_yos == 5
         assert elig.normal[0].min_age == 65
 
     def test_resolve_err_walks_same_as(self):
-        t1 = Tier.model_validate({
-            "name": "tier_1", "cola_key": "k", "fas_years": 5, "retirement_rate_set": "r",
-            "eligibility": {"default": {"normal": [], "early": [], "vesting_yos": 5}},
-            "early_retire_reduction": {"rate_per_year": 0.05, "nra": {"default": 62}},
-        })
-        t2 = Tier.model_validate({
-            "name": "tier_2", "cola_key": "k", "fas_years": 5, "retirement_rate_set": "r",
-            "eligibility": {"default": {"normal": [], "early": [], "vesting_yos": 5}},
-            "early_retire_reduction_same_as": "tier_1",
-        })
+        t1 = Tier.model_validate(
+            {
+                "name": "tier_1",
+                "cola_key": "k",
+                "fas_years": 5,
+                "retirement_rate_set": "r",
+                "eligibility": {"default": {"normal": [], "early": [], "vesting_yos": 5}},
+                "early_retire_reduction": {"rate_per_year": 0.05, "nra": {"default": 62}},
+            }
+        )
+        t2 = Tier.model_validate(
+            {
+                "name": "tier_2",
+                "cola_key": "k",
+                "fas_years": 5,
+                "retirement_rate_set": "r",
+                "eligibility": {"default": {"normal": [], "early": [], "vesting_yos": 5}},
+                "early_retire_reduction_same_as": "tier_1",
+            }
+        )
         err = t2.resolve_early_retire_reduction([t1, t2])
         assert err is not None
         assert err.rate_per_year == 0.05
         assert err.nra == {"default": 62}
 
     def test_validate_cross_refs_catches_missing_target(self):
-        t = Tier.model_validate({
-            "name": "tier_1", "cola_key": "k", "fas_years": 5, "retirement_rate_set": "r",
-            "eligibility_same_as": "ghost",
-            "early_retire_reduction": {"rate_per_year": 0.05, "nra": {"default": 60}},
-        })
+        t = Tier.model_validate(
+            {
+                "name": "tier_1",
+                "cola_key": "k",
+                "fas_years": 5,
+                "retirement_rate_set": "r",
+                "eligibility_same_as": "ghost",
+                "early_retire_reduction": {"rate_per_year": 0.05, "nra": {"default": 60}},
+            }
+        )
         with pytest.raises(ValueError, match="ghost"):
             validate_tier_cross_references([t])
 
     def test_validate_cross_refs_catches_cycle(self):
-        t1 = Tier.model_validate({
-            "name": "tier_1", "cola_key": "k", "fas_years": 5, "retirement_rate_set": "r",
-            "eligibility_same_as": "tier_2",
-            "early_retire_reduction": {"rate_per_year": 0.05, "nra": {"default": 60}},
-        })
-        t2 = Tier.model_validate({
-            "name": "tier_2", "cola_key": "k", "fas_years": 5, "retirement_rate_set": "r",
-            "eligibility_same_as": "tier_1",
-            "early_retire_reduction": {"rate_per_year": 0.05, "nra": {"default": 60}},
-        })
+        t1 = Tier.model_validate(
+            {
+                "name": "tier_1",
+                "cola_key": "k",
+                "fas_years": 5,
+                "retirement_rate_set": "r",
+                "eligibility_same_as": "tier_2",
+                "early_retire_reduction": {"rate_per_year": 0.05, "nra": {"default": 60}},
+            }
+        )
+        t2 = Tier.model_validate(
+            {
+                "name": "tier_2",
+                "cola_key": "k",
+                "fas_years": 5,
+                "retirement_rate_set": "r",
+                "eligibility_same_as": "tier_1",
+                "early_retire_reduction": {"rate_per_year": 0.05, "nra": {"default": 60}},
+            }
+        )
         with pytest.raises(ValueError, match="circular"):
             validate_tier_cross_references([t1, t2])
 
@@ -1151,10 +1302,12 @@ class TestDataSpec:
 
 class TestMortalitySpec:
     def test_loads_with_improvement_scale(self):
-        m = MortalitySpec.model_validate({
-            "base_table": "pub_2010_teacher_below_median",
-            "improvement_scale": "mp_2021",
-        })
+        m = MortalitySpec.model_validate(
+            {
+                "base_table": "pub_2010_teacher_below_median",
+                "improvement_scale": "mp_2021",
+            }
+        )
         assert m.base_table == "pub_2010_teacher_below_median"
         assert m.improvement_scale == "mp_2021"
 
@@ -1166,21 +1319,25 @@ class TestMortalitySpec:
 
 class TestTermVested:
     def test_loads(self):
-        tv = TermVested.model_validate({
-            "avg_deferral_years": 12,
-            "avg_payout_years": 25,
-            "method": "deferred_annuity",
-        })
+        tv = TermVested.model_validate(
+            {
+                "avg_deferral_years": 12,
+                "avg_payout_years": 25,
+                "method": "deferred_annuity",
+            }
+        )
         assert tv.avg_deferral_years == 12
         assert tv.method == "deferred_annuity"
 
     def test_unknown_method_raises(self):
         with pytest.raises(ValidationError, match="deferred_annuity"):
-            TermVested.model_validate({
-                "avg_deferral_years": 12,
-                "avg_payout_years": 25,
-                "method": "made_up_method",
-            })
+            TermVested.model_validate(
+                {
+                    "avg_deferral_years": 12,
+                    "avg_payout_years": 25,
+                    "method": "made_up_method",
+                }
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -1233,9 +1390,10 @@ class TestPlanConfigTopLevel:
         live = PlanConfig.model_json_schema(by_alias=True)
         assert live == committed, (
             "JSON Schema drift. Regenerate with:\n"
-            "  python -c \"import json; from pension_model.config_schema import PlanConfig; "
+            '  python -c "import json; from pension_model.config_schema import PlanConfig; '
             "open('plans/_schema/plan_config.schema.json','w').write("
-            "json.dumps(PlanConfig.model_json_schema(by_alias=True), indent=2, sort_keys=True)+'\\n')\""
+            "json.dumps(PlanConfig.model_json_schema(by_alias=True), "
+            "indent=2, sort_keys=True)+'\\n')\""
         )
 
 
@@ -1253,6 +1411,7 @@ class TestScenarioOverrides:
         # generator missed a real field.
         import json
         from pathlib import Path
+
         from pension_model.schemas.scenario import Scenario
 
         scenarios_dir = Path(__file__).parents[2] / "scenarios"
@@ -1265,23 +1424,29 @@ class TestScenarioOverrides:
 
     def test_top_level_typo_rejected(self):
         from pydantic import ValidationError
+
         from pension_model.schemas.scenario import Scenario
 
         with pytest.raises(ValidationError, match="economci"):
-            Scenario.model_validate({
-                "name": "x",
-                "overrides": {"economci": {"dr_current": 0.05}},  # typo
-            })
+            Scenario.model_validate(
+                {
+                    "name": "x",
+                    "overrides": {"economci": {"dr_current": 0.05}},  # typo
+                }
+            )
 
     def test_nested_typo_rejected(self):
         from pydantic import ValidationError
+
         from pension_model.schemas.scenario import Scenario
 
         with pytest.raises(ValidationError, match="modle_return"):
-            Scenario.model_validate({
-                "name": "x",
-                "overrides": {"economic": {"modle_return": 0.05}},  # typo
-            })
+            Scenario.model_validate(
+                {
+                    "name": "x",
+                    "overrides": {"economic": {"modle_return": 0.05}},  # typo
+                }
+            )
 
     def test_cola_extra_keys_admitted(self):
         # Cola uses extra="allow" for per-tier active-rate keys.
@@ -1290,15 +1455,21 @@ class TestScenarioOverrides:
         # explicit Cola field declaration).
         from pension_model.schemas.scenario import Scenario
 
-        s = Scenario.model_validate({
-            "name": "x",
-            "overrides": {
-                "benefit": {"cola": {
-                    "tier_1_active": 0.0, "tier_2_active": 0.0,
-                    "tier_3_active": 0.0, "tier_99_active": 0.0,
-                }}
-            },
-        })
+        s = Scenario.model_validate(
+            {
+                "name": "x",
+                "overrides": {
+                    "benefit": {
+                        "cola": {
+                            "tier_1_active": 0.0,
+                            "tier_2_active": 0.0,
+                            "tier_3_active": 0.0,
+                            "tier_99_active": 0.0,
+                        }
+                    }
+                },
+            }
+        )
         # tier_99_active is not in any plan today — Cola admits it
         # via extra=allow, so the override validates.
         assert s.overrides.benefit.cola.tier_1_active == 0.0  # type: ignore[union-attr]
@@ -1310,12 +1481,14 @@ class TestScenarioOverrides:
         # without also providing nra.
         from pension_model.schemas.scenario import Scenario
 
-        s = Scenario.model_validate({
-            "name": "x",
-            "overrides": {
-                "tier_defs": None,  # full-tier override would need a real Tier
-            },
-        })
+        s = Scenario.model_validate(
+            {
+                "name": "x",
+                "overrides": {
+                    "tier_defs": None,  # full-tier override would need a real Tier
+                },
+            }
+        )
         assert s.name == "x"
 
     def test_requires_check_passes_when_field_present(self):
@@ -1338,16 +1511,23 @@ class TestScenarioOverrides:
         # End-to-end: a malformed scenario JSON makes load_plan_config
         # raise (rather than silently merging the typo into raw).
         import json
+
         from pydantic import ValidationError
+
         from pension_model.config_loading import load_plan_config
 
         scenario_path = tmp_path / "bogus.json"
-        scenario_path.write_text(json.dumps({
-            "name": "bogus",
-            "overrides": {"economic": {"modle_return": 0.05}},  # typo
-        }))
+        scenario_path.write_text(
+            json.dumps(
+                {
+                    "name": "bogus",
+                    "overrides": {"economic": {"modle_return": 0.05}},  # typo
+                }
+            )
+        )
 
         from pathlib import Path
+
         repo_root = Path(__file__).parents[2]
         with pytest.raises(ValidationError, match="modle_return"):
             load_plan_config(

--- a/tests/test_pension_model/test_stage3_loader.py
+++ b/tests/test_pension_model/test_stage3_loader.py
@@ -45,14 +45,14 @@ pytestmark = [
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
 
-FRS_CLASSES = ["regular", "special", "admin", "eco", "eso",
-               "judges", "senior_management"]
+FRS_CLASSES = ["regular", "special", "admin", "eco", "eso", "judges", "senior_management"]
 FRS_BASELINES = Path(__file__).parent.parent.parent / "plans" / "frs" / "baselines"
 
 
 @pytest.fixture(scope="module")
 def frs_config():
     from pension_model.plan_config import load_plan_config_by_name
+
     return load_plan_config_by_name("frs")
 
 
@@ -81,17 +81,14 @@ def test_stage3_mortality_matches_excel(class_name, frs_config, raw_dir):
         pytest.skip("R_model Excel inputs or stage 3 mortality CSVs not available")
 
     cm_csv = _build_mortality_from_csv(frs_config, mort_dir, class_name)
-    cm_xlsx = build_compact_mortality_from_excel(
-        pub2010, mp2018, class_name, constants=frs_config
-    )
+    cm_xlsx = build_compact_mortality_from_excel(pub2010, mp2018, class_name, constants=frs_config)
 
     max_diff = 0.0
     for age in range(18, 121):
         for year in (2022, 2030, 2050, 2080):
             for is_retiree in (True, False):
                 d = abs(
-                    cm_csv.get_rate(age, year, is_retiree)
-                    - cm_xlsx.get_rate(age, year, is_retiree)
+                    cm_csv.get_rate(age, year, is_retiree) - cm_xlsx.get_rate(age, year, is_retiree)
                 )
                 if d > max_diff:
                     max_diff = d
@@ -125,16 +122,19 @@ def test_stage3_mortality_uses_safety_table(class_name, frs_config):
         table_name="safety",
         min_age=frs_config.ranges.min_age,
         max_age=frs_config.ranges.max_age,
-        max_year=(frs_config.ranges.start_year + frs_config.ranges.model_period
-                  + frs_config.ranges.max_age - frs_config.ranges.min_age),
+        max_year=(
+            frs_config.ranges.start_year
+            + frs_config.ranges.model_period
+            + frs_config.ranges.max_age
+            - frs_config.ranges.min_age
+        ),
         constants=frs_config,
         male_mp_forward_shift=0,
     )
 
     # Spot-check one rate that differs between safety and general
     assert (
-        abs(cm_via_loader.get_rate(30, 2022, False)
-            - cm_safety.get_rate(30, 2022, False)) < 1e-12
+        abs(cm_via_loader.get_rate(30, 2022, False) - cm_safety.get_rate(30, 2022, False)) < 1e-12
     ), f"{class_name} should load the safety table via base_table_map"
 
 
@@ -142,8 +142,8 @@ def test_stage3_mortality_uses_safety_table(class_name, frs_config):
 # Bug 2 regression: compute_adjustment_ratio must handle long-format headcount
 # ---------------------------------------------------------------------------
 
-@pytest.mark.parametrize("class_name", ["regular", "special", "admin",
-                                        "senior_management"])
+
+@pytest.mark.parametrize("class_name", ["regular", "special", "admin", "senior_management"])
 def test_adj_ratio_handles_long_format(class_name, frs_config):
     """`compute_adjustment_ratio` must sum the 'count' column for stage 3
     long-format headcount, not `iloc[:, 1:].sum().sum()` which would add
@@ -166,8 +166,7 @@ def test_adj_ratio_handles_long_format(class_name, frs_config):
 
     # Independently compute expected value
     expected_denom = float(hc_long["count"].sum())
-    expected_adj = (frs_config.class_data[class_name].total_active_member
-                    / expected_denom)
+    expected_adj = frs_config.class_data[class_name].total_active_member / expected_denom
 
     assert abs(adj - expected_adj) < 1e-12, (
         f"{class_name}: adj_ratio={adj} but expected {expected_adj} "
@@ -178,6 +177,7 @@ def test_adj_ratio_handles_long_format(class_name, frs_config):
 # ---------------------------------------------------------------------------
 # Bug 3 regression: admin must use regular-group design ratios (matching R)
 # ---------------------------------------------------------------------------
+
 
 def test_admin_design_ratios_match_r(frs_config):
     """Admin must get regular-group DB design ratios (0.75, 0.25, 0.25),
@@ -200,14 +200,17 @@ def test_special_still_uses_special_design_ratios(frs_config):
     the 'special' class itself, which really does use special-group ratios
     (0.95, 0.85, 0.75) in R."""
     ratios = frs_config.get_design_ratios("special")
-    assert ratios["db"] == (0.95, 0.85, 0.75), (
-        f"special must use special-group DB ratios, got {ratios['db']}"
-    )
+    assert ratios["db"] == (
+        0.95,
+        0.85,
+        0.75,
+    ), f"special must use special-group DB ratios, got {ratios['db']}"
 
 
 # ---------------------------------------------------------------------------
 # End-to-end: stage 3 pipeline must reproduce R's total_aal_est exactly
 # ---------------------------------------------------------------------------
+
 
 @pytest.fixture(scope="module")
 def stage3_liability(frs_config):
@@ -266,33 +269,38 @@ def test_unknown_retirement_rate_set_raises(frs_config, tmp_path):
     silent-fallback code would absorb without warning.
     """
     import pandas as pd
+
     from pension_model.core.data_loader import _build_yos_only_decrements
 
     # Force one tier to declare an unknown rate set. tier_id_to_retire_rate_set
     # is a tuple[str, ...] cached on PlanConfig.
-    bogus = frs_config.model_copy(update={
-        "tier_id_to_retire_rate_set": ("before_2011", "bogus_set", "2011_or_later"),
-    })
+    bogus = frs_config.model_copy(
+        update={
+            "tier_id_to_retire_rate_set": ("before_2011", "bogus_set", "2011_or_later"),
+        }
+    )
 
     # A valid term_df shape with the lookup_type column the loader keys on
-    term_df = pd.DataFrame({
-        "lookup_type": ["yos"] * 2,
-        "lookup_value": [0, 1],
-        "age": [25, 26],
-        "term_rate": [0.1, 0.1],
-    })
+    term_df = pd.DataFrame(
+        {
+            "lookup_type": ["yos"] * 2,
+            "lookup_value": [0, 1],
+            "age": [25, 26],
+            "term_rate": [0.1, 0.1],
+        }
+    )
     # ret_df has only the rate sets FRS already declares — bogus_set is missing
-    ret_df = pd.DataFrame({
-        "age": [55, 55],
-        "rate_set": ["before_2011", "2011_or_later"],
-        "retire_type": ["normal", "normal"],
-        "retire_rate": [0.05, 0.04],
-    })
+    ret_df = pd.DataFrame(
+        {
+            "age": [55, 55],
+            "rate_set": ["before_2011", "2011_or_later"],
+            "retire_type": ["normal", "normal"],
+            "retire_rate": [0.05, 0.04],
+        }
+    )
 
     with pytest.raises(ValueError, match="bogus_set"):
-        _build_yos_only_decrements(
-            {}, bogus, term_df, ret_df, tmp_path, "regular"
-        )
+        _build_yos_only_decrements({}, bogus, term_df, ret_df, tmp_path, "regular")
 
 
 def test_unknown_decrements_method_raises():
@@ -302,6 +310,7 @@ def test_unknown_decrements_method_raises():
     fails validation before reaching the dispatch in _load_decrements.
     """
     from pydantic import ValidationError
+
     from pension_model.schemas import Decrements
 
     with pytest.raises(ValidationError, match="made_up_method"):
@@ -315,12 +324,14 @@ def test_overlapping_funding_legs_raises(frs_config):
     from pension_model.config_validation import validate_funding_legs
     from pension_model.schemas import LegDef
 
-    new_funding = frs_config.funding.model_copy(update={
-        "legs": [
-            LegDef(name="legacy", entry_year_max=2030),
-            LegDef(name="new", entry_year_min=2020),  # overlap 2020-2029
-        ],
-    })
+    new_funding = frs_config.funding.model_copy(
+        update={
+            "legs": [
+                LegDef(name="legacy", entry_year_max=2030),
+                LegDef(name="new", entry_year_min=2020),  # overlap 2020-2029
+            ],
+        }
+    )
     bogus = frs_config.model_copy(update={"funding": new_funding})
 
     with pytest.raises(ValueError, match="overlap"):
@@ -334,12 +345,14 @@ def test_gappy_funding_legs_raises(frs_config):
     from pension_model.config_validation import validate_funding_legs
     from pension_model.schemas import LegDef
 
-    new_funding = frs_config.funding.model_copy(update={
-        "legs": [
-            LegDef(name="legacy", entry_year_max=2010),
-            LegDef(name="new", entry_year_min=2020),  # gap 2010-2019
-        ],
-    })
+    new_funding = frs_config.funding.model_copy(
+        update={
+            "legs": [
+                LegDef(name="legacy", entry_year_max=2010),
+                LegDef(name="new", entry_year_min=2020),  # gap 2010-2019
+            ],
+        }
+    )
     bogus = frs_config.model_copy(update={"funding": new_funding})
 
     with pytest.raises(ValueError, match="not covered"):
@@ -381,9 +394,7 @@ def test_missing_per_class_nra_raises(frs_config):
 
     # 'regular' isn't in the map and no default — should raise.
     with pytest.raises(ValueError, match="no 'default'"):
-        get_reduce_factor(
-            bogus, "regular", "tier_1", "early", dist_age=58, yos=10, entry_year=1990
-        )
+        get_reduce_factor(bogus, "regular", "tier_1", "early", dist_age=58, yos=10, entry_year=1990)
 
 
 def test_unknown_contribution_strategy_raises(frs_config):
@@ -391,6 +402,7 @@ def test_unknown_contribution_strategy_raises(frs_config):
     a clear ValueError from resolve_funding_context.
     """
     from pydantic import ValidationError
+
     from pension_model.schemas import Funding
 
     # Build a Funding payload with an unsupported contribution_strategy.
@@ -408,6 +420,7 @@ def test_statutory_strategy_requires_rates_block(frs_config):
     Funding model_validator.
     """
     from pydantic import ValidationError
+
     from pension_model.schemas import Funding
 
     # FRS today is "actuarial" with no statutory_rates. Build a payload
@@ -427,6 +440,7 @@ def test_missing_rule_nra_raises(frs_config):
     the NRA on a rule when the plan_config.json loads.
     """
     from pydantic import ValidationError
+
     from pension_model.schemas import Tier
 
     # Build a tier raw dict whose ERR rule-list has a linear rule

--- a/tests/test_pension_model/test_truth_table_frs.py
+++ b/tests/test_pension_model/test_truth_table_frs.py
@@ -2,19 +2,19 @@
 
 import pytest
 
-pytestmark = [pytest.mark.invariant, pytest.mark.regression]
-
 from pension_model.truth_table import (
     TRUTH_TABLE_COLUMNS,
     build_python_truth_table,
 )
 
+pytestmark = [pytest.mark.invariant, pytest.mark.regression]
+
 
 @pytest.fixture(scope="module")
 def frs_truth_table():
     """Run the FRS pipeline and build the truth table."""
-    from pension_model.core.pipeline import run_plan_pipeline
     from pension_model.core.funding_model import load_funding_inputs, run_funding_model
+    from pension_model.core.pipeline import run_plan_pipeline
     from pension_model.plan_config import load_plan_config_by_name
 
     constants = load_plan_config_by_name("frs")
@@ -42,9 +42,18 @@ def test_frs_truth_table_plan_column(frs_truth_table):
 
 def test_frs_truth_table_no_nan_in_required(frs_truth_table):
     """Required columns should have no NaN."""
-    required = ["year", "n_active_boy", "payroll", "benefits",
-                "aal_boy", "mva_boy", "mva_eoy", "ava_boy",
-                "fr_mva_boy", "fr_ava_boy"]
+    required = [
+        "year",
+        "n_active_boy",
+        "payroll",
+        "benefits",
+        "aal_boy",
+        "mva_boy",
+        "mva_eoy",
+        "ava_boy",
+        "fr_mva_boy",
+        "fr_ava_boy",
+    ]
     for col in required:
         assert frs_truth_table[col].notna().all(), f"{col} has NaN values"
 

--- a/tests/test_pension_model/test_truth_table_scenarios.py
+++ b/tests/test_pension_model/test_truth_table_scenarios.py
@@ -91,7 +91,8 @@ def test_truth_table_matches_r_baseline(plan, scenario):
     r = pd.read_csv(r_path)
 
     common_numeric = [
-        c for c in r.columns
+        c
+        for c in r.columns
         if c in py.columns
         and c not in ("plan", "year")
         and pd.api.types.is_numeric_dtype(r[c])
@@ -107,7 +108,8 @@ def test_truth_table_matches_r_baseline(plan, scenario):
         if pd.notna(rel) and rel > 1e-10:
             worst.append((col, float(rel), float(diff.max())))
 
-    assert not worst, (
-        f"{plan}/{scenario or 'baseline'} diverges from R beyond FP noise:\n"
-        + "\n".join(f"  {c}: max rel={r:.2e}, max abs={a:.6e}" for c, r, a in worst)
+    assert (
+        not worst
+    ), f"{plan}/{scenario or 'baseline'} diverges from R beyond FP noise:\n" + "\n".join(
+        f"  {c}: max rel={r:.2e}, max abs={a:.6e}" for c, r, a in worst
     )

--- a/tests/test_pension_model/test_truth_table_txtrs.py
+++ b/tests/test_pension_model/test_truth_table_txtrs.py
@@ -2,19 +2,19 @@
 
 import pytest
 
-pytestmark = [pytest.mark.invariant, pytest.mark.regression]
-
 from pension_model.truth_table import (
     TRUTH_TABLE_COLUMNS,
     build_python_truth_table,
 )
 
+pytestmark = [pytest.mark.invariant, pytest.mark.regression]
+
 
 @pytest.fixture(scope="module")
 def txtrs_truth_table():
     """Run the TXTRS pipeline and build the truth table."""
-    from pension_model.core.pipeline import run_plan_pipeline
     from pension_model.core.funding_model import load_funding_inputs, run_funding_model
+    from pension_model.core.pipeline import run_plan_pipeline
     from pension_model.plan_config import load_plan_config_by_name
 
     constants = load_plan_config_by_name("txtrs")
@@ -42,9 +42,18 @@ def test_txtrs_truth_table_plan_column(txtrs_truth_table):
 
 def test_txtrs_truth_table_no_nan_in_required(txtrs_truth_table):
     """Required columns should have no NaN."""
-    required = ["year", "n_active_boy", "payroll", "benefits",
-                "aal_boy", "mva_boy", "mva_eoy", "ava_boy",
-                "fr_mva_boy", "fr_ava_boy"]
+    required = [
+        "year",
+        "n_active_boy",
+        "payroll",
+        "benefits",
+        "aal_boy",
+        "mva_boy",
+        "mva_eoy",
+        "ava_boy",
+        "fr_mva_boy",
+        "fr_ava_boy",
+    ]
     for col in required:
         assert txtrs_truth_table[col].notna().all(), f"{col} has NaN values"
 

--- a/tests/test_pension_model/test_vectorized_resolvers_frs.py
+++ b/tests/test_pension_model/test_vectorized_resolvers_frs.py
@@ -4,8 +4,6 @@ import numpy as np
 import pandas as pd
 import pytest
 
-pytestmark = [pytest.mark.unit]
-
 from pension_model.plan_config import (
     get_ben_mult,
     get_reduce_factor,
@@ -23,6 +21,8 @@ from ._vectorized_resolver_test_support import (
     scalar_cola,
     vec_tier_components,
 )
+
+pytestmark = [pytest.mark.unit]
 
 
 def test_resolve_tiers_vec_matches_scalar_frs():
@@ -44,13 +44,14 @@ def test_resolve_tiers_vec_matches_scalar_frs():
     )[0]
     if len(mismatches) > 0:
         diffs = [
-            (rows[i], (expected_names[i], expected_statuses[i]),
-             (actual_names[i], actual_statuses[i]))
+            (
+                rows[i],
+                (expected_names[i], expected_statuses[i]),
+                (actual_names[i], actual_statuses[i]),
+            )
             for i in mismatches[:10]
         ]
-        pytest.fail(
-            f"{len(mismatches)} / {len(rows)} mismatches. First 10: {diffs}"
-        )
+        pytest.fail(f"{len(mismatches)} / {len(rows)} mismatches. First 10: {diffs}")
 
 
 def test_resolve_tiers_vec_accepts_categorical_class_name():
@@ -59,9 +60,7 @@ def test_resolve_tiers_vec_accepts_categorical_class_name():
     cn, ey, age, yos = rows_to_arrays(rows)
 
     expected_tier_id, expected_ret_status = resolve_tiers_vec(config, cn, ey, age, yos)
-    actual_tier_id, actual_ret_status = resolve_tiers_vec(
-        config, pd.Categorical(cn), ey, age, yos
-    )
+    actual_tier_id, actual_ret_status = resolve_tiers_vec(config, pd.Categorical(cn), ey, age, yos)
 
     assert np.array_equal(actual_tier_id, expected_tier_id)
     assert np.array_equal(actual_ret_status, expected_ret_status)
@@ -95,15 +94,16 @@ def test_resolve_cola_vec_matches_scalar_frs():
     tier_names, _ = vec_tier_components(config, cn, ey, age, yos)
     tier_id, _ = resolve_tiers_vec(config, cn, ey, age, yos)
 
-    expected = np.array([
-        scalar_cola(config, tier_names[i], int(ey[i]), int(yos[i]))
-        for i in range(len(rows))
-    ], dtype=np.float64)
+    expected = np.array(
+        [scalar_cola(config, tier_names[i], int(ey[i]), int(yos[i])) for i in range(len(rows))],
+        dtype=np.float64,
+    )
 
     actual = resolve_cola_vec(config, tier_id, ey, yos)
 
-    assert np.allclose(actual, expected, equal_nan=True), \
-        f"COLA mismatch. Max diff: {np.nanmax(np.abs(actual - expected))}"
+    assert np.allclose(
+        actual, expected, equal_nan=True
+    ), f"COLA mismatch. Max diff: {np.nanmax(np.abs(actual - expected))}"
 
 
 def test_resolve_ben_mult_vec_matches_scalar_frs():
@@ -115,16 +115,27 @@ def test_resolve_ben_mult_vec_matches_scalar_frs():
     tier_id, ret_status = resolve_tiers_vec(config, cn, ey, age, yos)
     dist_year = ey + yos
 
-    expected = np.array([
-        get_ben_mult(config, rows[i][0], tier_names[i], statuses[i],
-                     int(age[i]), int(yos[i]), int(dist_year[i]))
-        for i in range(len(rows))
-    ], dtype=np.float64)
+    expected = np.array(
+        [
+            get_ben_mult(
+                config,
+                rows[i][0],
+                tier_names[i],
+                statuses[i],
+                int(age[i]),
+                int(yos[i]),
+                int(dist_year[i]),
+            )
+            for i in range(len(rows))
+        ],
+        dtype=np.float64,
+    )
 
     actual = resolve_ben_mult_vec(config, cn, tier_id, ret_status, age, yos, dist_year)
 
-    assert np.allclose(actual, expected, equal_nan=True), \
-        f"ben_mult mismatch. Max diff: {np.nanmax(np.abs(actual - expected))}"
+    assert np.allclose(
+        actual, expected, equal_nan=True
+    ), f"ben_mult mismatch. Max diff: {np.nanmax(np.abs(actual - expected))}"
 
 
 def test_resolve_ben_mult_vec_accepts_categorical_class_name():
@@ -134,9 +145,7 @@ def test_resolve_ben_mult_vec_accepts_categorical_class_name():
     tier_id, ret_status = resolve_tiers_vec(config, cn, ey, age, yos)
     dist_year = ey + yos
 
-    expected = resolve_ben_mult_vec(
-        config, cn, tier_id, ret_status, age, yos, dist_year
-    )
+    expected = resolve_ben_mult_vec(config, cn, tier_id, ret_status, age, yos, dist_year)
     actual = resolve_ben_mult_vec(
         config, pd.Categorical(cn), tier_id, ret_status, age, yos, dist_year
     )
@@ -152,26 +161,27 @@ def test_resolve_reduce_factor_vec_matches_scalar_frs():
     tier_names, statuses = vec_tier_components(config, cn, ey, age, yos)
     tier_id, ret_status = resolve_tiers_vec(config, cn, ey, age, yos)
 
-    expected = np.array([
-        get_reduce_factor(config, rows[i][0], tier_names[i], statuses[i],
-                          int(age[i]), int(yos[i]), int(ey[i]))
-        for i in range(len(rows))
-    ], dtype=np.float64)
+    expected = np.array(
+        [
+            get_reduce_factor(
+                config, rows[i][0], tier_names[i], statuses[i], int(age[i]), int(yos[i]), int(ey[i])
+            )
+            for i in range(len(rows))
+        ],
+        dtype=np.float64,
+    )
 
     actual = resolve_reduce_factor_vec(config, cn, tier_id, ret_status, age, yos, ey)
 
     nan_match = np.isnan(expected) == np.isnan(actual)
-    val_match = np.where(np.isnan(expected), True,
-                         np.isclose(actual, expected, equal_nan=True))
+    val_match = np.where(np.isnan(expected), True, np.isclose(actual, expected, equal_nan=True))
     mismatches = np.where(~(nan_match & val_match))[0]
     if len(mismatches) > 0:
         diffs = [
-            (rows[i], (tier_names[i], statuses[i]), expected[i], actual[i])
-            for i in mismatches[:10]
+            (rows[i], (tier_names[i], statuses[i]), expected[i], actual[i]) for i in mismatches[:10]
         ]
         pytest.fail(
-            f"{len(mismatches)} / {len(rows)} reduce_factor mismatches. "
-            f"First 10: {diffs}"
+            f"{len(mismatches)} / {len(rows)} reduce_factor mismatches. " f"First 10: {diffs}"
         )
 
 
@@ -187,7 +197,5 @@ def test_resolve_reduce_factor_vec_accepts_categorical_class_name():
     )
 
     nan_match = np.isnan(expected) == np.isnan(actual)
-    val_match = np.where(
-        np.isnan(expected), True, np.isclose(actual, expected, equal_nan=True)
-    )
+    val_match = np.where(np.isnan(expected), True, np.isclose(actual, expected, equal_nan=True))
     assert np.all(nan_match & val_match)

--- a/tests/test_pension_model/test_vectorized_resolvers_txtrs.py
+++ b/tests/test_pension_model/test_vectorized_resolvers_txtrs.py
@@ -3,8 +3,6 @@
 import numpy as np
 import pytest
 
-pytestmark = [pytest.mark.unit]
-
 from pension_model.plan_config import (
     get_ben_mult,
     get_reduce_factor,
@@ -22,6 +20,8 @@ from ._vectorized_resolver_test_support import (
     scalar_cola,
     vec_tier_components,
 )
+
+pytestmark = [pytest.mark.unit]
 
 
 def test_resolve_tiers_vec_matches_scalar_txtrs():
@@ -43,13 +43,14 @@ def test_resolve_tiers_vec_matches_scalar_txtrs():
     )[0]
     if len(mismatches) > 0:
         diffs = [
-            (rows[i], (expected_names[i], expected_statuses[i]),
-             (actual_names[i], actual_statuses[i]))
+            (
+                rows[i],
+                (expected_names[i], expected_statuses[i]),
+                (actual_names[i], actual_statuses[i]),
+            )
             for i in mismatches[:10]
         ]
-        pytest.fail(
-            f"{len(mismatches)} / {len(rows)} mismatches. First 10: {diffs}"
-        )
+        pytest.fail(f"{len(mismatches)} / {len(rows)} mismatches. First 10: {diffs}")
 
 
 def test_resolve_cola_vec_matches_scalar_txtrs():
@@ -60,15 +61,16 @@ def test_resolve_cola_vec_matches_scalar_txtrs():
     tier_names, _ = vec_tier_components(config, cn, ey, age, yos)
     tier_id, _ = resolve_tiers_vec(config, cn, ey, age, yos)
 
-    expected = np.array([
-        scalar_cola(config, tier_names[i], int(ey[i]), int(yos[i]))
-        for i in range(len(rows))
-    ], dtype=np.float64)
+    expected = np.array(
+        [scalar_cola(config, tier_names[i], int(ey[i]), int(yos[i])) for i in range(len(rows))],
+        dtype=np.float64,
+    )
 
     actual = resolve_cola_vec(config, tier_id, ey, yos)
 
-    assert np.allclose(actual, expected, equal_nan=True), \
-        f"COLA mismatch. Max diff: {np.nanmax(np.abs(actual - expected))}"
+    assert np.allclose(
+        actual, expected, equal_nan=True
+    ), f"COLA mismatch. Max diff: {np.nanmax(np.abs(actual - expected))}"
 
 
 def test_resolve_ben_mult_vec_matches_scalar_txtrs():
@@ -80,16 +82,27 @@ def test_resolve_ben_mult_vec_matches_scalar_txtrs():
     tier_id, ret_status = resolve_tiers_vec(config, cn, ey, age, yos)
     dist_year = ey + yos
 
-    expected = np.array([
-        get_ben_mult(config, rows[i][0], tier_names[i], statuses[i],
-                     int(age[i]), int(yos[i]), int(dist_year[i]))
-        for i in range(len(rows))
-    ], dtype=np.float64)
+    expected = np.array(
+        [
+            get_ben_mult(
+                config,
+                rows[i][0],
+                tier_names[i],
+                statuses[i],
+                int(age[i]),
+                int(yos[i]),
+                int(dist_year[i]),
+            )
+            for i in range(len(rows))
+        ],
+        dtype=np.float64,
+    )
 
     actual = resolve_ben_mult_vec(config, cn, tier_id, ret_status, age, yos, dist_year)
 
-    assert np.allclose(actual, expected, equal_nan=True), \
-        f"ben_mult mismatch. Max diff: {np.nanmax(np.abs(actual - expected))}"
+    assert np.allclose(
+        actual, expected, equal_nan=True
+    ), f"ben_mult mismatch. Max diff: {np.nanmax(np.abs(actual - expected))}"
 
 
 def test_resolve_reduce_factor_vec_matches_scalar_txtrs():
@@ -103,24 +116,25 @@ def test_resolve_reduce_factor_vec_matches_scalar_txtrs():
     tier_names, statuses = vec_tier_components(config, cn, ey, age, yos)
     tier_id, ret_status = resolve_tiers_vec(config, cn, ey, age, yos)
 
-    expected = np.array([
-        get_reduce_factor(config, rows[i][0], tier_names[i], statuses[i],
-                          int(age[i]), int(yos[i]), int(ey[i]))
-        for i in range(len(rows))
-    ], dtype=np.float64)
+    expected = np.array(
+        [
+            get_reduce_factor(
+                config, rows[i][0], tier_names[i], statuses[i], int(age[i]), int(yos[i]), int(ey[i])
+            )
+            for i in range(len(rows))
+        ],
+        dtype=np.float64,
+    )
 
     actual = resolve_reduce_factor_vec(config, cn, tier_id, ret_status, age, yos, ey)
 
     nan_match = np.isnan(expected) == np.isnan(actual)
-    val_match = np.where(np.isnan(expected), True,
-                         np.isclose(actual, expected, equal_nan=True))
+    val_match = np.where(np.isnan(expected), True, np.isclose(actual, expected, equal_nan=True))
     mismatches = np.where(~(nan_match & val_match))[0]
     if len(mismatches) > 0:
         diffs = [
-            (rows[i], (tier_names[i], statuses[i]), expected[i], actual[i])
-            for i in mismatches[:10]
+            (rows[i], (tier_names[i], statuses[i]), expected[i], actual[i]) for i in mismatches[:10]
         ]
         pytest.fail(
-            f"{len(mismatches)} / {len(rows)} reduce_factor mismatches. "
-            f"First 10: {diffs}"
+            f"{len(mismatches)} / {len(rows)} reduce_factor mismatches. " f"First 10: {diffs}"
         )


### PR DESCRIPTION
## Summary

Cleans up lint and formatting drift across the codebase, then activates the previously-commented ruff and black pre-commit hooks so future drift is caught at commit time. **R-baseline preserved** — snapshot and truth-table tests pass unchanged; full suite is 500 passed.

This is the cleanup PR Phase A.2 deferred ("Phase A.3" in the comments left in `.pre-commit-config.yaml`).

## What changed

**Tooling:**
- `pyproject.toml`: migrated ruff config from deprecated top-level keys to `[tool.ruff.lint]`; excluded `scripts/` from ruff (one-off utilities with embedded long inline strings).
- `.pre-commit-config.yaml`: enabled the ruff and black hooks.

**Code changes — all mechanical, no behavior change:**

| Source | Count | Notes |
|--------|------:|-------|
| `ruff --fix` (auto) | 313 | UP045 `Optional[X]` → `X \| None`, I001 import sorting, F401 unused imports, F541 empty f-strings, etc. |
| `black` | 76 files | Pure reformat |
| `F821` | 6 | String-quoted `"Optional[...]"` → `"X \| None"`; `TYPE_CHECKING` import for `CompactMortality`. |
| `E402` | 26 | Move `pytestmark` below imports; `# noqa: E402` in three test files where `sys.path.insert` legitimately runs first. |
| `UP007 / UP045 / UP038` | ~10 | `Union[X, Y]` → `X \| Y` and `isinstance(x, (A, B))` → `isinstance(x, A \| B)`. One runtime `Union[*new_args]` kept with `# noqa`. |
| `C401, C416, B007, B905, E501` | 11 | Collapse generators, rename unused vars, `strict=True` on `zip()`, wrap long lines. |

**Cross-module cleanup:**
- `_funding_helpers.py` was importing `_get_pmt` via a re-export through `pipeline.py`. Updated to import from `pipeline_current` directly (where it's defined), matching the pattern `_funding_setup.py` already uses. The re-export indirection wasn't visible to ruff and made the import look unused.

## Verification

| Gate | Result |
|------|--------|
| `pytest -q` | 500 passed, 2 intentionally skipped |
| Bit-identical funding snapshots | unchanged |
| R-baseline truth-table tests (1e-10 rel) | unchanged |
| `pre-commit run --all-files` | all hooks pass |
| `pension-model run frs --no-test --check-identities` | clean |
| `pension-model run txtrs --no-test --check-identities` | clean |

## Test plan

- [ ] Pull this branch, run `pre-commit install`, then `pre-commit run --all-files` — every hook should pass.
- [ ] `pytest -q` — 500 passed.
- [ ] `pension-model run frs --no-test --check-identities` and `pension-model run txtrs --no-test --check-identities` — both clean.
- [ ] Spot-check `output/<plan>/summary.csv` against pre-PR runs (no number changes expected).

## Commit structure

Single commit. The changes are tightly coupled — the pre-commit hooks can't be enabled until the codebase is clean, and the codebase is being cleaned to enable the hooks. Splitting would put the repo in an awkward intermediate state (clean code but commented-out hooks, or hooks-on-a-failing-codebase).

## Notes

- Ruff config select list is unchanged; only the placement migrated.
- `scripts/` is excluded from ruff because it holds extract/build/diagnostic utilities with long embedded data strings; not part of the runtime engine.
- The pinned ruff version in `.pre-commit-config.yaml` is `v0.7.4`; can be bumped in a future PR to align with the system version (0.15.10) if desired. UP038 was deprecated in newer ruff but is still flagged at v0.7.4 — pre-existing instances are now fixed regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)